### PR TITLE
Remove a Gson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,10 +107,6 @@
             <version>${aws.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>


### PR DESCRIPTION
Jackson is already shipped with Spring Boot, so we can reuse it instead of introducing a new JSON dependency. Jackson also provides an API which allows to work with JSON objects represented as `File` without converting them to streams or strings.