### PR TITLE
Upgraded Maven Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,14 +59,14 @@
 
         <openjdk.version>8u131</openjdk.version>
 
-        <aws.version>1.11.141</aws.version>
+         <aws.version>1.11.213</aws.version>
 
-        <logback.version>1.2.1</logback.version>
+        <logback.version>1.2.3</logback.version>
         <jcloverslf4j.version>1.7.6</jcloverslf4j.version>
-        <commons-codec.version>1.2</commons-codec.version>
-        <xstream.version>1.4.9</xstream.version>
-        <commons-io.version>2.2</commons-io.version>
-        <joda-time.version>2.9.1</joda-time.version>
+        <commons-codec.version>1.10</commons-codec.version>
+        <xstream.version>1.4.10</xstream.version>
+        <commons-io.version>2.5</commons-io.version>
+        <joda-time.version>2.9.9</joda-time.version>
         <jackson.version>2.8.6</jackson.version>
         <spring-oxm.version>4.3.6.RELEASE</spring-oxm.version>
 


### PR DESCRIPTION
This PR upgrades the following dependencies:

* xstream - this also fixes a security vulnerability
* commons-io
* AWS SDK
* Logback
* Commons-codec
* Jodatime