### PR TITLE
Adds abort-multipart-upload + simple support for list-multipart-uploads

### DIFF
--- a/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -586,6 +586,26 @@ class FileStoreController {
             bucketName, keyMarker, delimiter, prefix, uploadIdMarker, maxUploads, isTruncated, nextKeyMarker, nextUploadIdMarker, multipartUploads, commmonPrefixes
     );
   }
+  /**
+   * Aborts a multipart upload for a given uploadId.
+   *
+   * http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html
+   *
+   * @param bucketName the Bucket in which to store the file in.
+   * @param uploadId id of the upload. Has to match all other part's uploads.
+   */
+  @RequestMapping(
+          value = "/{bucketName:.+}/**",
+          params = {"uploadId"},
+          method = RequestMethod.DELETE,
+          produces = "application/x-www-form-urlencoded")
+  public void abortMultipartUpload(
+          @PathVariable final String bucketName,
+          @RequestParam(required = true) final String uploadId,
+          final HttpServletRequest request) {
+    final String filename = filenameFrom(bucketName, request);
+    fileStore.abortMultipartUpload(bucketName, filename, uploadId);
+  }
 
   /**
    * Lists all parts a file multipart upload.

--- a/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -30,6 +30,7 @@ import com.adobe.testing.s3mock.dto.ErrorResponse;
 import com.adobe.testing.s3mock.dto.InitiateMultipartUploadResult;
 import com.adobe.testing.s3mock.dto.ListAllMyBucketsResult;
 import com.adobe.testing.s3mock.dto.ListBucketResult;
+import com.adobe.testing.s3mock.dto.ListMultipartUploadsResult;
 import com.adobe.testing.s3mock.dto.ListPartsResult;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.util.ObjectRefConverter;
@@ -254,6 +255,7 @@ public class S3MockApplication extends WebMvcConfigurerAdapter {
         CopyObjectResult.class,
         ListBucketResult.class,
         InitiateMultipartUploadResult.class,
+        ListMultipartUploadsResult.class,
         ListPartsResult.class,
         CompleteMultipartUploadResult.class,
         BatchDeleteRequest.class,
@@ -267,6 +269,7 @@ public class S3MockApplication extends WebMvcConfigurerAdapter {
         CopyObjectResult.class,
         ListBucketResult.class,
         InitiateMultipartUploadResult.class,
+        ListMultipartUploadsResult.class,
         ListPartsResult.class,
         CompleteMultipartUploadResult.class,
         BatchDeleteRequest.class,

--- a/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -811,14 +811,5 @@ public class FileStore {
     }
     return s3Object;
   }
-
-  private static class MultipartUploadInfo {
-    final MultipartUpload upload;
-    final String contentType;
-    MultipartUploadInfo(MultipartUpload upload, String contentType) {
-      this.upload = upload;
-      this.contentType = contentType;
-    }
-  }
   
 }

--- a/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2017 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.domain;
+
+import com.adobe.testing.s3mock.dto.MultipartUpload;
+
+class MultipartUploadInfo {
+	final MultipartUpload upload;
+	final String contentType;
+	MultipartUploadInfo(MultipartUpload upload, String contentType) {
+		this.upload = upload;
+		this.contentType = contentType;
+	}
+}

--- a/src/main/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResult.java
+++ b/src/main/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResult.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2017 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import java.util.List;
+
+/**
+ * List Multipart Uploads result according to the
+ * <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html">S3 API Reference</a>.
+ */
+@XStreamAlias("ListMultipartUploadsResult")
+public class ListMultipartUploadsResult {
+  @XStreamAlias("Bucket")
+  private final String bucket;
+  @XStreamAlias("KeyMarker")
+  private final String keyMarker;
+  @XStreamAlias("Delimiter")
+  private final String delimiter;
+  @XStreamAlias("Prefix")
+  private final String prefix;
+  @XStreamAlias("UploadIdMarker")
+  private final String uploadIdMarker;
+  @XStreamAlias("MaxUploads")
+  private final int maxUploads;
+  @XStreamAlias("IsTruncated")
+  private final boolean isTruncated;
+  @XStreamAlias("NextKeyMarker")
+  private final String nextKeyMarker;
+  @XStreamAlias("NextUploadIdMarker")
+  private final String nextUploadIdMarker;
+  @XStreamImplicit
+  private final List<MultipartUpload> multipartUploads;
+  @XStreamAlias("CommonPrefixes")
+  private final java.util.List<String> commonPrefixes;
+
+  public ListMultipartUploadsResult(String bucket,
+                                    String keyMarker,
+                                    String delimiter,
+                                    String prefix,
+                                    String uploadIdMarker,
+                                    int maxUploads,
+                                    boolean isTruncated,
+                                    String nextKeyMarker,
+                                    String nextUploadIdMarker,
+                                    List<MultipartUpload> multipartUploads,
+                                    List<String> commonPrefixes) {
+    this.bucket = bucket;
+    this.keyMarker = keyMarker;
+    this.delimiter = delimiter;
+    this.prefix = prefix;
+    this.uploadIdMarker = uploadIdMarker;
+    this.maxUploads = maxUploads;
+    this.isTruncated = isTruncated;
+    this.nextKeyMarker = nextKeyMarker;
+    this.nextUploadIdMarker = nextUploadIdMarker;
+    this.multipartUploads = multipartUploads;
+    this.commonPrefixes = commonPrefixes;
+  }
+
+  @Override
+  public String toString() {
+    return "ListMultipartUploadsResult{" +
+            "bucket='" + bucket + '\'' +
+            ", keyMarker='" + keyMarker + '\'' +
+            ", delimiter='" + delimiter + '\'' +
+            ", prefix='" + prefix + '\'' +
+            ", uploadIdMarker='" + uploadIdMarker + '\'' +
+            ", maxUploads=" + maxUploads +
+            ", isTruncated=" + isTruncated +
+            ", nextKeyMarker='" + nextKeyMarker + '\'' +
+            ", nextUploadIdMarker='" + nextUploadIdMarker + '\'' +
+            ", multipartUploads=" + multipartUploads +
+            ", commonPrefixes=" + commonPrefixes +
+            '}';
+  }
+
+}

