### PR TITLE
Fix shouldGetEncryptedObject and shouldStoreObjectEncrypted test from FileStoreTest for Windows

### DIFF
--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -63,6 +63,11 @@ public class FileStoreTest {
           + "demo=content\n"
           + "0;chunk-signature=2206490f19c068b46367173d1e155b597fd367037fa3f924290b41c1e83c1c08";
 
+  private static final String UNSIGNED_CONTENT =
+      "## sample test file ##\n"
+      + "\n"
+      + "demo=content";
+
   private static final String TEST_BUCKET_NAME = "testbucket";
 
   private static final String TEST_FILE_PATH = "src/test/resources/sampleFile.txt";
@@ -206,7 +211,8 @@ public class FileStoreTest {
 
     final String name = sourceFile.getName();
     final String contentType = ContentType.TEXT_PLAIN.toString();
-    final String md5 = HashUtil.getDigest(TEST_ENC_KEY, new FileInputStream(sourceFile));
+    final String md5 = HashUtil.getDigest(TEST_ENC_KEY,
+        new ByteArrayInputStream(UNSIGNED_CONTENT.getBytes(UTF_8)));
 
     final S3Object returnedObject =
         fileStore.putS3ObjectWithKMSEncryption(TEST_BUCKET_NAME,
@@ -235,7 +241,8 @@ public class FileStoreTest {
 
     final String name = sourceFile.getName();
     final String contentType = ContentType.TEXT_PLAIN.toString();
-    final String md5 = HashUtil.getDigest(TEST_ENC_KEY, new FileInputStream(sourceFile));
+    final String md5 = HashUtil.getDigest(TEST_ENC_KEY,
+        new ByteArrayInputStream(UNSIGNED_CONTENT.getBytes(UTF_8)));
 
     fileStore.putS3ObjectWithKMSEncryption(TEST_BUCKET_NAME,
         name,


### PR DESCRIPTION
Fix shouldGetEncryptedObject and shouldStoreObjectEncrypted test from FileStoreTest for Windows

## Description
In tests methods shouldGetEncryptedObject and shouldStoreObjectEncrypted of FileStoreTest class you are using hardcoded "SIGNED_CONTENT" which includes Linux style line ending. But for verification before this change you have used contents of the "src/test/resources/sampleFile.txt" file. So if I clone this git repo on Windows I will get this file with Windows style line endings. As a result md5 verification on Windows will fail. Since you are using hard coded "SIGNED_CONTENT" I've added hard coded "UNSIGNED_CONTENT" which does not depend on OS line ending.

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
