### PR TITLE
Adding optional region to client creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To use the JUnit4 Rule, use the following Maven artifact in `test` scope:
  <artifactId>s3mock-junit4</artifactId>
  <version>...</version>
  <scope>test</scope>
-<dependency>
+</dependency>
 ```
 
 #### Using the JUnit5 Extension
@@ -76,7 +76,7 @@ To use the JUnit5 Extension, use the following Maven artifact in `test` scope:
   <artifactId>s3mock-junit5</artifactId>
   <version>...</version>
   <scope>test</scope>
-<dependency>
+</dependency>
 ```
 
 #### Using the TestNG Listener
@@ -91,7 +91,7 @@ To use the TestNG Listener, use the following Maven artifact in `test` scope:
  <artifactId>s3mock-testng</artifactId>
  <version>...</version>
  <scope>test</scope>
-<dependency>
+</dependency>
 ```
 
 #### Starting Programmatically
@@ -103,7 +103,7 @@ Include the following dependency and use one of the `start` methods in `com.adob
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock</artifactId>
   <version>...</version>
-<dependency>
+</dependency>
 ```
 
 ### Build & Run

--- a/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
+++ b/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
@@ -65,6 +65,14 @@ public abstract class S3MockStarter {
    *         server using HTTPS.
    */
   public AmazonS3 createS3Client() {
+    return createS3Client("us-east-1");
+  }
+
+  /**
+   * @return An {@link AmazonS3} client instance that is configured to call the started S3Mock
+   *         server using HTTPS for a given region.
+   */
+  public AmazonS3 createS3Client(String region) {
     final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
 
     return AmazonS3ClientBuilder.standard()
@@ -72,7 +80,7 @@ public abstract class S3MockStarter {
         .withClientConfiguration(
             configureClientToIgnoreInvalidSslCertificates(new ClientConfiguration()))
         .withEndpointConfiguration(
-            new EndpointConfiguration("https://localhost:" + getPort(), "us-east-1"))
+            new EndpointConfiguration("https://localhost:" + getPort(), region))
         .enablePathStyleAccess()
         .build();
   }

--- a/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXMLConfigurationTest.java
+++ b/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXMLConfigurationTest.java
@@ -32,7 +32,7 @@ public class S3MockListenerXMLConfigurationTest {
     private static final String BUCKET_NAME = "mydemotestbucket";
     private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
 
-    private final AmazonS3 s3Client = S3Mock.getInstance().createS3Client();
+    private final AmazonS3 s3Client = S3Mock.getInstance().createS3Client("us-west-2");
     /**
      * Creates a bucket, stores a file, downloads the file again and compares checksums.
      * @throws Exception if FileStreams can not be read


### PR DESCRIPTION
## Description
Adding optional region parameter to createS3Client method

## Related Issue
#55 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
