### PR TITLE
Mark JUnit as an optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Not all users use JUnit as their test framework. There are people who use JUnit5, TestNG or Spock. We need JUnit only for `S3Rule`, which is optional.