### PR TITLE
Adding ability to create S3Client in a different region

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ To use the JUnit5 Extension, use the following Maven artifact in `test` scope:
 <dependency>
 ```
 
+#### Using the TestNG Listener
+
+The example [`S3MockListenerXMLConfigurationTest`](testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXMLConfigurationTest.java) demonstrates the usage of the `S3MockListener`, which can be configured as shown in [`testng.xml`](testsupport/testng/src/test/resources/testng.xml). The listener bootstraps S3Mock application before TestNG execution starts and shuts down the application just before the execution terminates. Please refer to [`IExecutionListener`](https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IExecutionListener.html) 
+
+To use the TestNG Listener, use the following Maven artifact in `test` scope:
+
+```xml
+<dependency>
+ <groupId>com.adobe.testing</groupId>
+ <artifactId>s3mock-testng</artifactId>
+ <version>...</version>
+ <scope>test</scope>
+<dependency>
+```
+
 #### Starting Programmatically
 
 Include the following dependency and use one of the `start` methods in `com.adobe.testing.s3mock.S3MockApplication`:

--- a/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
+++ b/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
@@ -64,7 +64,7 @@ public abstract class S3MockStarter {
    * @return An {@link AmazonS3} client instance that is configured to call the started S3Mock
    *         server using HTTPS.
    */
-  public AmazonS3 createS3Client() {
+  public AmazonS3 createS3Client(String region) {
     final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
 
     return AmazonS3ClientBuilder.standard()
@@ -72,9 +72,17 @@ public abstract class S3MockStarter {
         .withClientConfiguration(
             configureClientToIgnoreInvalidSslCertificates(new ClientConfiguration()))
         .withEndpointConfiguration(
-            new EndpointConfiguration("https://localhost:" + getPort(), "us-east-1"))
+            new EndpointConfiguration("https://localhost:" + getPort(), region))
         .enablePathStyleAccess()
         .build();
+  }
+
+  /**
+   * @return An {@link AmazonS3} client instance that is configured to call the started S3Mock
+   *         server using HTTPS.
+   */
+  public AmazonS3 createS3Client() {
+     return createS3Client("us-east-1");
   }
 
   /**

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -34,6 +34,7 @@
         <module>common</module>
         <module>junit4</module>
         <module>junit5</module>
+        <module>testng</module>
     </modules>
 
     <build>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -50,15 +50,6 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <!-- needs to be pinned down to 2.19.1 until a new junit-platform-surefire-provider provider is released -->
-                    <version>2.19.1</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-testng</artifactId>
-                            <version>2.19.1</version>
-                        </dependency>
-                    </dependencies>
                     <configuration>
                         <suiteXmlFiles>
                             <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2018 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>s3mock-parent</artifactId>
+        <groupId>com.adobe.testing</groupId>
+        <version>2.0.1-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>s3mock-testng</artifactId>
+    <packaging>jar</packaging>
+
+    <name>S3Mock - Testsupport - TestNG</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.14.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.testing</groupId>
+            <artifactId>s3mock-testsupport-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <!-- needs to be pinned down to 2.19.1 until a new junit-platform-surefire-provider provider is released -->
+                    <version>2.19.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-testng</artifactId>
+                            <version>2.19.1</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <suiteXmlFiles>
+                            <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                        </suiteXmlFiles>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
+++ b/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.testng;
+
+import com.adobe.testing.s3mock.S3MockApplication;
+import com.adobe.testing.s3mock.testsupport.common.S3MockStarter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class S3Mock extends S3MockStarter {
+    private static S3Mock instance = null;
+
+    private S3Mock() {
+        super(null);
+        this.properties.putAll(defaultProps());
+        final Map<String, Object> properties = new HashMap<>();
+
+        String httpsPort =  System.getProperty(S3MockApplication.PROP_HTTPS_PORT);
+        if(httpsPort != null) {
+            properties.put(S3MockApplication.PROP_HTTPS_PORT,httpsPort);
+        } else {
+            properties.put(S3MockApplication.PROP_HTTPS_PORT,S3MockApplication.DEFAULT_HTTPS_PORT);
+        }
+
+        String httpPort = System.getProperty(S3MockApplication.PROP_HTTP_PORT);
+        if(httpPort != null) {
+            properties.put(S3MockApplication.PROP_HTTP_PORT,httpPort);
+        } else {
+            properties.put(S3MockApplication.PROP_HTTP_PORT,S3MockApplication.DEFAULT_HTTP_PORT);
+        }
+
+        String initialBuckets = System.getProperty(S3MockApplication.PROP_INITIAL_BUCKETS);
+        if(initialBuckets != null) {
+            properties.put(S3MockApplication.PROP_INITIAL_BUCKETS,initialBuckets);
+        }
+
+        String rootDirectory = System.getProperty(S3MockApplication.PROP_ROOT_DIRECTORY);
+        if(rootDirectory != null) {
+            properties.put(S3MockApplication.PROP_ROOT_DIRECTORY,rootDirectory);
+        }
+
+        this.properties.putAll(properties);
+    }
+
+    public static S3Mock getInstance() {
+        if(instance == null) instance = new S3Mock();
+        return instance;
+    }
+
+    void bootstrap() {
+        this.start();
+    }
+
+    void terminate() {
+        this.stop();
+    }
+}

--- a/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
+++ b/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
@@ -16,45 +16,20 @@
 
 package com.adobe.testing.s3mock.testng;
 
-import com.adobe.testing.s3mock.S3MockApplication;
 import com.adobe.testing.s3mock.testsupport.common.S3MockStarter;
 
-import java.util.HashMap;
-import java.util.Map;
+/**
+ * Singleton extending {@link com.adobe.testing.s3mock.testsupport.common.S3MockStarter}.
+ *
+ * Used in the {@link com.adobe.testing.s3mock.testng.S3MockListener} to start {@link com.adobe.testing.s3mock.S3MockApplication}
+ * when TestNG starts running the suites and to stop when TestNG has run all the suites
+ */
 
 public class S3Mock extends S3MockStarter {
-    private static S3Mock instance = null;
+    private static S3Mock instance = new S3Mock();
 
     private S3Mock() {
         super(null);
-        this.properties.putAll(defaultProps());
-        final Map<String, Object> properties = new HashMap<>();
-
-        String httpsPort =  System.getProperty(S3MockApplication.PROP_HTTPS_PORT);
-        if(httpsPort != null) {
-            properties.put(S3MockApplication.PROP_HTTPS_PORT,httpsPort);
-        } else {
-            properties.put(S3MockApplication.PROP_HTTPS_PORT,S3MockApplication.DEFAULT_HTTPS_PORT);
-        }
-
-        String httpPort = System.getProperty(S3MockApplication.PROP_HTTP_PORT);
-        if(httpPort != null) {
-            properties.put(S3MockApplication.PROP_HTTP_PORT,httpPort);
-        } else {
-            properties.put(S3MockApplication.PROP_HTTP_PORT,S3MockApplication.DEFAULT_HTTP_PORT);
-        }
-
-        String initialBuckets = System.getProperty(S3MockApplication.PROP_INITIAL_BUCKETS);
-        if(initialBuckets != null) {
-            properties.put(S3MockApplication.PROP_INITIAL_BUCKETS,initialBuckets);
-        }
-
-        String rootDirectory = System.getProperty(S3MockApplication.PROP_ROOT_DIRECTORY);
-        if(rootDirectory != null) {
-            properties.put(S3MockApplication.PROP_ROOT_DIRECTORY,rootDirectory);
-        }
-
-        this.properties.putAll(properties);
     }
 
     public static S3Mock getInstance() {

--- a/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
+++ b/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
@@ -26,15 +26,14 @@ import com.adobe.testing.s3mock.testsupport.common.S3MockStarter;
  */
 
 public class S3Mock extends S3MockStarter {
-    private static S3Mock instance = new S3Mock();
+    private static final S3Mock INSTANCE = new S3Mock();
 
     private S3Mock() {
         super(null);
     }
 
     public static S3Mock getInstance() {
-        if(instance == null) instance = new S3Mock();
-        return instance;
+        return INSTANCE;
     }
 
     void bootstrap() {

--- a/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3MockListener.java
+++ b/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3MockListener.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.testng;
+
+import org.testng.IExecutionListener;
+
+/**
+ * TestNG listener to start and stop the S3Mock Application. After the tests, the S3Mock is
+ * stopped.
+ * <p>
+ *
+ * <h3>Configuring through testng.xml file</h3>
+ * <pre>
+ * {@code
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+ * <suite name="TestNG Listener Example">
+ *  <listeners>
+ *      <listener class-name="com.adobe.testing.s3mock.testng.S3ExecutionListener" />
+ *  </listeners>
+ *
+ *  <test name="TestNG Sample Test" preserve-order="true">
+ *      <classes>
+ *          <class name="SampleS3MockTest">
+ *              <methods>
+ *                  <include name="test1"/>
+ *              </methods>
+ *          </class>
+ *      </classes>
+ *  </test>
+ * </suite>
+ * }
+ * </pre>
+ */
+
+public class S3MockListener implements IExecutionListener {
+    @Override
+    public void onExecutionStart() {
+        S3Mock.getInstance().bootstrap();
+    }
+
+    @Override
+    public void onExecutionFinish() {
+        S3Mock.getInstance().terminate();
+    }
+}

--- a/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3MockListener.java
+++ b/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3MockListener.java
@@ -21,7 +21,6 @@ import org.testng.IExecutionListener;
 /**
  * TestNG listener to start and stop the S3Mock Application. After the tests, the S3Mock is
  * stopped.
- * <p>
  *
  * <h3>Configuring through testng.xml file</h3>
  * <pre>

--- a/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXMLConfigurationTest.java
+++ b/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXMLConfigurationTest.java
@@ -32,7 +32,7 @@ public class S3MockListenerXMLConfigurationTest {
     private static final String BUCKET_NAME = "mydemotestbucket";
     private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
 
-    private final AmazonS3 s3Client = S3Mock.getInstance().createS3Client();
+    private final AmazonS3 s3Client = S3Mock.getInstance().createS3Client("us-west-2");
     /**
      * Creates a bucket, stores a file, downloads the file again and compares checksums.
      * @throws Exception if FileStreams can not be read

--- a/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXMLConfigurationTest.java
+++ b/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXMLConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.testng;
+
+import com.adobe.testing.s3mock.util.HashUtil;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+@Test
+public class S3MockListenerXMLConfigurationTest {
+    private static final String BUCKET_NAME = "mydemotestbucket";
+    private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
+
+    private final AmazonS3 s3Client = S3Mock.getInstance().createS3Client();
+    /**
+     * Creates a bucket, stores a file, downloads the file again and compares checksums.
+     * @throws Exception if FileStreams can not be read
+     */
+    @Test
+    public void shouldUploadAndDownloadObject() throws Exception {
+        final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+        s3Client.createBucket(BUCKET_NAME);
+        s3Client.putObject(new PutObjectRequest(BUCKET_NAME, uploadFile.getName(), uploadFile));
+
+        final S3Object s3Object = s3Client.getObject(BUCKET_NAME, uploadFile.getName());
+
+        final InputStream uploadFileIS = new FileInputStream(uploadFile);
+        final String uploadHash = HashUtil.getDigest(uploadFileIS);
+        final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
+        uploadFileIS.close();
+        s3Object.close();
+
+        Assert.assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+    }
+}

--- a/testsupport/testng/src/test/resources/sampleFile.txt
+++ b/testsupport/testng/src/test/resources/sampleFile.txt
@@ -1,0 +1,3 @@
+## sample test file ##
+
+demo=content

--- a/testsupport/testng/src/test/resources/testng.xml
+++ b/testsupport/testng/src/test/resources/testng.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2018 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="TestNG S3MockListener Example">
+    <listeners>
+      <listener class-name="com.adobe.testing.s3mock.testng.S3MockListener" />
+    </listeners>
+
+    <test name="TestNG S3Mock Test">
+      <classes>
+          <class name="com.adobe.testing.s3mock.testng.S3MockListenerXMLConfigurationTest">
+              <methods>
+                  <include name="shouldUploadAndDownloadObject"/>
+              </methods>
+          </class>
+      </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Description
Adding ability to create S3Client in a different region

## Related Issue
#55 

## Tasks
- [ x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ x] I have written tests and verified that they fail without my change.
