### PR TITLE
Upgrade to JDK 11 Docker image and SpringBoot 2.1

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.0.12-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>2.0.12-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
     <spring-boot.version>2.1.0.RELEASE</spring-boot.version>
     <spring-security-oauth2.version>2.3.4.RELEASE</spring-security-oauth2.version>
     <commons-codec.version>1.11</commons-codec.version>
-    <xstream.version>1.4.10</xstream.version>
     <commons-io.version>2.6</commons-io.version>
+    <jackson.version>2.9.7</jackson.version>
 
     <junit-jupiter.version>5.2.0</junit-jupiter.version>
     <junit.version>4.12</junit.version>
@@ -103,9 +103,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>${xstream.version}</version>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,23 +48,24 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <start-class>com.adobe.testing.s3mock.S3MockApplication</start-class>
 
-    <openjdk.version>8u171</openjdk.version>
+    <adoptopenjdk11.image.version>jdk-11.28-alpine</adoptopenjdk11.image.version>
+    <alpine-glibc.image.version>alpine-3.8_glibc-2.28</alpine-glibc.image.version>
+
     <aws.version>1.11.310</aws.version>
 
-    <spring-boot.version>2.0.3.RELEASE</spring-boot.version>
+    <spring-boot.version>2.1.0.RELEASE</spring-boot.version>
+    <spring-security-oauth2.version>2.3.4.RELEASE</spring-security-oauth2.version>
     <commons-codec.version>1.11</commons-codec.version>
     <xstream.version>1.4.10</xstream.version>
     <commons-io.version>2.6</commons-io.version>
 
     <junit-jupiter.version>5.2.0</junit-jupiter.version>
+    <junit.version>4.12</junit.version>
 
     <docker.image.name>adobe/s3mock</docker.image.name>
 
     <license-maven-plugin-git.version>3.0</license-maven-plugin-git.version>
-    <spring-security-oauth2.version>2.3.4.RELEASE</spring-security-oauth2.version>
-    <junit.version>4.12</junit.version>
     <checkstyle.version>8.10</checkstyle.version>
   </properties>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -45,18 +45,14 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-oxm</artifactId>
-    </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -43,6 +43,25 @@
           <groupId>org.hibernate</groupId>
           <artifactId>hibernate-validator</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Use Jetty instead -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jetty</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>javax-websocket-server-impl</artifactId>
+          <groupId>org.eclipse.jetty.websocket</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>websocket-server</artifactId>
+          <groupId>org.eclipse.jetty.websocket</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -104,22 +104,7 @@
                 <alias>s3mock</alias>
                 <name>${docker.image.name}</name>
                 <build>
-                  <from>openjdk:${openjdk.version}-jre-alpine</from>
-                  <workdir>/opt/service</workdir>
-                  <ports>
-                    <port>9090</port>
-                    <port>9191</port>
-                  </ports>
-                  <entryPoint>
-                    <exec>
-                      <arg>java</arg>
-                      <arg>-Xmx128m</arg>
-                      <arg>-Djava.security.egd=file:/dev/./urandom</arg>
-                      <arg>-Xmx128m</arg>
-                      <arg>-jar</arg>
-                      <arg>${project.build.finalName}.jar</arg>
-                    </exec>
-                  </entryPoint>
+                  <dockerFileDir>${project.basedir}/src/main/docker</dockerFileDir>
                   <assembly>
                     <basedir>/opt</basedir>
                     <inline>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.0.12-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/src/main/docker/Dockerfile
