### PR TITLE
Complete support for user metadata including putObjectEncrypted and multipart upload

### DIFF
--- a/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -100,7 +100,6 @@ class FileStoreController {
 
   @Autowired
   private FileStore fileStore;
-
   /**
    * @return a list of all Buckets
    */
@@ -556,10 +555,13 @@ class FileStoreController {
   public InitiateMultipartUploadResult initiateMultipartUpload(
       @PathVariable final String bucketName,
       final HttpServletRequest request) {
-    return initiateMultipartUpload(bucketName,
+
+    final InitiateMultipartUploadResult response = initiateMultipartUpload(bucketName,
         ABSENT_ENCRYPTION,
         ABSENT_KEY_ID,
         request);
+
+    return response;
   }
 
   /**
@@ -587,10 +589,11 @@ class FileStoreController {
     verifyBucketExistence(bucketName);
 
     final String filename = filenameFrom(bucketName, request);
+    final Map<String, String> userMetadata = getUserMetadata(request);
 
     final String uploadId = UUID.randomUUID().toString();
     fileStore.prepareMultipartUpload(bucketName, filename, request.getContentType(), uploadId,
-        TEST_OWNER, TEST_OWNER);
+        TEST_OWNER, TEST_OWNER, userMetadata);
 
     return new InitiateMultipartUploadResult(bucketName, filename, uploadId);
   }

--- a/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -326,12 +326,14 @@ class FileStoreController {
     final String filename = filenameFrom(bucketName, request);
     final S3Object s3Object;
     try (ServletInputStream inputStream = request.getInputStream()) {
+      final Map<String, String> userMetadata = getUserMetadata(request);
       s3Object =
           fileStore.putS3ObjectWithKMSEncryption(bucketName,
               filename,
               request.getContentType(),
               inputStream,
               isV4SigningEnabled(request),
+              userMetadata,
               encryption,
               kmsKeyId);
 

--- a/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -546,7 +546,7 @@ public class FileStore {
    * @param uploadId id of the upload
    */
   public MultipartUpload prepareMultipartUpload(final String bucketName, final String fileName,
-      final String contentType, final String uploadId, final Owner owner, final Owner initiator) {
+      final String contentType, final String uploadId, final Owner owner, final Owner initiator, final Map<String, String> userMetadata) {
 
     if (!Paths.get(rootFolder.getAbsolutePath(), bucketName, fileName, uploadId).toFile()
         .mkdirs()) {
@@ -555,9 +555,22 @@ public class FileStore {
     }
     final MultipartUpload upload =
         new MultipartUpload(fileName, uploadId, owner, initiator, new Date());
-    uploadIdToInfo.put(uploadId, new MultipartUploadInfo(upload, contentType));
+    uploadIdToInfo.put(uploadId, new MultipartUploadInfo(upload, contentType, userMetadata));
 
     return upload;
+  }
+
+  /**
+   * Prepares everything to store files uploaded as multipart upload.
+   * @param bucketName in which to upload
+   * @param fileName of the file to upload
+   * @param contentType the content type
+   * @param uploadId id of the upload
+   */
+  public MultipartUpload prepareMultipartUpload(final String bucketName, final String fileName,
+                                                final String contentType, final String uploadId, final Owner owner, final Owner initiator) {
+
+    return prepareMultipartUpload(bucketName, fileName, contentType, uploadId, owner, initiator, Collections.emptyMap());
   }
 
   /**
@@ -689,6 +702,7 @@ public class FileStore {
         s3Object.setSize(Integer.toString(size));
         s3Object.setContentType(
             uploadInfo.contentType != null ? uploadInfo.contentType : DEFAULT_CONTENT_TYPE);
+        s3Object.setUserMetadata(uploadInfo.userMetadata);
 
         uploadIdToInfo.remove(uploadId);
 

--- a/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -257,14 +257,40 @@ public class FileStore {
    * @throws IOException if an I/O error occurs
    */
   public S3Object putS3ObjectWithKMSEncryption(final String bucketName,
+                                               final String fileName,
+                                               final String contentType,
+                                               final InputStream dataStream,
+                                               final boolean useV4Signing,
+                                               final String encryption, final String kmsKeyId) throws IOException {
+    return putS3ObjectWithKMSEncryption(bucketName, fileName, contentType, dataStream, useV4Signing,
+            Collections.emptyMap(), encryption, kmsKeyId);
+  }
+
+  /**
+   * Stores an encrypted File inside a Bucket
+   *
+   * @param bucketName Bucket to store the File in
+   * @param fileName name of the File to be stored
+   * @param contentType The files Content Type
+   * @param dataStream The File as InputStream
+   * @param useV4Signing If {@code true}, V4-style signing is enabled.
+   * @param userMetadata User metadata to store for this object, will be available for the object with the key prefixed with "x-amz-meta-".
+   * @param encryption The Encryption Type
+   * @param kmsKeyId The KMS encryption key id
+   * @return {@link S3Object}
+   * @throws IOException if an I/O error occurs
+   */
+  public S3Object putS3ObjectWithKMSEncryption(final String bucketName,
       final String fileName,
       final String contentType,
       final InputStream dataStream,
       final boolean useV4Signing,
+      final Map<String, String> userMetadata,
       final String encryption, final String kmsKeyId) throws IOException {
     final S3Object s3Object = new S3Object();
     s3Object.setName(fileName);
     s3Object.setContentType(contentType);
+    s3Object.setUserMetadata(userMetadata);
     s3Object.setEncrypted(true);
     s3Object.setKmsEncryption(encryption);
     s3Object.setKmsEncryptionKeyId(kmsKeyId);

--- a/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 Adobe.
+ *  Copyright 2017-2018 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
+++ b/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
@@ -18,15 +18,19 @@ package com.adobe.testing.s3mock.domain;
 
 import com.adobe.testing.s3mock.dto.MultipartUpload;
 
+import java.util.Map;
+
 /**
  * Encapsulates {@link MultipartUpload} and corresponding {@code contentType}
  */
 class MultipartUploadInfo {
   final MultipartUpload upload;
   final String contentType;
+  final Map<String, String> userMetadata;
 
-  MultipartUploadInfo(final MultipartUpload upload, final String contentType) {
+  MultipartUploadInfo(final MultipartUpload upload, final String contentType, Map<String, String> userMetadata) {
     this.upload = upload;
     this.contentType = contentType;
+    this.userMetadata = userMetadata;
   }
 }

--- a/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -201,15 +201,17 @@ public class AmazonClientUploadIT extends S3TestBase{
   }
 
   /**
-   * Tests if Object can be uploaded with KMS
+   * Tests if Object can be uploaded with KMS and Metadata can be retrieved.
    */
   @Test
   public void shouldUploadWithEncryption() {
     final File uploadFile = new File(UPLOAD_FILE_NAME);
     final String objectKey = UPLOAD_FILE_NAME;
     s3Client.createBucket(BUCKET_NAME);
+    final ObjectMetadata metadata = new ObjectMetadata();
+    metadata.addUserMetadata("key", "value");
     final PutObjectRequest putObjectRequest =
-        new PutObjectRequest(BUCKET_NAME, objectKey, uploadFile);
+        new PutObjectRequest(BUCKET_NAME, objectKey, uploadFile).withMetadata(metadata);
     putObjectRequest.setSSEAwsKeyManagementParams(new SSEAwsKeyManagementParams(TEST_ENC_KEYREF));
 
     s3Client.putObject(putObjectRequest);
@@ -220,6 +222,10 @@ public class AmazonClientUploadIT extends S3TestBase{
     final ObjectMetadata objectMetadata = s3Client.getObjectMetadata(getObjectMetadataRequest);
 
     assertThat(objectMetadata.getContentLength(), is(uploadFile.length()));
+
+    assertThat("User metadata should be identical!", objectMetadata.getUserMetadata(),
+            is(equalTo(metadata.getUserMetadata())));
+
   }
 
   /**


### PR DESCRIPTION
## Description
- support for user metadata was added already but could only be set by putObject
- now initiateMultipartUpload as well reads headers starting with "x-amz-meta-".

## Related Issue

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
