### PR TITLE
handle case where where end range is undefined

### DIFF
--- a/src/main/java/com/adobe/testing/s3mock/util/RangeConverter.java
+++ b/src/main/java/com/adobe/testing/s3mock/util/RangeConverter.java
@@ -22,6 +22,7 @@ import com.adobe.testing.s3mock.dto.Range;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
 
 /**
  * Converts http range header value to range object
@@ -46,7 +47,7 @@ public class RangeConverter implements Converter<String, Range> {
 
       range =
           new Range(rangeStart == null ? 0L : Long.parseLong(rangeStart),
-              (rangeEnd == null ? Long.MAX_VALUE
+              (StringUtils.isEmpty(rangeEnd) ? Long.MAX_VALUE
                   : Long.parseLong(rangeEnd)));
 
       if (matcher.groupCount() == 5 && !"".equals(matcher.group(4))) {

--- a/src/test/java/com/adobe/testing/s3mock/RangeConverterTest.java
+++ b/src/test/java/com/adobe/testing/s3mock/RangeConverterTest.java
@@ -41,6 +41,15 @@ public class RangeConverterTest {
     assertThat("bad range end", range.getEnd(), equalTo(35L));
   }
 
+  @Test
+  public void convertRangeWithRangeEndUndefined() {
+    final String rangeRequest = "bytes=10-";
+    final Range range = new RangeConverter().convert(rangeRequest);
+
+    assertThat("bad range start", range.getStart(), equalTo(10L));
+    assertThat("bad range end", range.getEnd(), equalTo(Long.MAX_VALUE));
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void throwsExceptionOnNegative() {
     final String rangeRequest = "bytes=2-1";


### PR DESCRIPTION
Hi There,

Please take a look at this PR, which fixes the issue where in GetObject request with byte range of format 10- (starting from 10 to the end of file).

Didn't find any test case to test controller , so tested manually.

Regards,

Syed Frahan Ali