### PR TITLE
 Fix lexical sorting for Multipart Upload

### DIFF
--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -85,7 +85,6 @@ import org.junit.rules.ExpectedException;
 /**
  * Test the application using the AmazonS3 client.
  */
-@SuppressWarnings("javadoc")
 public class AmazonClientUploadIT extends S3TestBase {
 
   @Rule
@@ -668,7 +667,7 @@ public class AmazonClientUploadIT extends S3TestBase {
     final S3Object copiedObject = s3Client.getObject(targetBucket.getName(), assumedDestinationKey);
 
     assertThat("Hashes for source and target S3Object do not match.",
-        HashUtil.getDigest(copiedObject.getObjectContent()) + "-1",
+        HashUtil.getDigest(copiedObject.getObjectContent()) + "-3",
         is(uploadResult.getETag()));
   }
 


### PR DESCRIPTION
## Description
When completing the multipart upload, file parts are sorted by their part number to not corrupt the file.

## Related Issue
Fixes https://github.com/adobe/S3Mock/issues/65
Fixes https://github.com/adobe/S3Mock/issues/67

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.

---

@agudian: Please review, merge + rebase
