### PR TITLE
Feature/check s3 bucket and object existence

### DIFF
--- a/etc/license-template.txt
+++ b/etc/license-template.txt
@@ -1,4 +1,4 @@
- Copyright 2017 Adobe.
+ Copyright ${license.git.copyrightYears} Adobe.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017 Adobe.
+     Copyright 2017-2018 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -71,6 +71,8 @@
         <!-- docker stuff -->
         <docker.image.name>adobe/s3mock</docker.image.name>
         <docker-maven-plugin.version>0.21.0</docker-maven-plugin.version>
+
+        <license-maven-plugin-git.version>3.0</license-maven-plugin-git.version>
     </properties>
 
     <dependencies>
@@ -265,7 +267,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>3.0</version>
+                    <version>${license-maven-plugin-git.version}</version>
                     <configuration>
                         <header>${project.basedir}/etc/license-template.txt</header>
                         <strictCheck>true</strictCheck>
@@ -287,7 +289,18 @@
                         <mapping>
                             <java>SLASHSTAR_STYLE</java>
                         </mapping>
+                        <properties>
+                            <project.inceptionYear>2017</project.inceptionYear>
+                        </properties>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.mycila</groupId>
+                            <artifactId>license-maven-plugin-git</artifactId>
+                            <!-- make sure you use the same version as license-maven-plugin -->
+                            <version>${license-maven-plugin-git.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -524,6 +524,8 @@ class FileStoreController {
     verifyBucketExistence(bucketName);
     final BatchDeleteResponse response = new BatchDeleteResponse();
     for (final BatchDeleteRequest.ObjectToDelete object : body.getObjectsToDelete()) {
+      verifyObjectExistence(bucketName, object.getKey());
+
       try {
         fileStore.deleteObject(bucketName, object.getKey());
 

--- a/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -24,9 +24,12 @@ import static com.adobe.testing.s3mock.util.BetterHeaders.NOT_SERVER_SIDE_ENCRYP
 import static com.adobe.testing.s3mock.util.BetterHeaders.RANGE;
 import static com.adobe.testing.s3mock.util.BetterHeaders.SERVER_SIDE_ENCRYPTION;
 import static com.adobe.testing.s3mock.util.BetterHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 
+import com.adobe.testing.s3mock.domain.Bucket;
 import com.adobe.testing.s3mock.domain.BucketContents;
 import com.adobe.testing.s3mock.domain.FileStore;
+import com.adobe.testing.s3mock.domain.S3Exception;
 import com.adobe.testing.s3mock.domain.S3Object;
 import com.adobe.testing.s3mock.dto.BatchDeleteRequest;
 import com.adobe.testing.s3mock.dto.BatchDeleteResponse;
@@ -149,6 +152,8 @@ class FileStoreController {
    */
   @RequestMapping(value = "/{bucketName}", method = RequestMethod.DELETE)
   public ResponseEntity<String> deleteBucket(@PathVariable final String bucketName) {
+    verifyBucketExistence(bucketName);
+
     final boolean deleted;
 
     try {
@@ -176,6 +181,7 @@ class FileStoreController {
       method = RequestMethod.HEAD)
   public ResponseEntity<String> headObject(@PathVariable final String bucketName,
       final HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
     final String filename = filenameFrom(bucketName, request);
 
     final S3Object s3Object = fileStore.getS3Object(bucketName, filename);
@@ -219,6 +225,7 @@ class FileStoreController {
   public ListBucketResult listObjectsInsideBucket(@PathVariable final String bucketName,
       @RequestParam(required = false) final String prefix,
       final HttpServletResponse response) throws IOException {
+    verifyBucketExistence(bucketName);
     try {
       final List<BucketContents> contents = new ArrayList<>();
       final List<S3Object> s3Objects = fileStore.getS3Objects(bucketName, prefix);
@@ -253,6 +260,8 @@ class FileStoreController {
   @RequestMapping(value = "/{bucketName:.+}/**", method = RequestMethod.PUT)
   public ResponseEntity<String> putObject(@PathVariable final String bucketName,
       final HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
+
     final String filename = filenameFrom(bucketName, request);
     try (ServletInputStream inputStream = request.getInputStream()) {
       final Map<String, String> userMetadata = getUserMetadata(request);
@@ -274,13 +283,13 @@ class FileStoreController {
     }
   }
 
-  private Map<String, String> getUserMetadata(HttpServletRequest request) {
+  private Map<String, String> getUserMetadata(final HttpServletRequest request) {
     return Collections.list(request.getHeaderNames()).stream()
-            .filter(header -> header.startsWith(HEADER_X_AMZ_META_PREFIX))
-            .collect(Collectors.toMap(
-                    header -> header.substring(HEADER_X_AMZ_META_PREFIX.length()),
-                    request::getHeader
-            ));
+        .filter(header -> header.startsWith(HEADER_X_AMZ_META_PREFIX))
+        .collect(Collectors.toMap(
+            header -> header.substring(HEADER_X_AMZ_META_PREFIX.length()),
+            request::getHeader
+        ));
   }
 
   private boolean isV4SigningEnabled(final HttpServletRequest request) {
@@ -313,6 +322,8 @@ class FileStoreController {
       @RequestHeader(value = SERVER_SIDE_ENCRYPTION) final String encryption,
       @RequestHeader(value = SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID) final String kmsKeyId,
       final HttpServletRequest request) throws IOException {
+    verifyBucketExistence(bucketName);
+
     final String filename = filenameFrom(bucketName, request);
     final S3Object s3Object;
     try (ServletInputStream inputStream = request.getInputStream()) {
@@ -397,6 +408,7 @@ class FileStoreController {
           required = false) final String kmsKeyId,
       final HttpServletRequest request,
       final HttpServletResponse response) throws IOException {
+    verifyBucketExistence(destinationBucket);
     final String destinationFile = filenameFrom(destinationBucket, request);
 
     final CopyObjectResult copyObjectResult =
@@ -439,13 +451,11 @@ class FileStoreController {
       final HttpServletResponse response) throws IOException {
     final String filename = filenameFrom(bucketName, request);
 
-    final S3Object s3Object = fileStore.getS3Object(bucketName, filename);
+    verifyBucketExistence(bucketName);
 
-    if (s3Object == null) {
-      LOG.error("Object could not be found!");
-      response.sendError(404,
-          String.format("File %s in Bucket %s couldn't be found!", filename, bucketName));
-    } else if (range != null) {
+    final S3Object s3Object = verifyObjectExistence(bucketName, filename);
+
+    if (range != null) {
       getObjectWithRange(response, range, s3Object);
     } else {
       response.setHeader(HttpHeaders.ETAG, "\"" + s3Object.getMd5() + "\"");
@@ -461,10 +471,11 @@ class FileStoreController {
     }
   }
 
-  private void addUserMetadata(BiConsumer<String, String> responseHeaders, S3Object s3Object) {
+  private void addUserMetadata(final BiConsumer<String, String> responseHeaders,
+      final S3Object s3Object) {
     if (s3Object.getUserMetadata() != null) {
       s3Object.getUserMetadata().forEach((key, value) ->
-              responseHeaders.accept(HEADER_X_AMZ_META_PREFIX + key, value)
+          responseHeaders.accept(HEADER_X_AMZ_META_PREFIX + key, value)
       );
     }
   }
@@ -481,6 +492,8 @@ class FileStoreController {
   public ResponseEntity<String> deleteObject(@PathVariable final String bucketName,
       final HttpServletRequest request) {
     final String filename = filenameFrom(bucketName, request);
+    verifyBucketExistence(bucketName);
+    verifyObjectExistence(bucketName, filename);
 
     try {
       fileStore.deleteObject(bucketName, filename);
@@ -508,6 +521,7 @@ class FileStoreController {
       produces = {"application/x-www-form-urlencoded"})
   public BatchDeleteResponse batchDeleteObjects(@PathVariable final String bucketName,
       @RequestBody final BatchDeleteRequest body) {
+    verifyBucketExistence(bucketName);
     final BatchDeleteResponse response = new BatchDeleteResponse();
     for (final BatchDeleteRequest.ObjectToDelete object : body.getObjectsToDelete()) {
       try {
@@ -568,6 +582,8 @@ class FileStoreController {
       @RequestHeader(value = SERVER_SIDE_ENCRYPTION) final String encryption,
       @RequestHeader(value = SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID) final String kmsKeyId,
       final HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
+
     final String filename = filenameFrom(bucketName, request);
 
     final String uploadId = UUID.randomUUID().toString();
@@ -594,7 +610,8 @@ class FileStoreController {
       method = RequestMethod.GET,
       produces = "application/x-www-form-urlencoded")
   public ListMultipartUploadsResult listMultipartUploads(@PathVariable final String bucketName,
-      @RequestParam(required = true) final String /*unused */ uploads) {
+      @RequestParam final String /*unused */ uploads) {
+    verifyBucketExistence(bucketName);
 
     final List<MultipartUpload> multipartUploads =
         new ArrayList<>(fileStore.listMultipartUploads());
@@ -633,6 +650,8 @@ class FileStoreController {
   public void abortMultipartUpload(@PathVariable final String bucketName,
       @RequestParam(required = true) final String uploadId,
       final HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
+
     final String filename = filenameFrom(bucketName, request);
     fileStore.abortMultipartUpload(bucketName, filename, uploadId);
   }
@@ -654,6 +673,7 @@ class FileStoreController {
   public ListPartsResult multipartListParts(@PathVariable final String bucketName,
       @RequestParam final String uploadId,
       final HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
     final String filename = filenameFrom(bucketName, request);
 
     return new ListPartsResult(bucketName, filename, uploadId);
@@ -692,6 +712,7 @@ class FileStoreController {
           value = SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID,
           required = false) final String kmsKeyId,
       final HttpServletRequest request) throws IOException {
+    verifyBucketExistence(bucketName);
 
     final String filename = filenameFrom(bucketName, request);
 
@@ -779,6 +800,8 @@ class FileStoreController {
       @RequestParam final String uploadId,
       @RequestParam final String partNumber,
       final HttpServletRequest request) throws IOException {
+    verifyBucketExistence(destinationBucket);
+
     final String destinationFile = filenameFrom(destinationBucket, request);
     final String partEtag = fileStore.copyPart(copySource.getBucket(),
         copySource.getKey(),
@@ -837,7 +860,9 @@ class FileStoreController {
   public ResponseEntity<CompleteMultipartUploadResult> completeMultipartUpload(
       @PathVariable final String bucketName,
       @RequestParam final String uploadId,
-      final HttpServletRequest request) throws IOException {
+      final HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
+
     final String filename = filenameFrom(bucketName, request);
 
     final String eTag =
@@ -872,7 +897,8 @@ class FileStoreController {
       @RequestParam final String uploadId,
       @RequestHeader(value = SERVER_SIDE_ENCRYPTION) final String encryption,
       @RequestHeader(value = SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID) final String kmsKeyId,
-      final HttpServletRequest request) throws IOException {
+      final HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
     final String filename = filenameFrom(bucketName, request);
 
     final String eTag = fileStore.completeMultipartUpload(bucketName,
@@ -933,5 +959,22 @@ class FileStoreController {
       final HttpServletRequest request) {
     final String requestURI = request.getRequestURI();
     return requestURI.substring(requestURI.indexOf(bucketName) + bucketName.length() + 1);
+  }
+
+  private S3Object verifyObjectExistence(@PathVariable final String bucketName,
+      final String filename) {
+    final S3Object s3Object = fileStore.getS3Object(bucketName, filename);
+    if (s3Object == null) {
+      LOG.error("Object could not be found!");
+      throw new S3Exception(SC_NOT_FOUND, "NoSuchKey", "The specified key does not exist.");
+    }
+    return s3Object;
+  }
+
+  private void verifyBucketExistence(final String bucketName) {
+    final Bucket bucket = fileStore.getBucket(bucketName);
+    if (bucket == null) {
+      throw new S3Exception(SC_NOT_FOUND, "NoSuchBucket", "The specified bucket does not exist.");
+    }
   }
 }

--- a/src/main/java/com/adobe/testing/s3mock/KMSValidationFilter.java
+++ b/src/main/java/com/adobe/testing/s3mock/KMSValidationFilter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/KMSValidationFilter.java
+++ b/src/main/java/com/adobe/testing/s3mock/KMSValidationFilter.java
@@ -57,8 +57,7 @@ class KMSValidationFilter extends OncePerRequestFilter {
   }
 
   @Override
-  protected void
-  doFilterInternal(final HttpServletRequest request,
+  protected void doFilterInternal(final HttpServletRequest request,
       final HttpServletResponse response,
       final FilterChain filterChain) throws ServletException,
       IOException {

--- a/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -19,6 +19,7 @@ package com.adobe.testing.s3mock;
 import com.adobe.testing.s3mock.domain.Bucket;
 import com.adobe.testing.s3mock.domain.FileStore;
 import com.adobe.testing.s3mock.domain.KMSKeyStore;
+import com.adobe.testing.s3mock.domain.S3Exception;
 import com.adobe.testing.s3mock.dto.BatchDeleteRequest;
 import com.adobe.testing.s3mock.dto.BatchDeleteResponse;
 import com.adobe.testing.s3mock.dto.CompleteMultipartUploadResult;
@@ -33,6 +34,8 @@ import com.adobe.testing.s3mock.dto.ListPartsResult;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.util.ObjectRefConverter;
 import com.adobe.testing.s3mock.util.RangeConverter;
+import com.adobe.testing.s3mock.util.S3ExceptionResolver;
+import javax.servlet.http.HttpServletResponse;
 import org.apache.catalina.connector.Connector;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +58,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.xml.MarshallingHttpMessageConverter;
 import org.springframework.oxm.xstream.XStreamMarshaller;
 import org.springframework.util.SocketUtils;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
@@ -69,6 +74,9 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 /**
  * File Store Application that mocks Amazon S3.
@@ -266,6 +274,11 @@ public class S3MockApplication extends WebMvcConfigurerAdapter {
     xmlConverter.setUnmarshaller(xstreamMarshaller);
 
     return xmlConverter;
+  }
+
+  @Bean
+  public S3ExceptionResolver s3ExceptionResolver() {
+    return new S3ExceptionResolver();
   }
 
   /**

--- a/src/main/java/com/adobe/testing/s3mock/S3MockRule.java
+++ b/src/main/java/com/adobe/testing/s3mock/S3MockRule.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/domain/S3Exception.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/S3Exception.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/domain/S3Exception.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/S3Exception.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.domain;
+
+/**
+ * {@link RuntimeException} to communicate general S3 errors. These are handled by
+ * {@code com.adobe.testing.s3mock.util.S3ExceptionResolver}, mapped to
+ * {@link com.adobe.testing.s3mock.dto.ErrorResponse} and serialized.
+ */
+public class S3Exception extends RuntimeException {
+  private final int status;
+  private final String code;
+  private final String message;
+
+  public S3Exception(final int status, final String code, final String message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/util/RangeConverter.java
+++ b/src/main/java/com/adobe/testing/s3mock/util/RangeConverter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/util/S3ExceptionResolver.java
+++ b/src/main/java/com/adobe/testing/s3mock/util/S3ExceptionResolver.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/util/S3ExceptionResolver.java
+++ b/src/main/java/com/adobe/testing/s3mock/util/S3ExceptionResolver.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.util;
+
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+
+import com.adobe.testing.s3mock.domain.S3Exception;
+import com.adobe.testing.s3mock.dto.ErrorResponse;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.oxm.xstream.XStreamMarshaller;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * {@link HandlerExceptionResolver} dealing with {@link S3Exception}s; Serializes them to response
+ * output as suitable ErrorResponses.
+ * See https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html.
+ */
+public class S3ExceptionResolver implements HandlerExceptionResolver {
+  private static final Logger LOG = LoggerFactory.getLogger(S3ExceptionResolver.class);
+
+  @Autowired
+  private XStreamMarshaller marshaller;
+
+  @Override
+  public ModelAndView resolveException(final HttpServletRequest request,
+      final HttpServletResponse response, final Object o, final Exception e) {
+    if (e instanceof S3Exception) {
+      final S3Exception s3Exception = (S3Exception) e;
+      final ErrorResponse errorResponse = new ErrorResponse();
+      errorResponse.setCode(s3Exception.getCode());
+      errorResponse.setMessage(s3Exception.getMessage());
+
+      try {
+        response.setStatus(s3Exception.getStatus());
+        response.setHeader(CONTENT_TYPE, APPLICATION_XML_VALUE);
+        marshaller.marshalOutputStream(errorResponse, response.getOutputStream());
+        response.flushBuffer();
+      } catch (final IOException e1) {
+        LOG.info(String.format("Could not write error Response for Exception=%s", e), e1);
+      }
+    }
+    return null;
+  }
+}

--- a/src/test/java/com/adobe/testing/s3mock/RangeConverterTest.java
+++ b/src/test/java/com/adobe/testing/s3mock/RangeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesIT.java
+++ b/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesIT.java
@@ -1,0 +1,437 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.services.s3.transfer.model.UploadResult;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Verifies S3 Mocks Error Responses.
+ */
+public class ErrorResponsesIT extends S3TestBase {
+  private static final String NO_SUCH_BUCKET = "Status Code: 404; Error Code: NoSuchBucket";
+  private static final String NO_SUCH_KEY = "Status Code: 404; Error Code: NoSuchKey";
+  private static final String STATUS_CODE_404 = "Status Code: 404";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  /**
+   * Verifies that {@code NoSuchBucket} is returned in Error Response if {@code putObject}
+   * references a non existing Bucket.
+   */
+  @Test
+  public void putObjectOnNonExistingBucket() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    thrown.expect(AmazonServiceException.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+  }
+
+  /**
+   * Verifies that {@code NoSuchBucket} is returned in Error Response if {@code putObject}
+   * references a non existing Bucket.
+   */
+  @Test
+  public void putObjectEncryptedOnNonExistingBucket() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    final PutObjectRequest putObjectRequest =
+        new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile);
+    putObjectRequest.setSSEAwsKeyManagementParams(new SSEAwsKeyManagementParams(TEST_ENC_KEYREF));
+
+    thrown.expect(AmazonServiceException.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+  }
+
+  /**
+   * Verifies that {@code NoSuchBucket} is returned in Error Response if {@code copyObject}
+   * references a non existing destination Bucket.
+   */
+  @Test
+  public void copyObjectToNonExistingDestinationBucket() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+    final String sourceKey = UPLOAD_FILE_NAME;
+    final String destinationBucketName = "destinationbucket";
+    final String destinationKey = "copyOf/" + sourceKey;
+
+    s3Client.createBucket(BUCKET_NAME);
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, sourceKey, uploadFile));
+
+    final CopyObjectRequest copyObjectRequest =
+        new CopyObjectRequest(BUCKET_NAME, sourceKey, destinationBucketName, destinationKey);
+
+    thrown.expect(AmazonServiceException.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.copyObject(copyObjectRequest);
+  }
+
+  /**
+   * Verifies that {@code NoSuchBucket} is returned in Error Response if {@code copyObject}
+   * encrypted references a non existing destination Bucket.
+   */
+  @Test
+  public void copyObjectEncryptedToNonExistingDestinationBucket() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+    final String sourceKey = UPLOAD_FILE_NAME;
+    final String destinationBucketName = "destinationbucket";
+    final String destinationKey = "copyOf/" + sourceKey;
+
+    s3Client.createBucket(BUCKET_NAME);
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, sourceKey, uploadFile));
+
+    final CopyObjectRequest copyObjectRequest =
+        new CopyObjectRequest(BUCKET_NAME, sourceKey, destinationBucketName, destinationKey);
+    copyObjectRequest.setSSEAwsKeyManagementParams(
+        new SSEAwsKeyManagementParams(TEST_ENC_KEYREF));
+
+    thrown.expect(AmazonServiceException.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.copyObject(copyObjectRequest);
+  }
+
+  /**
+   * Tests if the Metadata of an existing file can be retrieved.
+   */
+  @Test
+  public void getObjectMetadataWithNonExistingBucket() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+    s3Client.createBucket(BUCKET_NAME);
+
+    final ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.addUserMetadata("key", "value");
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile)
+        .withMetadata(objectMetadata));
+
+    thrown.expect(AmazonServiceException.class);
+    thrown.expectMessage(containsString(STATUS_CODE_404));
+    s3Client.getObjectMetadata(UUID.randomUUID().toString(), UPLOAD_FILE_NAME);
+  }
+
+  /**
+   * Tests if an object can be deleted.
+   */
+  @Test
+  public void deleteFromNonExistingBucket() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+    s3Client.createBucket(BUCKET_NAME);
+
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.deleteObject(UUID.randomUUID().toString(), UPLOAD_FILE_NAME);
+  }
+
+  /**
+   * Tests if an object can be deleted.
+   */
+  @Test
+  public void deleteNonExistingObject() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+    s3Client.createBucket(BUCKET_NAME);
+
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_KEY));
+    s3Client.deleteObject(BUCKET_NAME, UUID.randomUUID().toString());
+  }
+
+  /**
+   * Tests if an object can be deleted
+   */
+  @Test
+  public void batchDeleteObjectsFromNonExistingBucket() {
+    final File uploadFile1 = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(BUCKET_NAME);
+
+    s3Client
+        .putObject(new PutObjectRequest(BUCKET_NAME, "1_" + UPLOAD_FILE_NAME, uploadFile1));
+
+    final DeleteObjectsRequest multiObjectDeleteRequest =
+        new DeleteObjectsRequest(UUID.randomUUID().toString());
+
+    final List<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
+    keys.add(new DeleteObjectsRequest.KeyVersion("1_" + UPLOAD_FILE_NAME));
+
+    multiObjectDeleteRequest.setKeys(keys);
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.deleteObjects(multiObjectDeleteRequest);
+  }
+
+  /**
+   * Tests if an object can be deleted
+   */
+  @Test
+  public void batchDeleteNonExistingObjects() {
+    final File uploadFile1 = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(BUCKET_NAME);
+
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME,
+        "1_" + UPLOAD_FILE_NAME, uploadFile1));
+
+    final DeleteObjectsRequest multiObjectDeleteRequest =
+        new DeleteObjectsRequest(BUCKET_NAME);
+
+    final List<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
+    keys.add(new DeleteObjectsRequest.KeyVersion("1_" + UUID.randomUUID().toString()));
+
+    multiObjectDeleteRequest.setKeys(keys);
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_KEY));
+    s3Client.deleteObjects(multiObjectDeleteRequest);
+  }
+
+  /**
+   * Tests that a bucket can be deleted
+   */
+  @Test
+  public void deleteNonExistingBucket() {
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.deleteBucket(BUCKET_NAME);
+  }
+
+  /**
+   * Tests if the list objects can be retrieved.
+   */
+  @Test
+  public void listObjectsFromNonExistingBucket() {
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.listObjects(UUID.randomUUID().toString(), UPLOAD_FILE_NAME);
+  }
+
+  /**
+   * Tests if an object can be uploaded asynchronously
+   *
+   * @throws Exception not expected
+   */
+  @Test
+  public void uploadParallelToNonExistingBucket() throws Exception {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(BUCKET_NAME);
+
+    final TransferManager transferManager = createDefaultTransferManager();
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    final Upload upload = transferManager.upload(
+        new PutObjectRequest(UUID.randomUUID().toString(), UPLOAD_FILE_NAME, uploadFile));
+    upload.waitForUploadResult();
+  }
+
+  /**
+   * Tests if not yet completed / aborted multipart uploads are listed.
+   */
+  @Test
+  public void multipartUploadsToNonExistingBucket() {
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.initiateMultipartUpload(
+            new InitiateMultipartUploadRequest(BUCKET_NAME, UPLOAD_FILE_NAME));
+  }
+
+  /**
+   * Tests if not yet completed / aborted multipart uploads are listed.
+   */
+  @Test
+  public void listMultipartUploadsFromNonExistingBucket() {
+    s3Client.createBucket(BUCKET_NAME);
+
+    s3Client.initiateMultipartUpload(
+        new InitiateMultipartUploadRequest(BUCKET_NAME, UPLOAD_FILE_NAME));
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.listMultipartUploads(new ListMultipartUploadsRequest(UUID.randomUUID().toString()));
+  }
+
+  /**
+   * Tests if a multipart upload can be aborted.
+   */
+  @Test
+  public void abortMultipartUploadInNonExistingBucket() {
+    s3Client.createBucket(BUCKET_NAME);
+
+    final InitiateMultipartUploadResult initiateMultipartUploadResult = s3Client
+        .initiateMultipartUpload(new InitiateMultipartUploadRequest(BUCKET_NAME, UPLOAD_FILE_NAME));
+    final String uploadId = initiateMultipartUploadResult.getUploadId();
+
+    assertThat(s3Client.listMultipartUploads(new ListMultipartUploadsRequest(BUCKET_NAME))
+        .getMultipartUploads(), is(not(empty())));
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+    s3Client.abortMultipartUpload(
+        new AbortMultipartUploadRequest(UUID.randomUUID().toString(), UPLOAD_FILE_NAME, uploadId));
+  }
+
+  /**
+   * Verify that range-downloads work.
+   *
+   * @throws Exception not expected
+   */
+  @Test
+  public void rangeDownloadsFromNonExistingBucket() throws Exception {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(BUCKET_NAME);
+
+    final TransferManager transferManager = createDefaultTransferManager();
+    final Upload upload =
+        transferManager.upload(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+    upload.waitForUploadResult();
+
+    final File downloadFile = File.createTempFile(UUID.randomUUID().toString(), null);
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(STATUS_CODE_404));
+    transferManager.download(
+        new GetObjectRequest(UUID.randomUUID().toString(), UPLOAD_FILE_NAME).withRange(1, 2),
+        downloadFile).waitForCompletion();
+  }
+
+  /**
+   * Verify that range-downloads work.
+   *
+   * @throws Exception not expected
+   */
+  @Test
+  public void rangeDownloadsFromNonExistingObject() throws Exception {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(BUCKET_NAME);
+
+    final TransferManager transferManager = createDefaultTransferManager();
+    final Upload upload =
+        transferManager.upload(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+    upload.waitForUploadResult();
+
+    final File downloadFile = File.createTempFile(UUID.randomUUID().toString(), null);
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(STATUS_CODE_404));
+    transferManager.download(
+        new GetObjectRequest(BUCKET_NAME, UUID.randomUUID().toString()).withRange(1, 2),
+        downloadFile).waitForCompletion();
+  }
+
+  /**
+   * Verifies multipart copy.
+   */
+  @Test
+  public void multipartCopyToNonExistingBucket() throws InterruptedException {
+    final int contentLen = 3 * _1MB;
+
+    final ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(contentLen);
+
+    final String assumedSourceKey = UUID.randomUUID().toString();
+
+    final Bucket sourceBucket = s3Client.createBucket(UUID.randomUUID().toString());
+
+    final TransferManager transferManager = createTransferManager(_2MB, _1MB, _2MB, _1MB);
+
+    final InputStream sourceInputStream = randomInputStream(contentLen);
+    final Upload upload = transferManager
+        .upload(sourceBucket.getName(), assumedSourceKey,
+            sourceInputStream, objectMetadata);
+
+    final UploadResult uploadResult = upload.waitForUploadResult();
+
+    assertThat(uploadResult.getKey(), is(assumedSourceKey));
+
+    final String assumedDestinationKey = UUID.randomUUID().toString();
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(NO_SUCH_BUCKET));
+
+    transferManager.copy(sourceBucket.getName(), assumedSourceKey, UUID.randomUUID().toString(),
+        assumedDestinationKey).waitForCopyResult();
+  }
+
+  /**
+   * Verifies multipart copy.
+   */
+  @Test
+  public void multipartCopyNonExistingObject() throws InterruptedException {
+    final int contentLen = 3 * _1MB;
+
+    final ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(contentLen);
+
+    final String assumedSourceKey = UUID.randomUUID().toString();
+
+    final Bucket sourceBucket = s3Client.createBucket(UUID.randomUUID().toString());
+    final Bucket targetBucket = s3Client.createBucket(UUID.randomUUID().toString());
+
+    final TransferManager transferManager = createTransferManager(_2MB, _1MB, _2MB, _1MB);
+
+    final InputStream sourceInputStream = randomInputStream(contentLen);
+    final Upload upload = transferManager
+        .upload(sourceBucket.getName(), assumedSourceKey,
+            sourceInputStream, objectMetadata);
+
+    final UploadResult uploadResult = upload.waitForUploadResult();
+
+    assertThat(uploadResult.getKey(), is(assumedSourceKey));
+
+    final String assumedDestinationKey = UUID.randomUUID().toString();
+
+    thrown.expect(AmazonS3Exception.class);
+    thrown.expectMessage(containsString(STATUS_CODE_404));
+    transferManager.copy(sourceBucket.getName(), UUID.randomUUID().toString(),
+        targetBucket.getName(), assumedDestinationKey).waitForCopyResult();
+  }
+}

--- a/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
+++ b/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
@@ -1,0 +1,219 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its;
+
+import static java.util.Arrays.asList;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Base type for S3 Mock integration tests. Sets up S3 Client, Certificates, initial Buckets, etc.
+ */
+public abstract class S3TestBase {
+  static final Collection<String> INITIAL_BUCKET_NAMES = asList("bucket-a", "bucket-b");
+
+  static final String TEST_ENC_KEYREF =
+      "arn:aws:kms:us-east-1:1234567890:key/valid-test-key-ref";
+
+  static final String BUCKET_NAME = "mydemotestbucket";
+
+  static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
+
+  static final String TEST_WRONG_KEYREF =
+      "arn:aws:kms:us-east-1:1234567890:keyWRONGWRONGWRONG/2d70f7f6-b484-4309-91d5-7813b7dd46ce";
+  static final int _1MB = 1024 * 1024;
+  static final long _2MB = 2L * _1MB;
+  private static final long _6BYTE = 6L;
+
+  private static final int THREAD_COUNT = 50;
+
+  AmazonS3 s3Client;
+
+  /**
+   * Configures the S3-Client to be used in the Test. Sets the SSL context to accept untrusted SSL
+   * connections.
+   */
+  @Before
+  public void prepareS3Client() {
+    final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
+
+    s3Client = AmazonS3ClientBuilder.standard()
+        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+        .withClientConfiguration(ignoringInvalidSslCertificates(new ClientConfiguration()))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration("https://" + getHost() + ":" + getPort(),
+                "us-east-1"))
+        .enablePathStyleAccess()
+        .build();
+  }
+
+  /**
+   * Deletes all existing buckets
+   */
+  @After
+  public void cleanupFilestore() {
+    for (final Bucket bucket : s3Client.listBuckets()) {
+      if (!INITIAL_BUCKET_NAMES.contains(bucket.getName())) {
+        s3Client.listMultipartUploads(new ListMultipartUploadsRequest(bucket.getName()))
+            .getMultipartUploads()
+            .forEach(upload ->
+                s3Client.abortMultipartUpload(
+                    new AbortMultipartUploadRequest(bucket.getName(), upload.getKey(),
+                        upload.getUploadId()))
+            );
+        s3Client.deleteBucket(bucket.getName());
+      }
+    }
+  }
+
+  private String getHost() {
+    return System.getProperty("it.s3mock.host", "localhost");
+  }
+
+  private int getPort() {
+    return Integer.getInteger("it.s3mock.port_https", 9191);
+  }
+
+  private ClientConfiguration ignoringInvalidSslCertificates(
+      final ClientConfiguration clientConfiguration) {
+
+    clientConfiguration.getApacheHttpClientConfig()
+        .withSslSocketFactory(new SSLConnectionSocketFactory(
+            createBlindlyTrustingSSLContext(),
+            NoopHostnameVerifier.INSTANCE));
+
+    return clientConfiguration;
+  }
+
+  private SSLContext createBlindlyTrustingSSLContext() {
+    try {
+      final SSLContext sc = SSLContext.getInstance("TLS");
+
+      sc.init(null, new TrustManager[] {new X509ExtendedTrustManager() {
+        @Override
+        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+          return null;
+        }
+
+        @Override
+        public void checkClientTrusted(final X509Certificate[] certs, final String authType) {
+          // no-op
+        }
+
+        @Override
+        public void checkServerTrusted(final X509Certificate[] certs, final String authType) {
+          // no-op
+        }
+
+        @Override
+        public void checkClientTrusted(final X509Certificate[] arg0, final String arg1,
+            final Socket arg2) {
+          // no-op
+        }
+
+        @Override
+        public void checkClientTrusted(final X509Certificate[] arg0, final String arg1,
+            final SSLEngine arg2) {
+          // no-op
+        }
+
+        @Override
+        public void checkServerTrusted(final X509Certificate[] arg0, final String arg1,
+            final Socket arg2) {
+          // no-op
+        }
+
+        @Override
+        public void checkServerTrusted(final X509Certificate[] arg0, final String arg1,
+            final SSLEngine arg2) {
+          // no-op
+        }
+      }
+      }, new java.security.SecureRandom());
+
+      return sc;
+    } catch (final NoSuchAlgorithmException | KeyManagementException e) {
+      throw new RuntimeException("Unexpected exception", e);
+    }
+  }
+
+  TransferManager createDefaultTransferManager() {
+    return createTransferManager(_6BYTE, _6BYTE, _6BYTE, _6BYTE);
+  }
+
+  TransferManager createTransferManager(final long multipartUploadThreshold,
+      final long multipartUploadPartSize,
+      final long multipartCopyThreshold,
+      final long multipartCopyPartSize) {
+    final ThreadFactory threadFactory = new ThreadFactory() {
+      private int threadCount = 1;
+
+      @Override
+      public Thread newThread(final Runnable r) {
+        final Thread thread = new Thread(r);
+        thread.setName("s3-transfer-" + threadCount++);
+
+        return thread;
+      }
+    };
+
+    return TransferManagerBuilder.standard()
+        .withS3Client(s3Client)
+        .withExecutorFactory(() -> Executors.newFixedThreadPool(THREAD_COUNT, threadFactory))
+        .withMultipartUploadThreshold(multipartUploadThreshold)
+        .withMinimumUploadPartSize(multipartUploadPartSize)
+        .withMultipartCopyPartSize(multipartCopyPartSize)
+        .withMultipartCopyThreshold(multipartCopyThreshold)
+        .build();
+  }
+
+
+  InputStream randomInputStream(final int size) {
+    final byte[] content = new byte[size];
+    new Random().nextBytes(content);
+
+    return new ByteArrayInputStream(content);
+  }
+}


### PR DESCRIPTION
## Description
Operations on Bucket and Objects now check for existence of Bucket/Object. If one if not available a `S3Exception` will be thrown. According to https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html 
* non existing Buckets are reported by `HTTP 404 NoSuchBucket`
* non existing Objects are reported by `HTTP 404 NoSuchKey`

`S3ExceptionResolver` catches these exceptions and returns a corresponding `ErrorResponse` on the HttpResponse.

It also adapts the license header. We're now using which verifies that all touched files change the copyright year as
`Copyright 2017-[current-year] Adobe.`

---

@agudian: Please review, rebase + merge and delete branch.