### PR TITLE
Fix finding checkstyle config

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -25,19 +25,13 @@
     <version>2.0.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
 
   <artifactId>s3mock-build-config</artifactId>
   <name>S3Mock - Build Configuration</name>
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
The build-config module needs to be of type `jar` after all... My bad @timoe.

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