--- a/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
+++ b/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2017 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ISO8601DateConverter;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * Container for elements related to a particular multipart upload, according to the
+ * <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html">S3 API Reference</a>.
+ */
+@XStreamAlias("Upload")
+public class MultipartUpload {
+
+	@XStreamAlias("Key")
+	private final String key;
+	@XStreamAlias("UploadId")
+	private final String uploadId;
+	@XStreamAlias("Owner")
+	private final Owner owner;
+	@XStreamAlias("Initiator")
+	private final Owner initiator;
+	@XStreamAlias("StorageClass")
+	private final String storageClass = "STANDARD";
+	@XStreamAlias("Initiated")
+	@XStreamConverter(ISO8601DateConverter.class)
+	private final Date initiated;
+
+	public MultipartUpload(String key, String uploadId, Owner owner, Owner initiator, Date initiated) {
+		this.key = key;
+		this.uploadId = uploadId;
+		this.owner = owner;
+		this.initiator = initiator;
+		this.initiated = initiated;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public String getUploadId() {
+		return uploadId;
+	}
+
+	public Owner getOwner() {
+		return owner;
+	}
+
+	public Owner getInitiator() {
+		return initiator;
+	}
+
+	public String getStorageClass() {
+		return storageClass;
+	}
+
+	public Date getInitiated() {
+		return initiated;
+	}
+
+	@Override
+	public String toString() {
+		return "MultipartUpload{" +
+				"key='" + key + '\'' +
+				", uploadId='" + uploadId + '\'' +
+				", owner=" + owner +
+				", initiator=" + initiator +
+				", storageClass='" + storageClass + '\'' +
+				", initiated=" + initiated +
+				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		MultipartUpload that = (MultipartUpload) o;
+		return Objects.equals(key, that.key) &&
+				Objects.equals(uploadId, that.uploadId) &&
+				Objects.equals(owner, that.owner) &&
+				Objects.equals(initiator, that.initiator) &&
+				Objects.equals(storageClass, that.storageClass) &&
+				Objects.equals(initiated, that.initiated);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(key, uploadId, owner, initiator, storageClass, initiated);
+	}
+}

--- a/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -524,6 +524,30 @@ public class FileStoreTest {
   }
 
   @Test
+  public void abortMultipartUpload() throws Exception {
+    assertThat(fileStore.listMultipartUploads(), is(empty()));
+
+    final String fileName = "PartFile";
+    final String uploadId = "12345";
+    fileStore.prepareMultipartUpload(TEST_BUCKET_NAME, fileName, DEFAULT_CONTENT_TYPE, uploadId, TEST_OWNER, TEST_OWNER);
+    fileStore.putPart(TEST_BUCKET_NAME, fileName, uploadId, "1", new ByteArrayInputStream("Part1".getBytes()), false);
+    assertThat(fileStore.listMultipartUploads(), hasSize(1));
+
+    fileStore.abortMultipartUpload(TEST_BUCKET_NAME, fileName, uploadId);
+
+    assertThat(fileStore.listMultipartUploads(), is(empty()));
+    assertThat("File exists!",
+            Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, fileName, "fileData").toFile().exists(),
+            is(false));
+    assertThat("Metadata exists!",
+            Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, fileName, "metadata").toFile().exists(),
+            is(false));
+    assertThat("Temp upload folder exists!",
+            Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, fileName, uploadId).toFile().exists(),
+            is(false));
+  }
+
+  @Test
   public void copyPart() throws Exception {
 
     final String sourceFile = UUID.randomUUID().toString();


### PR DESCRIPTION
Hey guys, here's an MVP solution for listing multipart uploads (#15), where all in-progress multipart uploads are returned. I.e. several request parameters are not yet supported: delimiter, encoding-type, max-uploads, key-marker, prefix, upload-id-marker.

Additionally this brings support for aborting a multipart upload.