### PR TITLE
Fix common prefix for listObjectsV2 request.

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -336,8 +336,8 @@ class FileStoreController {
       final List<BucketContents> contents = getBucketContents(bucketName, prefix);
       List<BucketContents> filteredContents = getFilteredBucketContents(contents, startAfter);
 
-      Set<String> commonPrefixes = null;
-      if (null != delimiter) {
+      Set<String> commonPrefixes = new HashSet<>();
+      if (delimiter != null) {
         collapseCommonPrefixes(prefix, delimiter, filteredContents, commonPrefixes);
       }
       
@@ -364,7 +364,7 @@ class FileStoreController {
       }
 
       return new ListBucketResultV2(bucketName, prefix, maxKeysParam,
-          isTruncated, filteredContents, null,
+          isTruncated, filteredContents, commonPrefixes,
           continuationToken, String.valueOf(filteredContents.size()),
           nextContinuationToken, startAfter);
     } catch (final IOException e) {


### PR DESCRIPTION


## Description
Fix common prefix for listObjectsV2 request.
Otherwise a NPE was thrown.

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
