### PR TITLE
Content-Range value should contain complete-length

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -1184,7 +1184,8 @@ class FileStoreController {
     response.setStatus(PARTIAL_CONTENT.value());
     response.setHeader(HttpHeaders.ACCEPT_RANGES, RANGES_BYTES);
     response.setHeader(HttpHeaders.CONTENT_RANGE,
-        String.format("bytes %s-%s", range.getStart(), bytesToRead + range.getStart() - 1));
+        String.format("bytes %s-%s/%s",
+            range.getStart(), bytesToRead + range.getStart() - 1, s3Object.getSize()));
     response.setHeader(HttpHeaders.ETAG, "\"" + s3Object.getMd5() + "\"");
     response.setDateHeader(HttpHeaders.LAST_MODIFIED, s3Object.getLastModified());
 

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -68,6 +68,7 @@ import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.Download;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.services.s3.transfer.model.CopyResult;
@@ -665,11 +666,12 @@ public class AmazonClientUploadIT extends S3TestBase {
     upload.waitForUploadResult();
 
     final File downloadFile = File.createTempFile(randomUUID().toString(), null);
-    transferManager
-        .download(new GetObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME).withRange(1, 2),
-            downloadFile)
-        .waitForCompletion();
+    Download download = transferManager.download(
+            new GetObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME).withRange(1, 2), downloadFile);
+    download.waitForCompletion();
     assertThat("Invalid file length", downloadFile.length(), is(2L));
+    assertThat(download.getObjectMetadata().getInstanceLength(), is(uploadFile.length()));
+    assertThat(download.getObjectMetadata().getContentLength(), is(2L));
 
     transferManager
         .download(new GetObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME).withRange(0, 1000),


### PR DESCRIPTION
## Description
"Content-Range" header should contain the complete-length of the body in response to a request with "Range" header.
S3 also returns Content-Range header with  the complete-length and `ObjectMetadata.getInstanceLength()` in AWS SDK for Java depends on it.

RFC 7233 says 
>For byte ranges, a sender SHOULD indicate the complete length of the
   representation from which the range has been extracted, unless the
   complete length is unknown or difficult to determine.

https://tools.ietf.org/html/rfc7233#section-4.2


## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
