### PR TITLE
Prepare more automated release: use nexus-staging-plugin for deploy phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,15 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>1.5.9.RELEASE</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <scm>
         <connection>scm:git:git://github.com:adobe/S3Mock.git</connection>
         <developerConnection>scm:git:git@github.com:adobe/S3Mock.git</developerConnection>
         <url>http://github.com/adobe/S3Mock/tree/master</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <snapshotRepository>
@@ -158,6 +158,15 @@
                         <goals>deploy -DskipTests -Prelease -Ppush-docker-image</goals>
                         <preparationGoals>clean install -DskipTests</preparationGoals>
                         <tagNameFormat>@{project.version}</tagNameFormat>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -283,6 +292,10 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
This may already close and release the nexus staging repo automatically, but I'm not sure. We'll have to try it out and maybe add the `nexus-staging:close` goal to the release goals if it's not yet working.
Plus, the configuration properties `nexusUrl` and `serverId` are not specified in the plugin config, although the documentation on https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin describes them as mandatory. It works for deploying to the sonatype-snapshots repository, though. So I'm not sure if they are still required.

@timoe please review / merge / delete the branch.