### PR TITLE
Support GET Bucket (List Objects) Version 2

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -269,8 +269,8 @@ class FileStoreController {
    * @param bucketName {@link String} set bucket name
    * @param prefix {@link String} find object names they starts with prefix
    * @param startAfter {@link String} return key names after a specific object key in your key space
-   * @param maxKeysParam {@link String} set the maximum number of keys returned in the response body. Default: 1000
-   * @param continuationToken {@link String} pagination token returned by previous request to this endpoint
+   * @param maxKeysParam {@link String} set the maximum number of keys returned in the response body
+   * @param continuationToken {@link String} pagination token returned by previous request
    * @param response {@link HttpServletResponse}
    *
    * @return {@link ListBucketResult} a list of objects in Bucket

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -263,6 +263,20 @@ class FileStoreController {
     return null;
   }
 
+  /**
+   * Retrieve list of objects of a bucket see https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
+   *
+   * @param bucketName {@link String} set bucket name
+   * @param prefix {@link String} find object names they starts with prefix
+   * @param startAfter {@link String} return key names after a specific object key in your key space
+   * @param maxKeysParam {@link String} set the maximum number of keys returned in the response body. Default: 1000
+   * @param continuationToken {@link String} pagination token returned by previous request to this endpoint
+   * @param response {@link HttpServletResponse}
+   *
+   * @return {@link ListBucketResult} a list of objects in Bucket
+   *
+   * @throws IOException IOException If an input or output exception occurs
+   */
   @RequestMapping(value = "/{bucketName}", params = "list-type=2",
       method = RequestMethod.GET,
       produces = {"application/x-www-form-urlencoded" })

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -19,17 +19,36 @@ package com.adobe.testing.s3mock;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 
+import com.adobe.testing.s3mock.domain.Bucket;
+import com.adobe.testing.s3mock.domain.FileStore;
+import com.adobe.testing.s3mock.domain.KmsKeyStore;
+import com.adobe.testing.s3mock.domain.Tag;
+import com.adobe.testing.s3mock.dto.BatchDeleteRequest;
+import com.adobe.testing.s3mock.dto.BatchDeleteResponse;
+import com.adobe.testing.s3mock.dto.CompleteMultipartUploadResult;
+import com.adobe.testing.s3mock.dto.CopyObjectResult;
+import com.adobe.testing.s3mock.dto.CopyPartResult;
+import com.adobe.testing.s3mock.dto.ErrorResponse;
+import com.adobe.testing.s3mock.dto.InitiateMultipartUploadResult;
+import com.adobe.testing.s3mock.dto.ListAllMyBucketsResult;
+import com.adobe.testing.s3mock.dto.ListBucketResult;
+import com.adobe.testing.s3mock.dto.ListBucketResultV2;
+import com.adobe.testing.s3mock.dto.ListMultipartUploadsResult;
+import com.adobe.testing.s3mock.dto.ListPartsResult;
+import com.adobe.testing.s3mock.dto.Owner;
+import com.adobe.testing.s3mock.dto.Tagging;
+import com.adobe.testing.s3mock.util.ObjectRefConverter;
+import com.adobe.testing.s3mock.util.RangeConverter;
+import com.thoughtworks.xstream.XStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.PostConstruct;
 import javax.servlet.Filter;
 import javax.servlet.http.HttpServletRequest;
-
 import org.apache.catalina.connector.Connector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,28 +75,6 @@ import org.springframework.http.converter.xml.MarshallingHttpMessageConverter;
 import org.springframework.oxm.xstream.XStreamMarshaller;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import com.adobe.testing.s3mock.domain.Bucket;
-import com.adobe.testing.s3mock.domain.FileStore;
-import com.adobe.testing.s3mock.domain.KmsKeyStore;
-import com.adobe.testing.s3mock.domain.Tag;
-import com.adobe.testing.s3mock.dto.BatchDeleteRequest;
-import com.adobe.testing.s3mock.dto.BatchDeleteResponse;
-import com.adobe.testing.s3mock.dto.CompleteMultipartUploadResult;
-import com.adobe.testing.s3mock.dto.CopyObjectResult;
-import com.adobe.testing.s3mock.dto.CopyPartResult;
-import com.adobe.testing.s3mock.dto.ErrorResponse;
-import com.adobe.testing.s3mock.dto.InitiateMultipartUploadResult;
-import com.adobe.testing.s3mock.dto.ListAllMyBucketsResult;
-import com.adobe.testing.s3mock.dto.ListBucketResult;
-import com.adobe.testing.s3mock.dto.ListBucketResultV2;
-import com.adobe.testing.s3mock.dto.ListMultipartUploadsResult;
-import com.adobe.testing.s3mock.dto.ListPartsResult;
-import com.adobe.testing.s3mock.dto.Owner;
-import com.adobe.testing.s3mock.dto.Tagging;
-import com.adobe.testing.s3mock.util.ObjectRefConverter;
-import com.adobe.testing.s3mock.util.RangeConverter;
-import com.thoughtworks.xstream.XStream;
 
 /**
  * File Store Application that mocks Amazon S3.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import com.adobe.testing.s3mock.domain.BucketContents;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamInclude;
+
+/**
+ * Represents a result of listing objects that reside in a Bucket.
+ */
+@XStreamAlias("ListBucketResult")
+@XStreamInclude({ BucketContents.class })
+public class ListBucketResultV2 implements Serializable {
+	@XStreamAlias("Name")
+	private String name;
+
+	@XStreamAlias("Prefix")
+	private String prefix;
+
+	@XStreamAlias("MaxKeys")
+	private int maxKeys;
+
+	@XStreamAlias("IsTruncated")
+	private boolean isTruncated;
+
+	@XStreamImplicit(itemFieldName = "Contents")
+	private List<BucketContents> contents;
+
+	@XStreamAlias("CommonPrefixes")
+	private String commonPrefixes;
+
+	@XStreamAlias("ContinuationToken")
+	private String continuationToken;
+
+	@XStreamAlias("KeyCount")
+	private String keyCount;
+
+	@XStreamAlias("NextContinuationToken")
+	private String nextContinuationToken;
+
+	@XStreamAlias("StartAfter")
+	private String startAfter;
+
+	/**
+	 * Constructs a new {@link ListBucketResultV2}.
+	 *
+	 */
+	public ListBucketResultV2() {
+		// empty
+	}
+
+	/**
+	 * Constructs a new {@link ListBucketResultV2}.
+	 *
+	 * @param name
+	 *            {@link String}
+	 * @param prefix
+	 *            {@link String}
+	 * @param maxKeys
+	 *            {@link String}
+	 * @param isTruncated
+	 *            {@link Boolean}
+	 * @param contents
+	 *            {@link List}
+	 * @param commonPrefixes
+	 *            {@link String}
+	 * @param continuationToken
+	 *            {@link String}
+	 * @param keyCount
+	 *            {@link String}
+	 * @param nextContinuationToken
+	 *            {@link String}
+	 * @param startAfter
+	 *            {@link String}
+	 */
+	public ListBucketResultV2(final String name, final String prefix, final String maxKeys, final boolean isTruncated,
+			final List<BucketContents> contents, final String commonPrefixes, final String continuationToken,
+			final String keyCount, final String nextContinuationToken, final String startAfter) {
+		super();
+		this.name = name;
+		this.prefix = prefix;
+		this.maxKeys = Integer.valueOf(maxKeys);
+		this.isTruncated = isTruncated;
+		this.contents = new ArrayList<>();
+		this.contents.addAll(contents);
+		this.commonPrefixes = commonPrefixes;
+		this.continuationToken = continuationToken;
+		this.keyCount = keyCount;
+		this.nextContinuationToken = nextContinuationToken;
+		this.startAfter = startAfter;
+	}
+
+	@XmlElement(name = "Name")
+	public String getName() {
+		return name;
+	}
+
+	@XmlElement(name = "MaxKeys")
+	public String getMaxKeys() {
+		return String.valueOf(maxKeys);
+	}
+
+	@XmlElement(name = "IsTruncated")
+	public boolean isTruncated() {
+		return isTruncated;
+	}
+
+	public List<BucketContents> getContents() {
+		return contents;
+	}
+
+	public void setContents(final List<BucketContents> contents) {
+		this.contents = contents;
+	}
+
+	@XmlElement(name = "CommonPrefixes")
+	public String getCommonPrefixes() {
+		return commonPrefixes;
+	}
+
+	@XmlElement(name = "ContinuationToken")
+	public String getContinuationToken() {
+		return continuationToken;
+	}
+
+	@XmlElement(name = "KeyCount")
+	public String getKeyCount() {
+		return keyCount;
+	}
+
+	@XmlElement(name = "NextContinuationToken")
+	public String getNextContinuationToken() {
+		return nextContinuationToken;
+	}
+
+	@XmlElement(name = "StartAfter")
+	public String getStartAfter() {
+		return startAfter;
+	}
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -16,16 +16,14 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.bind.annotation.XmlElement;
-
 import com.adobe.testing.s3mock.domain.BucketContents;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlElement;
 
 /**
  * Represents a result of listing objects that reside in a Bucket.
@@ -33,130 +31,131 @@ import com.thoughtworks.xstream.annotations.XStreamInclude;
 @XStreamAlias("ListBucketResult")
 @XStreamInclude({ BucketContents.class })
 public class ListBucketResultV2 implements Serializable {
-	@XStreamAlias("Name")
-	private String name;
+  @XStreamAlias("Name")
+  private String name;
 
-	@XStreamAlias("Prefix")
-	private String prefix;
+  @XStreamAlias("Prefix")
+  private String prefix;
 
-	@XStreamAlias("MaxKeys")
-	private int maxKeys;
+  @XStreamAlias("MaxKeys")
+  private int maxKeys;
 
-	@XStreamAlias("IsTruncated")
-	private boolean isTruncated;
+  @XStreamAlias("IsTruncated")
+  private boolean isTruncated;
 
-	@XStreamImplicit(itemFieldName = "Contents")
-	private List<BucketContents> contents;
+  @XStreamImplicit(itemFieldName = "Contents")
+  private List<BucketContents> contents;
 
-	@XStreamAlias("CommonPrefixes")
-	private String commonPrefixes;
+  @XStreamAlias("CommonPrefixes")
+  private String commonPrefixes;
 
-	@XStreamAlias("ContinuationToken")
-	private String continuationToken;
+  @XStreamAlias("ContinuationToken")
+  private String continuationToken;
 
-	@XStreamAlias("KeyCount")
-	private String keyCount;
+  @XStreamAlias("KeyCount")
+  private String keyCount;
 
-	@XStreamAlias("NextContinuationToken")
-	private String nextContinuationToken;
+  @XStreamAlias("NextContinuationToken")
+  private String nextContinuationToken;
 
-	@XStreamAlias("StartAfter")
-	private String startAfter;
+  @XStreamAlias("StartAfter")
+  private String startAfter;
 
-	/**
-	 * Constructs a new {@link ListBucketResultV2}.
-	 *
-	 */
-	public ListBucketResultV2() {
-		// empty
-	}
+  /**
+   * Constructs a new {@link ListBucketResultV2}.
+   *
+   */
+  public ListBucketResultV2() {
+    // empty
+  }
 
-	/**
-	 * Constructs a new {@link ListBucketResultV2}.
-	 *
-	 * @param name
-	 *            {@link String}
-	 * @param prefix
-	 *            {@link String}
-	 * @param maxKeys
-	 *            {@link String}
-	 * @param isTruncated
-	 *            {@link Boolean}
-	 * @param contents
-	 *            {@link List}
-	 * @param commonPrefixes
-	 *            {@link String}
-	 * @param continuationToken
-	 *            {@link String}
-	 * @param keyCount
-	 *            {@link String}
-	 * @param nextContinuationToken
-	 *            {@link String}
-	 * @param startAfter
-	 *            {@link String}
-	 */
-	public ListBucketResultV2(final String name, final String prefix, final String maxKeys, final boolean isTruncated,
-			final List<BucketContents> contents, final String commonPrefixes, final String continuationToken,
-			final String keyCount, final String nextContinuationToken, final String startAfter) {
-		super();
-		this.name = name;
-		this.prefix = prefix;
-		this.maxKeys = Integer.valueOf(maxKeys);
-		this.isTruncated = isTruncated;
-		this.contents = new ArrayList<>();
-		this.contents.addAll(contents);
-		this.commonPrefixes = commonPrefixes;
-		this.continuationToken = continuationToken;
-		this.keyCount = keyCount;
-		this.nextContinuationToken = nextContinuationToken;
-		this.startAfter = startAfter;
-	}
+  /**
+   * Constructs a new {@link ListBucketResultV2}.
+   *
+   * @param name
+   *          {@link String}
+   * @param prefix
+   *          {@link String}
+   * @param maxKeys
+   *          {@link String}
+   * @param isTruncated
+   *          {@link Boolean}
+   * @param contents
+   *          {@link List}
+   * @param commonPrefixes
+   *          {@link String}
+   * @param continuationToken
+   *          {@link String}
+   * @param keyCount
+   *          {@link String}
+   * @param nextContinuationToken
+   *          {@link String}
+   * @param startAfter
+   *          {@link String}
+   */
+  public ListBucketResultV2(final String name, final String prefix, final String maxKeys,
+      final boolean isTruncated, final List<BucketContents> contents,
+      final String commonPrefixes, final String continuationToken,
+      final String keyCount, final String nextContinuationToken, final String startAfter) {
+    super();
+    this.name = name;
+    this.prefix = prefix;
+    this.maxKeys = Integer.valueOf(maxKeys);
+    this.isTruncated = isTruncated;
+    this.contents = new ArrayList<>();
+    this.contents.addAll(contents);
+    this.commonPrefixes = commonPrefixes;
+    this.continuationToken = continuationToken;
+    this.keyCount = keyCount;
+    this.nextContinuationToken = nextContinuationToken;
+    this.startAfter = startAfter;
+  }
 
-	@XmlElement(name = "Name")
-	public String getName() {
-		return name;
-	}
+  @XmlElement(name = "Name")
+  public String getName() {
+    return name;
+  }
 
-	@XmlElement(name = "MaxKeys")
-	public String getMaxKeys() {
-		return String.valueOf(maxKeys);
-	}
+  @XmlElement(name = "MaxKeys")
+  public String getMaxKeys() {
+    return String.valueOf(maxKeys);
+  }
 
-	@XmlElement(name = "IsTruncated")
-	public boolean isTruncated() {
-		return isTruncated;
-	}
+  @XmlElement(name = "IsTruncated")
+  public boolean isTruncated() {
+    return isTruncated;
+  }
 
-	public List<BucketContents> getContents() {
-		return contents;
-	}
+  public List<BucketContents> getContents() {
+    return contents;
+  }
 
-	public void setContents(final List<BucketContents> contents) {
-		this.contents = contents;
-	}
+  public void setContents(final List<BucketContents> contents) {
+    this.contents = contents;
+  }
 
-	@XmlElement(name = "CommonPrefixes")
-	public String getCommonPrefixes() {
-		return commonPrefixes;
-	}
+  @XmlElement(name = "CommonPrefixes")
+  public String getCommonPrefixes() {
+    return commonPrefixes;
+  }
 
-	@XmlElement(name = "ContinuationToken")
-	public String getContinuationToken() {
-		return continuationToken;
-	}
+  @XmlElement(name = "ContinuationToken")
+  public String getContinuationToken() {
+    return continuationToken;
+  }
 
-	@XmlElement(name = "KeyCount")
-	public String getKeyCount() {
-		return keyCount;
-	}
+  @XmlElement(name = "KeyCount")
+  public String getKeyCount() {
+    return keyCount;
+  }
 
-	@XmlElement(name = "NextContinuationToken")
-	public String getNextContinuationToken() {
-		return nextContinuationToken;
-	}
+  @XmlElement(name = "NextContinuationToken")
+  public String getNextContinuationToken() {
+    return nextContinuationToken;
+  }
 
-	@XmlElement(name = "StartAfter")
-	public String getStartAfter() {
-		return startAfter;
-	}
+  @XmlElement(name = "StartAfter")
+  public String getStartAfter() {
+    return startAfter;
+  }
 }


### PR DESCRIPTION
## Description
Without this change only V1 (http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html) API is supported. V2 adds pagination support. See http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html 
I have added new endpoint to FileStoreController which is responsible for V2 requests. Corresponding integration test is also added. In addition to this I have tested my implementation using AWS s3 sdk version 2.0.0.preview-10

## Related Issue
https://github.com/adobe/S3Mock/issues/7

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
