### PR TITLE
excludes SecurityAutoConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
         <docker.image.name>adobe/s3mock</docker.image.name>
 
         <license-maven-plugin-git.version>3.0</license-maven-plugin-git.version>
+        <spring-security-oauth2.version>2.0.8.RELEASE</spring-security-oauth2.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <modules>
@@ -112,7 +114,21 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>${junit.version}</version>
+            </dependency>
+
+            <!--
+                S3 Mock doesn't need spring-security-oauth2. We ran into trouble
+                when dependency was on classpath where server did not accept any
+                requests (see https://github.com/adobe/S3Mock/issues/59).
+                spring-security-oauth2 is referenced by s3mock-junit4, S3MockRuleTest needs
+                to turn green.
+            -->
+            <dependency>
+                <groupId>org.springframework.security.oauth</groupId>
+                <artifactId>spring-security-oauth2</artifactId>
+                <version>${spring-security-oauth2.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -55,6 +55,7 @@ import org.springframework.boot.Banner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.filter.OrderedHttpPutFormContentFilter;
@@ -74,7 +75,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * File Store Application that mocks Amazon S3.
  */
 @Configuration
-@EnableAutoConfiguration
+@EnableAutoConfiguration(exclude = {SecurityAutoConfiguration.class })
 @ComponentScan
 public class S3MockApplication {
   public static final int DEFAULT_HTTPS_PORT = 9191;

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -40,5 +40,10 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security.oauth</groupId>
+            <artifactId>spring-security-oauth2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Description
Spring Sec. Filters avoid invocations of S3 Mocks API- 

## Related Issue
https://github.com/adobe/S3Mock/issues/59

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
