### PR TITLE
Isolate the aws-java-sdk-s3 dependency to S3MockRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>${aws.version}</version>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
@@ -122,9 +117,17 @@
         </dependency>
 
         <!-- Test Dependencies -->
+
+        <!-- JUnit Rule dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -43,8 +43,6 @@ import com.adobe.testing.s3mock.dto.MultipartUpload;
 import com.adobe.testing.s3mock.dto.ObjectRef;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Range;
-import com.amazonaws.services.s3.model.MultipartUploadListing;
-import com.amazonaws.services.s3.model.StorageClass;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -224,7 +222,7 @@ class FileStoreController {
             s3Object.getModificationDate(),
             s3Object.getMd5(),
             s3Object.getSize(),
-            StorageClass.Standard,
+            "STANDARD",
             TEST_OWNER));
       }
 
@@ -561,7 +559,7 @@ class FileStoreController {
    * prefix, upload-id-marker.
    *
    * @param bucketName the Bucket in which to store the file in.
-   * @return the {@link MultipartUploadListing}
+   * @return the {@link ListMultipartUploadsResult}
    */
   @RequestMapping(
       value = "/{bucketName:.+}/",

--- a/src/main/java/com/adobe/testing/s3mock/domain/BucketContents.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/BucketContents.java
@@ -17,7 +17,6 @@
 package com.adobe.testing.s3mock.domain;
 
 import com.adobe.testing.s3mock.dto.Owner;
-import com.amazonaws.services.s3.model.StorageClass;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import javax.xml.bind.annotation.XmlElement;
 
@@ -73,14 +72,14 @@ public class BucketContents {
       final String lastModified,
       final String etag,
       final String size,
-      final StorageClass storageClass,
+      final String storageClass,
       final Owner owner) {
     super();
     this.key = key;
     this.lastModified = lastModified;
     this.etag = etag;
     this.size = size;
-    this.storageClass = storageClass.name();
+    this.storageClass = storageClass;
     this.owner = owner;
   }
 

--- a/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
+++ b/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
@@ -16,12 +16,19 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.amazonaws.util.DateUtils;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 @XStreamAlias("CopyPartResult")
 public class CopyPartResult {
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+          .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+          .withZone(ZoneId.of("UTC"));
+
   @XStreamAlias("LastModified")
   private final String lastModified;
 
@@ -34,6 +41,14 @@ public class CopyPartResult {
   }
 
   public static CopyPartResult from(final Date date, final String etag) {
-    return new CopyPartResult(DateUtils.formatISO8601Date(new Date()), etag);
+    return new CopyPartResult(DATE_TIME_FORMATTER.format(date.toInstant()), etag);
+  }
+
+  public String getLastModified() {
+    return lastModified;
+  }
+
+  public String getEtag() {
+    return etag;
   }
 }

--- a/src/main/java/com/adobe/testing/s3mock/util/AwsChunkDecodingInputStream.java
+++ b/src/main/java/com/adobe/testing/s3mock/util/AwsChunkDecodingInputStream.java
@@ -39,7 +39,8 @@ import java.nio.charset.StandardCharsets;
  * [payload-bytes-of-this-chunk][crlf]
  * </pre>
  *
- * @see com.amazonaws.auth.AwsChunkedEncodingInputStream
+ * @see <a href="http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AwsChunkedEncodingInputStream.html">
+ *     AwsChunkedEncodingInputStream</a>
  */
 public class AwsChunkDecodingInputStream extends InputStream {
   /**

--- a/src/main/java/com/adobe/testing/s3mock/util/BetterHeaders.java
+++ b/src/main/java/com/adobe/testing/s3mock/util/BetterHeaders.java
@@ -16,28 +16,24 @@
 
 package com.adobe.testing.s3mock.util;
 
-import com.amazonaws.services.s3.Headers;
-
 /**
- * Holds Header used in HTTP requests from AWS S3 Client. Adapts {@link Headers} for some
- * missing ones.
+ * Holds Header used in HTTP requests from AWS S3 Client
  */
 public final class BetterHeaders {
 
   private static final String NOT = "!";
 
-  public static final String SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID =
-      Headers.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID;
+  public static final String SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID = "x-amz-server-side-encryption-aws-kms-key-id";
 
-  public static final String SERVER_SIDE_ENCRYPTION = Headers.SERVER_SIDE_ENCRYPTION;
+  public static final String SERVER_SIDE_ENCRYPTION = "x-amz-server-side-encryption";
   public static final String NOT_SERVER_SIDE_ENCRYPTION = NOT + SERVER_SIDE_ENCRYPTION;
 
-  public static final String RANGE = Headers.RANGE;
+  public static final String RANGE = "Range";
 
   public static final String COPY_SOURCE = "x-amz-copy-source";
   public static final String NOT_COPY_SOURCE = NOT + COPY_SOURCE;
 
-  public static final String COPY_SOURCE_RANGE = Headers.COPY_PART_RANGE;
+  public static final String COPY_SOURCE_RANGE = "x-amz-copy-source-range";
   public static final String NOT_COPY_SOURCE_RANGE = NOT + COPY_SOURCE_RANGE;
 
   private BetterHeaders() {

--- a/src/test/java/com/adobe/testing/s3mock/dto/CopyPartResultTest.java
+++ b/src/test/java/com/adobe/testing/s3mock/dto/CopyPartResultTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2017 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.adobe.testing.s3mock.dto;
+
+import org.junit.Test;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CopyPartResultTest {
+
+  @Test
+  public void testCreationFromDate() {
+    final CopyPartResult result = CopyPartResult.from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
+  }
+
+}


### PR DESCRIPTION
There's a ton of different versions of the Java S3 SDK [1} . A version is used at the client side is most certainly will not match with the version declared in S3Mock. In case if the library integrated to a
Java application via Maven/Gradle, the developer will have to exclude the aws-java-sdk-s3 dependency or to be at mercy of the default version resolution process in the dependency manager.

It makes sense to declare the dependency as optional and isolate it to `S3MockRule`. In this case the dependency manager will pick up the version of the client SDK. In case the server is run as a Docker
container, we will not add the library to the a distribution, because
the server doesn't depend on it.

[1]: https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3