### PR TITLE
Added Last-modified header to getObject operation response

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -486,6 +486,7 @@ class FileStoreController {
       response.setContentLengthLong(s3Object.getDataFile().length());
       response.setHeader(HttpHeaders.ACCEPT_RANGES, RANGES_BYTES);
       response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, ANY);
+      response.setDateHeader(HttpHeaders.LAST_MODIFIED, s3Object.getLastModified());
       addUserMetadata(response::addHeader, s3Object);
 
       try (final OutputStream outputStream = response.getOutputStream()) {


### PR DESCRIPTION
## Description
jclouds library fails its "getBlob" operation if there is no Last-Modified header. This commit adds this header. 

## Related Issue
https://github.com/adobe/S3Mock/issues/32

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