+++ b/server/src/main/docker/Dockerfile
@@ -1,0 +1,55 @@
+#
+#  Copyright 2017-2018 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+FROM adoptopenjdk/openjdk11:${adoptopenjdk11.image.version} as staging_area
+
+# create a minimal jdk assembly with those modules that we need
+RUN jlink \
+    --module-path $JAVA_HOME/jmods \
+    --verbose \
+    --add-modules java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument \
+    --compress 2 \
+    --no-header-files \
+    --no-man-pages \
+    --strip-debug \
+    --output /target/opt/jdk-minimal
+
+# add libz* files, so that we don't have to re-install that (not included in alpine-glibc)
+RUN mkdir -p /target/usr/glibc-compat/lib; \
+    cp /usr/glibc-compat/lib/libz* /target/usr/glibc-compat/lib
+
+#
+# build the actual image
+#
+FROM frolvlad/alpine-glibc:${alpine-glibc.image.version}
+
+# copy files prepared in the other container
+COPY --from=staging_area /target /
+
+# rebuild ld.so.cache to add libz
+RUN /usr/glibc-compat/sbin/ldconfig
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    JAVA_HOME=/opt/jdk-minimal \
+    PATH="$PATH:/opt/jdk-minimal/bin"
+
+EXPOSE 9090 9191
+
+COPY maven /opt/
+
+ENTRYPOINT java -XX:+UseContainerSupport -Xmx128m --illegal-access=warn -Djava.security.egd=file:/dev/./urandom -jar /opt/service/*.jar

--- a/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.oxm.xstream.XStreamMarshaller;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -46,7 +46,7 @@ class KmsValidationFilter extends OncePerRequestFilter {
   private final KmsKeyStore keystore;
 
   @Autowired
-  private XStreamMarshaller marshaller;
+  private MappingJackson2XmlHttpMessageConverter messageConverter;
 
   /**
    * Constructs a new {@link KmsValidationFilter}.
@@ -79,7 +79,7 @@ class KmsValidationFilter extends OncePerRequestFilter {
         errorResponse.setCode("KMS.NotFoundException");
         errorResponse.setMessage("Key " + encryptionKeyRef + " does not exist!");
 
-        marshaller.marshalOutputStream(errorResponse, response.getOutputStream());
+        messageConverter.getObjectMapper().writeValue(response.getOutputStream(), errorResponse);
 
         response.flushBuffer();
       } else {

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -61,7 +61,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
-import org.springframework.boot.web.servlet.filter.OrderedHttpPutFormContentFilter;
+import org.springframework.boot.web.servlet.filter.OrderedFormContentFilter;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.cache.Cache;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
@@ -195,7 +195,6 @@ public class S3MockApplication {
   public void stop() {
     SpringApplication.exit(context, (ExitCodeGenerator) () -> 0);
   }
-
 
   /**
    * Gets the Https server port.
@@ -364,8 +363,8 @@ public class S3MockApplication {
     }
 
     @Bean
-    OrderedHttpPutFormContentFilter httpPutFormContentFilter() {
-      return new OrderedHttpPutFormContentFilter() {
+    OrderedFormContentFilter httpPutFormContentFilter() {
+      return new OrderedFormContentFilter() {
         @Override
         protected boolean shouldNotFilter(final HttpServletRequest request) {
           return true;

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -19,27 +19,10 @@ package com.adobe.testing.s3mock;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 
-import com.adobe.testing.s3mock.domain.Bucket;
 import com.adobe.testing.s3mock.domain.FileStore;
 import com.adobe.testing.s3mock.domain.KmsKeyStore;
-import com.adobe.testing.s3mock.domain.Tag;
-import com.adobe.testing.s3mock.dto.BatchDeleteRequest;
-import com.adobe.testing.s3mock.dto.BatchDeleteResponse;
-import com.adobe.testing.s3mock.dto.CompleteMultipartUploadResult;
-import com.adobe.testing.s3mock.dto.CopyObjectResult;
-import com.adobe.testing.s3mock.dto.CopyPartResult;
-import com.adobe.testing.s3mock.dto.ErrorResponse;
-import com.adobe.testing.s3mock.dto.InitiateMultipartUploadResult;
-import com.adobe.testing.s3mock.dto.ListAllMyBucketsResult;
-import com.adobe.testing.s3mock.dto.ListBucketResult;
-import com.adobe.testing.s3mock.dto.ListBucketResultV2;
-import com.adobe.testing.s3mock.dto.ListMultipartUploadsResult;
-import com.adobe.testing.s3mock.dto.ListPartsResult;
-import com.adobe.testing.s3mock.dto.Owner;
-import com.adobe.testing.s3mock.dto.Tagging;
 import com.adobe.testing.s3mock.util.ObjectRefConverter;
 import com.adobe.testing.s3mock.util.RangeConverter;
-import com.thoughtworks.xstream.XStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -71,8 +54,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.xml.MarshallingHttpMessageConverter;
-import org.springframework.oxm.xstream.XStreamMarshaller;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -304,62 +286,21 @@ public class S3MockApplication {
     }
 
     /**
-     * Creates a MarshallingHttpMessageConverter using the given {@code xstreamMarshaller}.
+     * Creates an HttpMessageConverter for XML.
      *
-     * @param xstreamMarshaller The fully configured {@link XStreamMarshaller}
-     *
-     * @return The configured {@link MarshallingHttpMessageConverter}.
+     * @return The configured {@link MappingJackson2XmlHttpMessageConverter}.
      */
     @Bean
