### PR TITLE
Matching real S3 partial prefix matching

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -504,20 +504,12 @@ public class FileStore {
 
     final List<S3Object> resultObjects = new ArrayList<>();
     final Stream<Path> directoryHierarchy = Files.walk(theBucket.getPath());
-    
-    // Determine whether the prefix ends with a path separator by looking at
-    // what adding some definitely non-separator stuff does to equality.
-    boolean endsWithSeparator = !StringUtils.isEmpty(prefix)
-        && theBucket.getPath().resolve(prefix).equals(
-            theBucket.getPath().resolve(prefix + "FOO").getParent()
-        );
-    
+
     final Set<Path> collect = directoryHierarchy
         .filter(path -> path.toFile().isDirectory())
         .map(path -> theBucket.getPath().relativize(path))
         .filter(path -> {
-          Path p = endsWithSeparator ? path.getParent() : path;
-          return isEmpty(prefix) || (null != p && p.toString().startsWith(prefix));
+          return isEmpty(prefix) || (null != path && path.toString().startsWith(prefix));
         })
         .collect(toSet());
 

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -517,7 +517,7 @@ public class FileStore {
         .map(path -> theBucket.getPath().relativize(path))
         .filter(path -> {
           Path p = endsWithSeparator ? path.getParent() : path;
-          return isEmpty(prefix) || (null != p && p.startsWith(prefix));
+          return isEmpty(prefix) || (null != p && p.toString().startsWith(prefix));
         })
         .collect(toSet());
 

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -655,9 +655,9 @@ public class FileStoreTest {
   public void getObjectsForPartialPrefix() throws Exception {
     fileStore.createBucket(TEST_BUCKET_NAME);
     fileStore
-      .putS3Object(TEST_BUCKET_NAME, "foo_bar_baz", TEXT_PLAIN,
-        new FileInputStream(new File(TEST_FILE_PATH)),
-        false);
+        .putS3Object(TEST_BUCKET_NAME, "foo_bar_baz", TEXT_PLAIN,
+          new FileInputStream(new File(TEST_FILE_PATH)),
+          false);
     final List<S3Object> result = fileStore.getS3Objects(TEST_BUCKET_NAME, "fo");
     assertThat(result, hasSize(1));
     assertThat(result.get(0).getName(), is("foo_bar_baz"));

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -652,6 +652,18 @@ public class FileStoreTest {
   }
 
   @Test
+  public void getObjectsForPartialPrefix() throws Exception {
+    fileStore.createBucket(TEST_BUCKET_NAME);
+    fileStore
+      .putS3Object(TEST_BUCKET_NAME, "foo_bar_baz", TEXT_PLAIN,
+        new FileInputStream(new File(TEST_FILE_PATH)),
+        false);
+    final List<S3Object> result = fileStore.getS3Objects(TEST_BUCKET_NAME, "fo");
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getName(), is("foo_bar_baz"));
+  }
+
+  @Test
   public void getObjectsForEmptyPrefix() throws Exception {
     fileStore.createBucket(TEST_BUCKET_NAME);
     fileStore

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -695,7 +695,7 @@ public class FileStoreTest {
             new FileInputStream(new File(TEST_FILE_PATH)),
             false);
     final List<S3Object> result = fileStore.getS3Objects(TEST_BUCKET_NAME, "a/b");
-    assertThat(result, is(empty()));
+    assertThat(result, hasSize(1));
   }
 
   @Test

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -407,7 +407,7 @@ public class FileStoreTest {
    * @throws Exception if an Exception occurred.
    */
   @Test
-  public void shoudDeleteBucket() throws Exception {
+  public void shouldDeleteBucket() throws Exception {
     final File sourceFile = new File(TEST_FILE_PATH);
     final String objectName = sourceFile.getName();
 

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
@@ -95,10 +95,13 @@ public class ListObjectIT extends S3TestBase {
         param(null, "").keys(ALL_OBJECTS), //
         param("/", null), //
         param("b", null).keys("b", "b/1", "b/1/1", "b/1/2", "b/2"), //
-        param("b/", null).keys("b/1/1", "b/1/2"), //
+        param("b/", null).keys("b/1", "b/1/1", "b/1/2", "b/2"), //
         param("b", "/").keys("b").prefixes("b/"), //
+        param("b/", "/").keys("b/1", "b/2").prefixes("b/1/"), //
         param("b/1", "/").keys("b/1").prefixes("b/1/"), //
+        param("b/1/", "/").keys("b/1/1", "b/1/2"), //
         param("c", "/").prefixes("c/"), //
+        param("c/", "/").keys("c/1").prefixes("c/1/"), //
         param("eor", "/").keys("eor.txt") //
     );
   }

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
@@ -42,7 +42,11 @@ public class ListObjectIT extends S3TestBase {
   private static final String BUCKET_NAME = "list-objects-test";
 
   private static final String[] ALL_OBJECTS = 
-      new String[] {"a", "b", "b/1", "b/1/1", "b/1/2", "b/2", "c/1", "c/1/1", "d:1", "d:1:1"};
+      new String[] {"a",
+          "b", "b/1", "b/1/1", "b/1/2", "b/2",
+          "c/1", "c/1/1",
+          "d:1", "d:1:1",
+          "eor.txt", "foo/eor.txt"};
   
   static class Param {
     final String prefix;
@@ -91,13 +95,11 @@ public class ListObjectIT extends S3TestBase {
         param(null, "").keys(ALL_OBJECTS), //
         param("/", null), //
         param("b", null).keys("b", "b/1", "b/1/1", "b/1/2", "b/2"), //
-        param("b/", null).keys("b/1", "b/1/1", "b/1/2", "b/2"), //
+        param("b/", null).keys("b/1/1", "b/1/2"), //
         param("b", "/").keys("b").prefixes("b/"), //
-        param("b/", "/").keys("b/1", "b/2").prefixes("b/1/"), //
         param("b/1", "/").keys("b/1").prefixes("b/1/"), //
-        param("b/1/", "/").keys("b/1/1", "b/1/2"), //
         param("c", "/").prefixes("c/"), //
-        param("c/", "/").keys("c/1").prefixes("c/1/") //
+        param("eor", "/").keys("eor.txt") //
     );
   }
 


### PR DESCRIPTION
## Description

Based on https://aws.amazon.com/blogs/compute/amazon-s3-adds-prefix-and-suffix-filters-for-lambda-function-triggering/

This should allow filtering by partial filenames

## Related Issue
To address: https://github.com/adobe/S3Mock/issues/97

## Tasks
- validate that the functionality matches real S3
- run the tests
- ???
- profit

- [X] I have signed the [CLA](http://adobe.github.io/cla.html).
- [X] I have written tests and verified that they fail without my change.

### Before:
<img width="933" alt="screen shot 2018-08-09 at 8 35 35 am" src="https://user-images.githubusercontent.com/18075411/43905920-498e6efc-9baf-11e8-8460-261d194731a9.png">

### After:
<img width="837" alt="screen shot 2018-08-09 at 8 35 49 am" src="https://user-images.githubusercontent.com/18075411/43905926-4d5801c4-9baf-11e8-96ec-2d014ca7dd8f.png">
