### PR TITLE
Allow the s3 client to communicate over HTTP or HTTPS connections.

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -111,6 +111,11 @@ public class S3MockApplication {
   public static final String PROP_HTTP_PORT = "http.port";
 
   /**
+   * Property name for using either HTTPS or HTTP connections
+   */
+  public static final String PROP_SECURE_CONNECTION = "secureConnection";
+
+  /**
    * Property name for enabling the silent mode with logging set at WARN and without banner.
    */
   public static final String PROP_SILENT = "silent";

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -111,7 +111,7 @@ public class S3MockApplication {
   public static final String PROP_HTTP_PORT = "http.port";
 
   /**
-   * Property name for using either HTTPS or HTTP connections
+   * Property name for using either HTTPS or HTTP connections.
    */
   public static final String PROP_SECURE_CONNECTION = "secureConnection";
 

--- a/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
+++ b/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
@@ -85,8 +85,7 @@ public abstract class S3MockStarter {
         .withCredentials(new AWSStaticCredentialsProvider(credentials))
         .withClientConfiguration(
             configureClientToIgnoreInvalidSslCertificates(new ClientConfiguration()))
-        .withEndpointConfiguration(
-            new EndpointConfiguration("https://localhost:" + getPort(), region))
+        .withEndpointConfiguration(getEndpointCongiguration(region))
         .enablePathStyleAccess()
         .build();
   }
@@ -125,6 +124,13 @@ public abstract class S3MockStarter {
             NoopHostnameVerifier.INSTANCE));
 
     return clientConfiguration;
+  }
+
+  protected EndpointConfiguration getEndpointCongiguration(final String region) {
+    boolean isSecureConnection = (boolean) properties.getOrDefault(S3MockApplication.PROP_SECURE_CONNECTION, true);
+    String serviceEndpoint = isSecureConnection ? "https://localhost:" + getPort() : "http://localhost:" + getHttpPort();
+
+    return new EndpointConfiguration(serviceEndpoint, region);
   }
 
   protected void start() {
@@ -208,6 +214,11 @@ public abstract class S3MockStarter {
 
     public BaseBuilder<T> withRootFolder(final String rootFolder) {
       arguments.put(S3MockApplication.PROP_ROOT_DIRECTORY, rootFolder);
+      return this;
+    }
+
+    public BaseBuilder<T> withSecureConnection(final boolean secureConnection) {
+      arguments.put(S3MockApplication.PROP_SECURE_CONNECTION, secureConnection);
       return this;
     }
 

--- a/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
+++ b/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
@@ -127,8 +127,10 @@ public abstract class S3MockStarter {
   }
 
   protected EndpointConfiguration getEndpointCongiguration(final String region) {
-    boolean isSecureConnection = (boolean) properties.getOrDefault(S3MockApplication.PROP_SECURE_CONNECTION, true);
-    String serviceEndpoint = isSecureConnection ? "https://localhost:" + getPort() : "http://localhost:" + getHttpPort();
+    boolean isSecureConnection = (boolean) properties.getOrDefault(
+            S3MockApplication.PROP_SECURE_CONNECTION, true);
+    String serviceEndpoint = isSecureConnection ? "https://localhost:" + getPort()
+            : "http://localhost:" + getHttpPort();
 
     return new EndpointConfiguration(serviceEndpoint, region);
   }

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/S3MockExtensionProgrammaticTest.java
@@ -33,7 +33,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  */
 public class S3MockExtensionProgrammaticTest {
   @RegisterExtension
-  static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent().withSecureConnection(false).build();
+  static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent()
+          .withSecureConnection(false).build();
 
   private static final String BUCKET_NAME = "mydemotestbucket";
   private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/S3MockExtensionProgrammaticTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  */
 public class S3MockExtensionProgrammaticTest {
   @RegisterExtension
-  static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
+  static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent().withSecureConnection(false).build();
 
   private static final String BUCKET_NAME = "mydemotestbucket";
   private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";


### PR DESCRIPTION
## Description
Allow the s3 client to communicate over HTTP or HTTPS connections.

## Related Issue
Fixes #95 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