-    public MarshallingHttpMessageConverter getMessageConverter(
-        final XStreamMarshaller xstreamMarshaller) {
+    public MappingJackson2XmlHttpMessageConverter getMessageConverter() {
       final List<MediaType> mediaTypes = new ArrayList<>();
       mediaTypes.add(MediaType.APPLICATION_XML);
       mediaTypes.add(MediaType.APPLICATION_FORM_URLENCODED);
 
-      final MarshallingHttpMessageConverter xmlConverter = new MarshallingHttpMessageConverter();
+      final MappingJackson2XmlHttpMessageConverter xmlConverter =
+          new MappingJackson2XmlHttpMessageConverter();
       xmlConverter.setSupportedMediaTypes(mediaTypes);
 
-      xmlConverter.setMarshaller(xstreamMarshaller);
-      xmlConverter.setUnmarshaller(xstreamMarshaller);
-
       return xmlConverter;
-    }
-
-    @Bean
-    XStreamMarshaller getXStreamMarshaller() {
-      final Class[] supportedClasses = {
-          BatchDeleteRequest.class,
-          BatchDeleteRequest.ObjectToDelete.class,
-          BatchDeleteResponse.class,
-          Bucket.class,
-          CompleteMultipartUploadResult.class,
-          CopyObjectResult.class,
-          CopyPartResult.class,
-          ErrorResponse.class,
-          InitiateMultipartUploadResult.class,
-          ListAllMyBucketsResult.class,
-          ListBucketResult.class,
-          ListBucketResultV2.class,
-          ListMultipartUploadsResult.class,
-          ListPartsResult.class,
-          Owner.class,
-          Tagging.class,
-          Tag.class
-      };
-
-      final XStreamMarshaller xstreamMarshaller = new XStreamMarshaller() {
-        @Override
-        protected void customizeXStream(final XStream xstream) {
-          XStream.setupDefaultSecurity(xstream);
-          xstream.allowTypes(supportedClasses);
-        }
-      };
-
-      xstreamMarshaller.setSupportedClasses(supportedClasses);
-      xstreamMarshaller.setAnnotatedClasses(supportedClasses);
-
-      return xstreamMarshaller;
     }
 
     @Bean

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/Bucket.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/Bucket.java
@@ -16,19 +16,20 @@
 
 package com.adobe.testing.s3mock.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import java.nio.file.Path;
 
 /**
  * DTO representing a bucket.
  */
-@XStreamAlias("Bucket")
+@JsonRootName("Bucket")
 public class Bucket {
 
-  @XStreamAlias("Name")
+  @JsonProperty("Name")
   private String name;
 
-  @XStreamAlias("CreationDate")
+  @JsonProperty("CreationDate")
   private String creationDate;
 
   private Path path;
@@ -41,10 +42,9 @@ public class Bucket {
    * @param creationDate date of creation.
    */
   public Bucket(final Path bucketPath, final String name, final String creationDate) {
-    super();
     this.name = name;
     this.creationDate = creationDate;
-    this.path = bucketPath;
+    path = bucketPath;
   }
 
   public String getCreationDate() {
@@ -68,6 +68,6 @@ public class Bucket {
   }
 
   public void setPath(final Path bucketPath) {
-    this.path = bucketPath;
+    path = bucketPath;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/BucketContents.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/BucketContents.java
@@ -17,31 +17,32 @@
 package com.adobe.testing.s3mock.domain;
 
 import com.adobe.testing.s3mock.dto.Owner;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import javax.xml.bind.annotation.XmlElement;
 
 /**
  * Contents are the XMLElements of ListBucketResult see http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
  */
-@XStreamAlias("Contents")
+@JsonRootName("Contents")
 public class BucketContents {
 
-  @XStreamAlias("Key")
+  @JsonProperty("Key")
   private String key;
 
-  @XStreamAlias("LastModified")
+  @JsonProperty("LastModified")
   private String lastModified;
 
-  @XStreamAlias("ETag")
+  @JsonProperty("ETag")
   private String etag;
 
-  @XStreamAlias("Size")
+  @JsonProperty("Size")
   private String size;
 
-  @XStreamAlias("StorageClass")
+  @JsonProperty("StorageClass")
   private String storageClass;
 
-  @XStreamAlias("Owner")
+  @JsonProperty("Owner")
   private Owner owner;
 
   /**
@@ -67,7 +68,6 @@ public class BucketContents {
       final String size,
       final String storageClass,
       final Owner owner) {
-    super();
     this.key = key;
     this.lastModified = lastModified;
     this.etag = etag;

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/Buckets.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/Buckets.java
@@ -16,17 +16,19 @@
 
 package com.adobe.testing.s3mock.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.List;
 
 /**
  * DTO representing a list of buckets.
  */
-@XStreamAlias("Buckets")
+@JsonRootName("Buckets")
 public class Buckets {
 
-  @XStreamImplicit
+  @JsonProperty("Bucket")
+  @JacksonXmlElementWrapper(useWrapping = false)
   private List<Bucket> buckets;
 
   public List<Bucket> getBuckets() {

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/Tag.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/Tag.java
@@ -16,16 +16,14 @@
 
 package com.adobe.testing.s3mock.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
-@XStreamAlias("Tag")
 public class Tag {
-
-  @XStreamAlias("Key")
+  @JsonProperty("Key")
   private String key;
 
-  @XStreamAlias("Value")
+  @JsonProperty("Value")
   private String value;
 
   public Tag() {

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteRequest.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteRequest.java
@@ -16,20 +16,22 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.List;
 
 /**
  * Request to initiate a batch delete request.
  */
-@XStreamAlias("Delete")
+@JsonRootName("Delete")
 public class BatchDeleteRequest {
 
-  @XStreamAlias("Quiet")
+  @JsonProperty("Quiet")
   private boolean quiet;
 
-  @XStreamImplicit
+  @JsonProperty("Object")
+  @JacksonXmlElementWrapper(useWrapping = false)
   private List<ObjectToDelete> objectsToDelete;
 
   public List<ObjectToDelete> getObjectsToDelete() {
@@ -48,13 +50,12 @@ public class BatchDeleteRequest {
     this.quiet = quiet;
   }
 
-  @XStreamAlias("Object")
-  public class ObjectToDelete {
+  public static class ObjectToDelete {
 
-    @XStreamAlias("Key")
+    @JsonProperty("Key")
     private String key;
 
-    @XStreamAlias("VersionId")
+    @JsonProperty("VersionId")
     private String versionId;
 
     public String getKey() {

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteResponse.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteResponse.java
@@ -16,20 +16,20 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Result to be returned after batch delete request.
  */
-@XStreamAlias("DeleteResult")
-@XStreamInclude({DeletedObject.class})
+@JsonRootName("DeleteResult")
 public class BatchDeleteResponse {
 
-  @XStreamImplicit
+  @JsonProperty("Deleted")
+  @JacksonXmlElementWrapper(useWrapping = false)
   private final List<DeletedObject> deletedObjects = new ArrayList<>();
 
   public List<DeletedObject> getDeletedObjects() {
@@ -37,6 +37,6 @@ public class BatchDeleteResponse {
   }
 
   public void addDeletedObject(final DeletedObject deletedObject) {
-    this.deletedObjects.add(deletedObject);
+    deletedObjects.add(deletedObject);
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CommonPrefixes.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CommonPrefixes.java
@@ -16,14 +16,16 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.Collection;
 
-@XStreamAlias("CommonPrefixes")
+@JsonRootName("CommonPrefixes")
 class CommonPrefixes {
 
-  @XStreamImplicit(itemFieldName = "Prefix")
+  @JsonProperty("Prefix")
+  @JacksonXmlElementWrapper(useWrapping = false)
   private final Collection<String> commonPrefixes;
 
   public CommonPrefixes(final Collection<String> commonPrefixes) {

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResult.java
@@ -16,24 +16,25 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  * Result to be returned when completing a multipart request.
  */
-@XStreamAlias("CompleteMultipartUploadResult")
+@JsonRootName("CompleteMultipartUploadResult")
 public class CompleteMultipartUploadResult {
 
-  @XStreamAlias("Location")
+  @JsonProperty("Location")
   private final String location;
 
-  @XStreamAlias("Bucket")
+  @JsonProperty("Bucket")
   private final String bucket;
 
-  @XStreamAlias("Key")
+  @JsonProperty("Key")
   private final String key;
 
-  @XStreamAlias("ETag")
+  @JsonProperty("ETag")
   private final String etag;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CopyObjectResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CopyObjectResult.java
@@ -16,18 +16,19 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  * DTO as representation of a succeeded copy process.
  */
-@XStreamAlias("CopyObjectResult")
+@JsonRootName("CopyObjectResult")
 public class CopyObjectResult {
 
-  @XStreamAlias("LastModified")
+  @JsonProperty("LastModified")
   private String lastModified;
 
-  @XStreamAlias("ETag")
+  @JsonProperty("ETag")
   private String etag;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
@@ -16,22 +16,23 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
-@XStreamAlias("CopyPartResult")
+@JsonRootName("CopyPartResult")
 public class CopyPartResult {
 
   private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
       .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
       .withZone(ZoneId.of("UTC"));
 
-  @XStreamAlias("LastModified")
+  @JsonProperty("LastModified")
   private final String lastModified;
 
-  @XStreamAlias("ETag")
+  @JsonProperty("ETag")
   private final String etag;
 
   public CopyPartResult(final String lastModified, final String etag) {

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/DeletedObject.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/DeletedObject.java
@@ -16,18 +16,19 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  * Object entry of a successful batch delete request.
  */
-@XStreamAlias("Deleted")
+@JsonRootName("Deleted")
 public class DeletedObject {
 
-  @XStreamAlias("Key")
+  @JsonProperty("Key")
   private String key;
 
-  @XStreamAlias("VersionId")
+  @JsonProperty("VersionId")
   private String versionId;
 
   public String getKey() {

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ErrorResponse.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ErrorResponse.java
@@ -16,8 +16,8 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  * A DTO which can be used as an response body if an error occurred.
@@ -25,19 +25,19 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @see <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html">AWS REST
  *     Error Response</a>
  */
-@XStreamAlias("Error")
+@JsonRootName("Error")
 public class ErrorResponse {
 
-  @XStreamAlias("Code")
+  @JsonProperty("Code")
   private String code;
 
-  @XStreamAlias("Message")
+  @JsonProperty("Message")
   private String message;
 
-  @XStreamAlias("Resource")
+  @JsonProperty("Resource")
   private String resource;
 
-  @XStreamAlias("RequestId")
+  @JsonProperty("RequestId")
   private String requestId;
 
   public void setCode(final String code) {
@@ -54,16 +54,5 @@ public class ErrorResponse {
 
   public void setRequestId(final String requestId) {
     this.requestId = requestId;
-  }
-
-  /**
-   * Returns a xml representation of this Error.
-   *
-   * @return xml String
-   */
-  public String toXml() {
-    final XStream xStream = new XStream();
-    xStream.processAnnotations(ErrorResponse.class);
-    return xStream.toXML(this);
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResult.java
@@ -16,21 +16,22 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  * Result to be returned after multipart upload initiation.
  */
-@XStreamAlias("InitiateMultipartUploadResult")
+@JsonRootName("InitiateMultipartUploadResult")
 public class InitiateMultipartUploadResult {
 
-  @XStreamAlias("Bucket")
+  @JsonProperty("Bucket")
   private final String bucketName;
 
-  @XStreamAlias("Key")
+  @JsonProperty("Key")
   private final String fileName;
 
-  @XStreamAlias("UploadId")
+  @JsonProperty("UploadId")
   private final String uploadId;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResult.java
@@ -18,21 +18,20 @@ package com.adobe.testing.s3mock.dto;
 
 import com.adobe.testing.s3mock.domain.Bucket;
 import com.adobe.testing.s3mock.domain.Buckets;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import java.util.List;
 
 /**
  * Represents a result of listing all Buckets.
  */
-@XStreamAlias("ListAllMyBucketsResult")
-@XStreamInclude({Buckets.class})
+@JsonRootName("ListAllMyBucketsResult")
 public class ListAllMyBucketsResult {
 
-  @XStreamAlias("Owner")
+  @JsonProperty("Owner")
   private Owner owner;
 
-  @XStreamAlias("Buckets")
+  @JsonProperty("Buckets")
   private Buckets buckets;
 
   /**
@@ -48,7 +47,6 @@ public class ListAllMyBucketsResult {
    * @param buckets list of buckets of the owner.
    */
   public ListAllMyBucketsResult(final Owner owner, final List<Bucket> buckets) {
-    super();
     this.owner = owner;
     this.buckets = new Buckets();
     this.buckets.setBuckets(buckets);

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -17,9 +17,9 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.adobe.testing.s3mock.domain.BucketContents;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,29 +29,29 @@ import javax.xml.bind.annotation.XmlElement;
 /**
  * Represents a result of listing objects that reside in a Bucket.
  */
-@XStreamAlias("ListBucketResult")
-@XStreamInclude({BucketContents.class})
+@JsonRootName("ListBucketResult")
 public class ListBucketResult implements Serializable {
 
-  @XStreamAlias("Name")
+  @JsonProperty("Name")
   private String name;
 
-  @XStreamAlias("Prefix")
+  @JsonProperty("Prefix")
   private String prefix;
 
-  @XStreamAlias("Marker")
+  @JsonProperty("Marker")
   private String marker;
 
-  @XStreamAlias("MaxKeys")
+  @JsonProperty("MaxKeys")
   private int maxKeys;
 
-  @XStreamAlias("IsTruncated")
+  @JsonProperty("IsTruncated")
   private boolean isTruncated;
 
-  @XStreamImplicit(itemFieldName = "Contents")
+  @JsonProperty("Contents")
+  @JacksonXmlElementWrapper(useWrapping = false)
   private List<BucketContents> contents;
 
-  @XStreamAlias("CommonPrefixes")
+  @JsonProperty("CommonPrefixes")
   private CommonPrefixes commonPrefixes;
 
   /**
@@ -79,7 +79,6 @@ public class ListBucketResult implements Serializable {
       final boolean isTruncated,
       final List<BucketContents> contents,
       final Collection<String> commonPrefixes) {
-    super();
     this.name = name;
     this.prefix = prefix;
     this.marker = marker;

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -17,9 +17,9 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.adobe.testing.s3mock.domain.BucketContents;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,38 +29,38 @@ import javax.xml.bind.annotation.XmlElement;
 /**
  * Represents a result of listing objects that reside in a Bucket.
  */
-@XStreamAlias("ListBucketResult")
-@XStreamInclude({BucketContents.class})
+@JsonRootName("ListBucketResult")
 public class ListBucketResultV2 implements Serializable {
 
-  @XStreamAlias("Name")
+  @JsonProperty("Name")
   private String name;
 
-  @XStreamAlias("Prefix")
+  @JsonProperty("Prefix")
   private String prefix;
 
-  @XStreamAlias("MaxKeys")
+  @JsonProperty("MaxKeys")
   private int maxKeys;
 
-  @XStreamAlias("IsTruncated")
+  @JsonProperty("IsTruncated")
   private boolean isTruncated;
 
-  @XStreamImplicit(itemFieldName = "Contents")
+  @JsonProperty("Contents")
+  @JacksonXmlElementWrapper(useWrapping = false)
   private List<BucketContents> contents;
 
-  @XStreamAlias("CommonPrefixes")
+  @JsonProperty("CommonPrefixes")
   private CommonPrefixes commonPrefixes;
 
-  @XStreamAlias("ContinuationToken")
+  @JsonProperty("ContinuationToken")
   private String continuationToken;
 
-  @XStreamAlias("KeyCount")
+  @JsonProperty("KeyCount")
   private String keyCount;
 
-  @XStreamAlias("NextContinuationToken")
+  @JsonProperty("NextContinuationToken")
   private String nextContinuationToken;
 
-  @XStreamAlias("StartAfter")
+  @JsonProperty("StartAfter")
   private String startAfter;
 
   /**
@@ -88,7 +88,6 @@ public class ListBucketResultV2 implements Serializable {
       final boolean isTruncated, final List<BucketContents> contents,
       final Collection<String> commonPrefixes, final String continuationToken,
       final String keyCount, final String nextContinuationToken, final String startAfter) {
-    super();
     this.name = name;
     this.prefix = prefix;
     this.maxKeys = Integer.valueOf(maxKeys);

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResult.java
@@ -16,40 +16,44 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * List Multipart Uploads result according to the
  * <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html">S3 API
  * Reference</a>.
  */
-@XStreamAlias("ListMultipartUploadsResult")
+@JsonRootName("ListMultipartUploadsResult")
 public class ListMultipartUploadsResult {
 
-  @XStreamAlias("Bucket")
+  @JsonProperty("Bucket")
   private final String bucket;
-  @XStreamAlias("KeyMarker")
+  @JsonProperty("KeyMarker")
   private final String keyMarker;
-  @XStreamAlias("Delimiter")
+  @JsonProperty("Delimiter")
   private final String delimiter;
-  @XStreamAlias("Prefix")
+  @JsonProperty("Prefix")
   private final String prefix;
-  @XStreamAlias("UploadIdMarker")
+  @JsonProperty("UploadIdMarker")
   private final String uploadIdMarker;
-  @XStreamAlias("MaxUploads")
+  @JsonProperty("MaxUploads")
   private final int maxUploads;
-  @XStreamAlias("IsTruncated")
+  @JsonProperty("IsTruncated")
   private final boolean isTruncated;
-  @XStreamAlias("NextKeyMarker")
+  @JsonProperty("NextKeyMarker")
   private final String nextKeyMarker;
-  @XStreamAlias("NextUploadIdMarker")
+  @JsonProperty("NextUploadIdMarker")
   private final String nextUploadIdMarker;
-  @XStreamImplicit
+  @JsonProperty("Upload")
+  @JacksonXmlElementWrapper(useWrapping = false)
   private final List<MultipartUpload> multipartUploads;
-  @XStreamAlias("CommonPrefixes")
-  private final java.util.List<String> commonPrefixes;
+  @JsonProperty("CommonPrefixes")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  private final List<Prefix> commonPrefixes;
 
   /**
    * Creates a new ListMultipartUploadsResult.
@@ -87,7 +91,7 @@ public class ListMultipartUploadsResult {
     this.nextKeyMarker = nextKeyMarker;
     this.nextUploadIdMarker = nextUploadIdMarker;
     this.multipartUploads = multipartUploads;
-    this.commonPrefixes = commonPrefixes;
+    this.commonPrefixes = commonPrefixes.stream().map(Prefix::new).collect(Collectors.toList());
   }
 
   @Override
@@ -105,5 +109,14 @@ public class ListMultipartUploadsResult {
         + ", multipartUploads=" + multipartUploads
         + ", commonPrefixes=" + commonPrefixes
         + '}';
+  }
+
+  public static class Prefix {
+    @JsonProperty
+    private final String prefix;
+
+    public Prefix(final String prefix) {
+      this.prefix = prefix;
+    }
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
@@ -16,33 +16,34 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  * List-Parts result with some hard-coded values as this is sufficient for now.
  */
-@XStreamAlias("ListPartsResult")
+@JsonRootName("ListPartsResult")
 public class ListPartsResult {
 
-  @XStreamAlias("Bucket")
+  @JsonProperty("Bucket")
   private final String bucket;
 
-  @XStreamAlias("Key")
+  @JsonProperty("Key")
   private final String key;
 
-  @XStreamAlias("UploadId")
+  @JsonProperty("UploadId")
   private final String uploadId;
 
-  @XStreamAlias("PartNumberMarker")
+  @JsonProperty("PartNumberMarker")
   private final String partnumber = "0";
 
-  @XStreamAlias("NextPartNumberMarker")
+  @JsonProperty("NextPartNumberMarker")
   private final String nextpartnumber = "1";
 
-  @XStreamAlias("IsTruncated")
+  @JsonProperty("IsTruncated")
   private final boolean truncated = false;
 
-  @XStreamAlias("StorageClass")
+  @JsonProperty("StorageClass")
   private final String storageClass = "STANDARD";
 
   /**
@@ -53,8 +54,8 @@ public class ListPartsResult {
    * @param uploadId of the multipart upload.
    */
   public ListPartsResult(final String bucketName, final String fileName, final String uploadId) {
-    this.bucket = bucketName;
-    this.key = fileName;
+    bucket = bucketName;
+    key = fileName;
     this.uploadId = uploadId;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
@@ -16,9 +16,8 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
-import com.thoughtworks.xstream.converters.extended.ISO8601DateConverter;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import java.util.Objects;
 
@@ -27,21 +26,20 @@ import java.util.Objects;
  * <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html">S3 API
  * Reference</a>.
  */
-@XStreamAlias("Upload")
 public class MultipartUpload {
 
-  @XStreamAlias("Key")
+  @JsonProperty("Key")
   private final String key;
-  @XStreamAlias("UploadId")
+  @JsonProperty("UploadId")
   private final String uploadId;
-  @XStreamAlias("Owner")
+  @JsonProperty("Owner")
   private final Owner owner;
-  @XStreamAlias("Initiator")
+  @JsonProperty("Initiator")
   private final Owner initiator;
-  @XStreamAlias("StorageClass")
+  @JsonProperty("StorageClass")
   private final String storageClass = "STANDARD";
-  @XStreamAlias("Initiated")
-  @XStreamConverter(ISO8601DateConverter.class)
+  @JsonProperty("Initiated")
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
   private final Date initiated;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
@@ -16,19 +16,20 @@
 
 package com.adobe.testing.s3mock.dto;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import javax.xml.bind.annotation.XmlElement;
 
 /**
- * Owner of an Bucket.
+ * Owner of a Bucket.
  */
-@XStreamAlias("Owner")
+@JsonRootName("Owner")
 public class Owner {
 
-  @XStreamAlias("ID")
+  @JsonProperty("ID")
   private long id;
 
-  @XStreamAlias("DisplayName")
+  @JsonProperty("DisplayName")
   private String displayName;
 
   /**
@@ -44,7 +45,6 @@ public class Owner {
    * @param displayName name of ther owner.
    */
   public Owner(final long id, final String displayName) {
-    super();
     this.id = id;
     this.displayName = displayName;
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Tagging.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Tagging.java
@@ -17,22 +17,24 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.adobe.testing.s3mock.domain.Tag;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Result to be returned for GetObjectTagging.
+ * See https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtagging.html
  */
-@XStreamAlias("Tagging")
-@XStreamInclude(Tag.class)
+@JsonRootName("Tagging")
 public class Tagging {
 
-  @XStreamAlias("TagSet")
+  @JsonProperty("Tag")
+  @JacksonXmlElementWrapper(localName = "TagSet")
   private List<Tag> tagSet = new ArrayList<>();
 
-  @XStreamAlias("VersionId")
+  @JsonProperty("VersionId")
   private String versionId;
 
   public Tagging() {
@@ -40,7 +42,7 @@ public class Tagging {
 
   public Tagging(final List<Tag> tagSet) {
     this.tagSet = tagSet;
-    this.versionId = "0";
+    versionId = "0";
   }
 
   public void setTagSet(final List<Tag> tagSet) {

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -17,3 +17,5 @@
 server.ssl.key-store=classpath:s3mock.jks
 server.ssl.key-store-password=password
 server.ssl.key-password=password
+
+logging.level.org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver=ERROR

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.0.12-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.0.12-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.0.12-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.testing</groupId>
         <artifactId>s3mock-parent</artifactId>
-        <version>2.0.12-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.0.12-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 


### PR DESCRIPTION
## Description

I've played around a little bit to see how ready we are for JDK 11 and SpringBoot 2.1. Don't merge, yet.

This branch contains the following commits:

* Use AdoptOpenJDK 11.0.1 build with minified modular runtime, created in a multi-stage Dockerfile. This reduces the image size by 21MB compared to `adobe/s3mock:2.0.8`.
* Use SpringBoot 2.1.0.RELEASE and enable `illegal-access` warnings, to see where we still might get into trouble on JDK 10/11.
* Switch to Jackson-Dataformat-Xml and kick out XStream.
* Use Jetty instead of Tomcat to avoid the warnings at shutdown-time.

## Related Issue
#40 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
