### PR TITLE
Fix getS3Objects for root directory.

### DIFF
--- a/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -18,6 +18,7 @@ package com.adobe.testing.s3mock.domain;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
+import static org.springframework.util.StringUtils.isEmpty;
 
 import com.adobe.testing.s3mock.dto.CopyObjectResult;
 import com.adobe.testing.s3mock.util.AwsChunkDecodingInputStream;
@@ -404,7 +405,7 @@ public class FileStore {
     final Set<Path> collect = directoryHierarchy
             .filter(path -> path.toFile().isDirectory())
             .map(path -> theBucket.getPath().relativize(path))
-            .filter(path -> prefix == null || path.startsWith(prefix)
+            .filter(path -> isEmpty(prefix) || path.startsWith(prefix)
     ).collect(toSet());
 
     for (final Path path : collect) {

--- a/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -559,6 +559,28 @@ public class FileStoreTest {
   }
 
   @Test
+  public void getObjectsForEmptyPrefix() throws Exception {
+    fileStore.createBucket(TEST_BUCKET_NAME);
+    fileStore
+            .putS3Object(TEST_BUCKET_NAME, "a", "text/plain", new FileInputStream(new File(TEST_FILE_PATH)),
+                    false);
+    List<S3Object> result = fileStore.getS3Objects(TEST_BUCKET_NAME, "");
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getName(), is("a"));
+  }
+
+  @Test
+  public void getObjectsForNullPrefix() throws Exception {
+    fileStore.createBucket(TEST_BUCKET_NAME);
+    fileStore
+            .putS3Object(TEST_BUCKET_NAME, "a", "text/plain", new FileInputStream(new File(TEST_FILE_PATH)),
+                    false);
+    List<S3Object> result = fileStore.getS3Objects(TEST_BUCKET_NAME, null);
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getName(), is("a"));
+  }
+
+  @Test
   public void getObjectsForPartialParentDirectory() throws Exception {
     fileStore.createBucket(TEST_BUCKET_NAME);
     fileStore


### PR DESCRIPTION
Empty prefix should have the same meaning as null prefix.