### PR TITLE
Fixed alias for bucket name in InitiateMultipartUploadResult

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResult.java
@@ -23,7 +23,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("InitiateMultipartUploadResult")
 public class InitiateMultipartUploadResult {
-  @XStreamAlias("Bucketname")
+  @XStreamAlias("Bucket")
   private final String bucketName;
 
   @XStreamAlias("Key")

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -581,8 +581,8 @@ public class AmazonClientUploadIT extends S3TestBase {
     final String uploadId = initiateMultipartUploadResult.getUploadId();
 
     final UploadPartResult uploadPartResult = s3Client.uploadPart(new UploadPartRequest()
-        .withBucketName(BUCKET_NAME)
-        .withKey(UPLOAD_FILE_NAME)
+        .withBucketName(initiateMultipartUploadResult.getBucketName())
+        .withKey(initiateMultipartUploadResult.getKey())
         .withUploadId(uploadId)
         .withFile(uploadFile)
         .withFileOffset(0)
@@ -591,11 +591,16 @@ public class AmazonClientUploadIT extends S3TestBase {
         .withLastPart(true));
 
     final List<PartETag> partETags = singletonList(uploadPartResult.getPartETag());
-    s3Client.completeMultipartUpload(
-        new CompleteMultipartUploadRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadId, partETags));
+    s3Client.completeMultipartUpload(new CompleteMultipartUploadRequest(
+        initiateMultipartUploadResult.getBucketName(),
+        initiateMultipartUploadResult.getKey(),
+        initiateMultipartUploadResult.getUploadId(),
+        partETags
+    ));
 
-    final ObjectMetadata metadataExisting =
-        s3Client.getObjectMetadata(BUCKET_NAME, UPLOAD_FILE_NAME);
+    final ObjectMetadata metadataExisting = s3Client.getObjectMetadata(
+        initiateMultipartUploadResult.getBucketName(), initiateMultipartUploadResult.getKey()
+    );
 
     assertThat("User metadata should be identical!", metadataExisting.getUserMetadata(),
         is(equalTo(objectMetadata.getUserMetadata())));


### PR DESCRIPTION
## Description
Renamed bucket name's alias to "Bucket" according to https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html

## Related Issue
#102 

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
