### PR TITLE
Add support for the delimiter parameter to the List Objects API

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -65,8 +65,11 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -248,18 +251,56 @@ class FileStoreController {
   @ResponseBody
   public ListBucketResult listObjectsInsideBucket(@PathVariable final String bucketName,
       @RequestParam(required = false) final String prefix,
+      @RequestParam(required = false) final String delimiter,
       final HttpServletResponse response) throws IOException {
     verifyBucketExistence(bucketName);
     try {
       final List<BucketContents> contents = getBucketContents(bucketName, prefix);
 
-      return new ListBucketResult(bucketName, prefix, null, "1000", false, contents, null);
+      Set<String> commonPrefixes = new HashSet<>();
+      if (null != delimiter) {
+        collapseCommonPrefixes(prefix, delimiter, contents, commonPrefixes);
+      }
+      
+      return new ListBucketResult(bucketName, prefix, null, "1000", false, contents, 
+          commonPrefixes);
     } catch (final IOException e) {
       LOG.error(String.format("Object(s) could not retrieved from bucket %s", bucketName));
       response.sendError(500, e.getMessage());
     }
 
     return null;
+  }
+
+  /**
+   * Collapse all bucket elements with keys starting with some prefix up to the given delimiter 
+   * into one prefix entry. Collapsed elements are removed from the contents list.
+   * 
+   * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html">
+   *    List Objects API Specification</a>
+   * 
+   * @param queryPrefix the key prefix as specified in the list request
+   * @param delimiter the delimiter used to separate a prefix from the rest of the object name
+   * @param contents the contents list
+   * @param commonPrefixes the set of common prefixes
+   */
+  private void collapseCommonPrefixes(final String queryPrefix, final String delimiter, 
+      final List<BucketContents> contents, final Set<String> commonPrefixes) {
+    String normalizedQueryPrefix = 
+        queryPrefix.endsWith(delimiter) ? queryPrefix : queryPrefix + delimiter;
+    
+    for (Iterator<BucketContents> i = contents.iterator(); i.hasNext();) {
+      BucketContents c = i.next();
+      if (c.getKey().startsWith(normalizedQueryPrefix)) {
+        String relativeKey = c.getKey().substring(normalizedQueryPrefix.length());
+        
+        int delimiterIndex = relativeKey.indexOf(delimiter);
+        if (delimiterIndex > 0) {
+          commonPrefixes.add(relativeKey.substring(0, delimiterIndex + delimiter.length()));
+          i.remove();
+        }
+      }
+    }
   }
 
   /**
@@ -284,6 +325,7 @@ class FileStoreController {
   @ResponseBody
   public ListBucketResultV2 listObjectsInsideBucketV2(@PathVariable final String bucketName,
       @RequestParam(required = false) final String prefix,
+      @RequestParam(required = false) final String delimiter,
       @RequestParam(name = "start-after", required = false) final String startAfter,
       @RequestParam(name = "max-keys", defaultValue = "1000", required = false)
       final String maxKeysParam,
@@ -294,6 +336,11 @@ class FileStoreController {
       final List<BucketContents> contents = getBucketContents(bucketName, prefix);
       List<BucketContents> filteredContents = getFilteredBucketContents(contents, startAfter);
 
+      Set<String> commonPrefixes = null;
+      if (null != delimiter) {
+        collapseCommonPrefixes(prefix, delimiter, filteredContents, commonPrefixes);
+      }
+      
       String nextContinuationToken = null;
       boolean isTruncated = false;
 

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -52,6 +52,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,11 +63,11 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
-import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * S3 Mock file store.
@@ -506,7 +507,7 @@ public class FileStore {
     
     // Determine whether the prefix ends with a path separator by looking at
     // what adding some definitely non-separator stuff does to equality.
-    boolean endsWithSeparator = !Strings.isEmpty(prefix)
+    boolean endsWithSeparator = !StringUtils.isEmpty(prefix)
         && theBucket.getPath().resolve(prefix).equals(
             theBucket.getPath().resolve(prefix + "FOO").getParent()
         );

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -62,6 +62,7 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -502,11 +503,22 @@ public class FileStore {
 
     final List<S3Object> resultObjects = new ArrayList<>();
     final Stream<Path> directoryHierarchy = Files.walk(theBucket.getPath());
+    
+    // Determine whether the prefix ends with a path separator by looking at
+    // what adding some definitely non-separator stuff does to equality.
+    boolean endsWithSeparator = !Strings.isEmpty(prefix)
+        && theBucket.getPath().resolve(prefix).equals(
+            theBucket.getPath().resolve(prefix + "FOO").getParent()
+        );
+    
     final Set<Path> collect = directoryHierarchy
         .filter(path -> path.toFile().isDirectory())
         .map(path -> theBucket.getPath().relativize(path))
-        .filter(path -> isEmpty(prefix) || path.startsWith(prefix)
-        ).collect(toSet());
+        .filter(path -> {
+          Path p = endsWithSeparator ? path.getParent() : path;
+          return isEmpty(prefix) || (null != p && p.startsWith(prefix));
+        })
+        .collect(toSet());
 
     for (final Path path : collect) {
       final S3Object s3Object = getS3Object(bucketName, path.toString());

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CommonPrefixes.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CommonPrefixes.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import java.util.Collection;
+
+@XStreamAlias("CommonPrefixes")
+class CommonPrefixes {
+  @XStreamImplicit(itemFieldName = "Prefix")
+  private final Collection<String> commonPrefixes;
+  
+  public CommonPrefixes(final Collection<String> commonPrefixes) {
+    this.commonPrefixes = commonPrefixes;
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -22,7 +22,9 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlElement;
 
 /**
@@ -50,7 +52,7 @@ public class ListBucketResult implements Serializable {
   private List<BucketContents> contents;
 
   @XStreamAlias("CommonPrefixes")
-  private String commonPrefixes;
+  private CommonPrefixes commonPrefixes;
 
   /**
    * Constructs a new {@link ListBucketResult}.
@@ -77,7 +79,7 @@ public class ListBucketResult implements Serializable {
       final String maxKeys,
       final boolean isTruncated,
       final List<BucketContents> contents,
-      final String commonPrefixes) {
+      final Collection<String> commonPrefixes) {
     super();
     this.name = name;
     this.prefix = prefix;
@@ -86,7 +88,7 @@ public class ListBucketResult implements Serializable {
     this.isTruncated = isTruncated;
     this.contents = new ArrayList<>();
     this.contents.addAll(contents);
-    this.commonPrefixes = commonPrefixes;
+    this.commonPrefixes = new CommonPrefixes(commonPrefixes);
   }
 
   @XmlElement(name = "Name")
@@ -117,8 +119,7 @@ public class ListBucketResult implements Serializable {
     this.contents = contents;
   }
 
-  @XmlElement(name = "CommonPrefixes")
-  public String getCommonPrefixes() {
+  public CommonPrefixes getCommonPrefixes() {
     return commonPrefixes;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -22,7 +22,9 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlElement;
 
 /**
@@ -47,7 +49,7 @@ public class ListBucketResultV2 implements Serializable {
   private List<BucketContents> contents;
 
   @XStreamAlias("CommonPrefixes")
-  private String commonPrefixes;
+  private CommonPrefixes commonPrefixes;
 
   @XStreamAlias("ContinuationToken")
   private String continuationToken;
@@ -95,7 +97,7 @@ public class ListBucketResultV2 implements Serializable {
    */
   public ListBucketResultV2(final String name, final String prefix, final String maxKeys,
       final boolean isTruncated, final List<BucketContents> contents,
-      final String commonPrefixes, final String continuationToken,
+      final Collection<String> commonPrefixes, final String continuationToken,
       final String keyCount, final String nextContinuationToken, final String startAfter) {
     super();
     this.name = name;
@@ -104,7 +106,7 @@ public class ListBucketResultV2 implements Serializable {
     this.isTruncated = isTruncated;
     this.contents = new ArrayList<>();
     this.contents.addAll(contents);
-    this.commonPrefixes = commonPrefixes;
+    this.commonPrefixes = new CommonPrefixes(commonPrefixes);
     this.continuationToken = continuationToken;
     this.keyCount = keyCount;
     this.nextContinuationToken = nextContinuationToken;
@@ -134,8 +136,7 @@ public class ListBucketResultV2 implements Serializable {
     this.contents = contents;
   }
 
-  @XmlElement(name = "CommonPrefixes")
-  public String getCommonPrefixes() {
+  public CommonPrefixes getCommonPrefixes() {
     return commonPrefixes;
   }
 

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -515,7 +515,7 @@ public class AmazonClientUploadIT extends S3TestBase {
   /**
    * Tests if the list objects can be retrieved.
    * 
-   * <p>For more detailed tests of the List Objects API 
+   * <p>For more detailed tests of the List Objects API see {@link ListObjectIT}.
    */
   @Test
   public void shouldGetObjectListing() {

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -18,7 +18,6 @@ package com.adobe.testing.s3mock.its;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -46,7 +45,6 @@ import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.MultipartUpload;

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -514,6 +514,8 @@ public class AmazonClientUploadIT extends S3TestBase {
 
   /**
    * Tests if the list objects can be retrieved.
+   * 
+   * <p>For more detailed tests of the List Objects API 
    */
   @Test
   public void shouldGetObjectListing() {
@@ -530,33 +532,6 @@ public class AmazonClientUploadIT extends S3TestBase {
     assertThat("The Name of the first S3ObjectSummary item has not expected the key name.",
         objectListingResult.getObjectSummaries().get(0).getKey(),
         is(UPLOAD_FILE_NAME));
-  }
-
-  /**
-   * Tests if the list objects can be retrieved.
-   */
-  @Test
-  public void shouldGetObjectListingWithDelimiterBasedGrouping() {
-    final File uploadFile = new File(UPLOAD_FILE_NAME);
-    s3Client.createBucket(BUCKET_NAME);
-    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, "sibling/o1", uploadFile));
-    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, "listRoot/o2", uploadFile));
-    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, "listRoot/sub1/o3", uploadFile));
-    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, "listRoot/sub1/o4", uploadFile));
-    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, "listRoot/sub2/o5", uploadFile));
-
-    final ObjectListing objectListingResult =
-        s3Client.listObjects(new ListObjectsRequest(BUCKET_NAME, "listRoot", null, "/", 1000));
-
-    assertThat("ObjectListinig has incorrect number of objects.",
-        objectListingResult.getObjectSummaries().size(),
-        equalTo(1));
-    assertThat("The Name of the first S3ObjectSummary item has not expected the key name.",
-        objectListingResult.getObjectSummaries().get(0).getKey(),
-        equalTo("listRoot/o2"));
-    assertThat("The object prefixes are not correct.",
-        objectListingResult.getCommonPrefixes(),
-        containsInAnyOrder("sub1/", "sub2/"));
   }
 
   /**

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
@@ -1,0 +1,194 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import com.adobe.testing.s3mock.S3MockApplication;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.logging.log4j.util.Strings;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Parameterized.class)
+public class ListObjectIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ListObjectIT.class);
+
+  private static final String BUCKET_NAME = "list-objects-test";
+
+  private static final String[] ALL_OBJECTS = 
+      arr("a", "b", "b/1", "b/1/1", "b/1/2", "b/2", "c/1", "c/1/1");
+
+  private static final boolean RUN_AGAINST_AWS = false;
+  
+  private static <T> T[] arr(@SuppressWarnings("unchecked") final T... a) {
+    return a;
+  }
+
+  /**
+   * Parameter fatcory.
+   * 
+   * @return
+   */
+  @Parameters(name = "{index}: prefix={0}, delimiter={1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.<Object[]>asList(//
+        arr(null, null, ALL_OBJECTS, arr()), //
+        arr("", null, ALL_OBJECTS, arr()), //
+        arr(null, "", ALL_OBJECTS, arr()), //
+        arr("/", null, arr(), arr()), //
+        arr("b", null, arr("b", "b/1", "b/1/1", "b/1/2", "b/2"), arr()), //
+        arr("b/", null, arr("b/1", "b/1/1", "b/1/2", "b/2"), arr()), //
+        arr("b", "/", arr("b"), arr("b/")), //
+        arr("b/", "/", arr("b/1", "b/2"), arr("b/1/")), //
+        arr("b/1", "/", arr("b/1"), arr("b/1/")), //
+        arr("b/1/", "/", arr("b/1/1", "b/1/2"), arr()), //
+        arr("c", "/", arr(), arr("c/")), //
+        arr("c/", "/", arr("c/1"), arr("c/1/")) //
+    );
+  }
+
+  private static final List<String> param = new ArrayList<>();
+
+  @Parameter(0)
+  public String prefix;
+
+  @Parameter(1)
+  public String delimiter;
+
+  @Parameter(2)
+  public Object[] expectedKeys;
+
+  @Parameter(3)
+  public Object[] expectedPrefixes;
+
+
+  private static S3MockApplication s3mock;
+
+  private static AmazonS3 s3client;
+  
+  /**
+   * Initialize the test bucket.
+   */
+  @BeforeClass
+  public static void createBucket() {
+    s3mock = S3MockApplication.start();
+
+    s3client = RUN_AGAINST_AWS ? createAwsClient() : createMockClient();
+    
+    try {
+      s3client.deleteBucket(BUCKET_NAME);
+    } catch (SdkClientException e) {
+      // ignored
+    }
+    s3client.createBucket(BUCKET_NAME);
+
+    // create all expected objects
+    for (String key : ALL_OBJECTS) {
+      s3client.putObject(BUCKET_NAME, key, "Test");
+    }
+  }
+
+  private static AmazonS3 createMockClient() {
+    final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
+
+    return AmazonS3ClientBuilder.standard() //
+        .withCredentials(new AWSStaticCredentialsProvider(credentials)) //
+        .withClientConfiguration(new ClientConfiguration()) //
+        .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
+            "http://localhost:" + s3mock.getHttpPort(), "us-east-1")) //
+        .enablePathStyleAccess() //
+        .build();
+  }
+
+  private static AmazonS3 createAwsClient() {
+    AWSCredentials credentials = new BasicAWSCredentials("key", "secret");
+
+    return AmazonS3ClientBuilder.standard() //
+        .withCredentials(new AWSStaticCredentialsProvider(credentials)) //
+        .withRegion(Regions.DEFAULT_REGION) //
+        .build();
+  }
+
+  @AfterClass
+  public static void logParams() {
+    LOGGER.info("Expected parameters are: \n{} //\n", param.stream().collect(joining(", //\n")));
+  }
+
+  @Test
+  public void listV1() {
+    ObjectListing l = s3client.listObjects(
+        new ListObjectsRequest(BUCKET_NAME, prefix, null, delimiter, null));
+
+    LOGGER.info(
+        "list V1, prefix='{}', delimiter='{}': \n  Objects: \n    {}\n  Prefixes: \n    {}\n", //
+        prefix, //
+        delimiter, //
+        l.getObjectSummaries().stream().map(s -> s.getKey()).collect(joining("\n    ")), //
+        l.getCommonPrefixes().stream().collect(joining("\n    ")) //
+    );
+
+    param.add(String.format("arr(%s, %s, arr(%s), arr(%s))", //
+        qq(prefix), //
+        qq(delimiter), //
+        l.getObjectSummaries().isEmpty()
+            ? ""
+            : l.getObjectSummaries().stream().map(s -> s.getKey()).collect(
+                joining("\", \"", "\"", "\"")), //
+        l.getCommonPrefixes().isEmpty()
+            ? ""
+            : l.getCommonPrefixes().stream().collect(joining("\", \"", "\"", "\""))));
+
+    assertThat("Returned keys are correct",
+        l.getObjectSummaries().stream().map(s -> s.getKey()).collect(toList()),
+        expectedKeys.length > 0 ? contains(expectedKeys) : empty());
+    assertThat("Returned prefixes are correct", l.getCommonPrefixes().stream().collect(toList()),
+        expectedPrefixes.length > 0 ? contains(expectedPrefixes) : empty());
+  }
+
+  private String qq(final String s) {
+    return null != s ? Strings.dquote(s) : "null";
+  }
+}


### PR DESCRIPTION
## Description
Add support for `delimiter` parameter to the ListObjects and ListObjectsV2 APIs

## Related Issue
#89 

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.

