### PR TITLE
Adds support for user metadata for putObject / headObject

### DIFF
--- a/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -177,13 +177,35 @@ public class FileStore {
    * @throws IOException if an I/O error occurs
    */
   public S3Object putS3Object(final String bucketName,
+                              final String fileName,
+                              final String contentType,
+                              final InputStream dataStream,
+                              final boolean useV4Signing) throws IOException {
+    return putS3Object(bucketName, fileName, contentType, dataStream, useV4Signing, Collections.emptyMap());
+  }
+
+  /**
+   * Stores a File inside a Bucket
+   *
+   * @param bucketName Bucket to store the File in
+   * @param fileName name of the File to be stored
+   * @param contentType The files Content Type
+   * @param dataStream The File as InputStream
+   * @param useV4Signing If {@code true}, V4-style signing is enabled.
+   * @param userMetadata User metadata to store for this object, will be available for the object with the key prefixed with "x-amz-meta-".
+   * @return {@link S3Object}
+   * @throws IOException if an I/O error occurs
+   */
+  public S3Object putS3Object(final String bucketName,
       final String fileName,
       final String contentType,
       final InputStream dataStream,
-      final boolean useV4Signing) throws IOException {
+      final boolean useV4Signing,
+      final Map<String, String> userMetadata) throws IOException {
     final S3Object s3Object = new S3Object();
     s3Object.setName(fileName);
     s3Object.setContentType(contentType);
+    s3Object.setUserMetadata(userMetadata);
 
     final Bucket theBucket = getBucketOrCreateNewOne(bucketName);
 

--- a/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
@@ -17,6 +17,7 @@
 package com.adobe.testing.s3mock.domain;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Holds S3 object metadata.
@@ -43,6 +44,8 @@ public class S3Object {
   private transient File dataFile = null;
 
   private String kmsKeyId;
+
+  private Map<String, String> userMetadata;
 
   public String getName() {
     return name;
@@ -131,4 +134,13 @@ public class S3Object {
   public void setKmsEncryptionKeyId(final String kmsKeyId) {
     this.kmsKeyId = kmsKeyId;
   }
+
+  public Map<String, String> getUserMetadata() {
+    return userMetadata;
+  }
+
+  public void setUserMetadata(Map<String, String> userMetadata) {
+    this.userMetadata = userMetadata;
+  }
+
 }

--- a/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -458,13 +458,17 @@ public class AmazonClientUploadIT {
     final File uploadFile = new File(UPLOAD_FILE_NAME);
     s3Client.createBucket(BUCKET_NAME);
 
+    final ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.addUserMetadata("key", "value");
     final PutObjectResult putObjectResult =
-        s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+        s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile).withMetadata(objectMetadata));
     final ObjectMetadata metadataExisting =
         s3Client.getObjectMetadata(BUCKET_NAME, UPLOAD_FILE_NAME);
 
     assertThat("The ETags should be identically!", metadataExisting.getETag(),
         is(putObjectResult.getETag()));
+    assertThat("User metadata should be identically!", metadataExisting.getUserMetadata(),
+            is(equalTo(objectMetadata.getUserMetadata())));
 
     thrown.expect(AmazonS3Exception.class);
     thrown.expectMessage(containsString("Status Code: 404"));


### PR DESCRIPTION
This is an MVP version for user-defined metadata support (headers starting
with "x-amz-meta-"). User metadata is read in `putObject` and returned
with `headObject` or `getObject`.

More support for user-defined metadata (like e.g. for multipart uploads etc)
would have to be added with separate PRs.