### PR TITLE
Honor max-keys parameter in List Objects v1 API

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -273,7 +273,7 @@ class FileStoreController {
         contents = contents.subList(0, maxKeys);
       }
 
-      return new ListBucketResult(bucketName, prefix, null, "1000", false, contents,
+      return new ListBucketResult(bucketName, prefix, null, maxKeys, false, contents,
           commonPrefixes);
     } catch (final IOException e) {
       LOG.error(String.format("Object(s) could not retrieved from bucket %s", bucketName));

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -84,6 +84,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -235,7 +236,7 @@ class FileStoreController {
   }
 
   /**
-   * Retrieve list of objects of a bucket see http://docs.aws.amazon .com/AmazonS3/latest/API/RESTBucketGET.html
+   * Retrieve list of objects of a bucket see http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
    *
    * @param bucketName {@link String} set bucket name
    * @param prefix {@link String} find object names they starts with prefix
@@ -253,14 +254,23 @@ class FileStoreController {
   public ListBucketResult listObjectsInsideBucket(@PathVariable final String bucketName,
       @RequestParam(required = false) final String prefix,
       @RequestParam(required = false) final String delimiter,
+      @RequestParam(name = "max-keys", defaultValue = "1000",
+              required = false) final Integer maxKeys,
       final HttpServletResponse response) throws IOException {
     verifyBucketExistence(bucketName);
+    if (maxKeys < 0) {
+      throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
+              "maxKeys should be non-negative");
+    }
     try {
-      final List<BucketContents> contents = getBucketContents(bucketName, prefix);
+      List<BucketContents> contents = getBucketContents(bucketName, prefix);
 
       final Set<String> commonPrefixes = new HashSet<>();
       if (null != delimiter) {
         collapseCommonPrefixes(prefix, delimiter, contents, commonPrefixes);
+      }
+      if (maxKeys < contents.size()) {
+        contents = contents.subList(0, maxKeys);
       }
 
       return new ListBucketResult(bucketName, prefix, null, "1000", false, contents,

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -75,7 +75,7 @@ public class ListBucketResult implements Serializable {
   public ListBucketResult(final String name,
       final String prefix,
       final String marker,
-      final String maxKeys,
+      final int maxKeys,
       final boolean isTruncated,
       final List<BucketContents> contents,
       final Collection<String> commonPrefixes) {
@@ -83,7 +83,7 @@ public class ListBucketResult implements Serializable {
     this.name = name;
     this.prefix = prefix;
     this.marker = marker;
-    this.maxKeys = Integer.valueOf(maxKeys);
+    this.maxKeys = maxKeys;
     this.isTruncated = isTruncated;
     this.contents = new ArrayList<>();
     this.contents.addAll(contents);

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its;
+
+import static org.junit.Assert.assertEquals;
+
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class ListObjectV1MaxKeysIT extends S3TestBase {
+
+  private final String bucketName = "some-bucket";
+
+  @Before
+  @Override
+  public void prepareS3Client() {
+    super.prepareS3Client();
+    s3Client.createBucket(bucketName);
+    s3Client.putObject(bucketName, "a", "");
+    s3Client.putObject(bucketName, "b", "");
+  }
+
+  @Test
+  public void limitsAmountOfObjectsBasedOnMaxKeys() {
+    ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName).withMaxKeys(1);
+    ObjectListing objectListing = s3Client.listObjects(request);
+
+    // This assertion fails. listObjects returns 2 objects instead of 1.
+    assertEquals(1, objectListing.getObjectSummaries().size());
+  }
+
+  @Test
+  public void returnsAllIfMaxKeysIsDefault() {
+    ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName);
+    ObjectListing objectListing = s3Client.listObjects(request);
+
+    assertEquals(2, objectListing.getObjectSummaries().size());
+  }
+
+  @Test
+  public void returnsAllIfMaxKeysEqualToAmountOfObjects() {
+    ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
+            .withMaxKeys(2);
+    ObjectListing objectListing = s3Client.listObjects(request);
+
+    assertEquals(2, objectListing.getObjectSummaries().size());
+  }
+
+  @Test
+  public void returnsAllIfMaxKeysMoreThanAmountOfObjects() {
+    ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
+            .withMaxKeys(3);
+    ObjectListing objectListing = s3Client.listObjects(request);
+
+    assertEquals(2, objectListing.getObjectSummaries().size());
+  }
+
+  @Test
+  public void returnsNoOnbjectsIfMaxKeysIsZero() {
+    ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
+            .withMaxKeys(0);
+    ObjectListing objectListing = s3Client.listObjects(request);
+
+    assertEquals(0, objectListing.getObjectSummaries().size());
+  }
+
+  @Test
+  public void returnsAllOnbjectsIfMaxKeysIsNegative() {
+    ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
+            .withMaxKeys(-1);
+    ObjectListing objectListing = s3Client.listObjects(request);
+
+    // Apparently, the Amazon SDK rejects negative max keys, and by default it's 1000
+    assertEquals(2, objectListing.getObjectSummaries().size());
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.java
@@ -16,19 +16,18 @@
 
 package com.adobe.testing.s3mock.its;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ListObjectV1MaxKeysIT extends S3TestBase {
 
   private final String bucketName = "some-bucket";
 
-  @Before
+  @BeforeEach
   @Override
   public void prepareS3Client() {
     super.prepareS3Client();
@@ -38,56 +37,61 @@ public class ListObjectV1MaxKeysIT extends S3TestBase {
   }
 
   @Test
-  public void limitsAmountOfObjectsBasedOnMaxKeys() {
+  public void returnsLimitedAmountOfObjectsBasedOnMaxKeys() {
     ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName).withMaxKeys(1);
     ObjectListing objectListing = s3Client.listObjects(request);
 
-    // This assertion fails. listObjects returns 2 objects instead of 1.
     assertEquals(1, objectListing.getObjectSummaries().size());
+    assertEquals(1, objectListing.getMaxKeys());
   }
 
   @Test
-  public void returnsAllIfMaxKeysIsDefault() {
+  public void returnsAllObjectsIfMaxKeysIsDefault() {
     ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName);
     ObjectListing objectListing = s3Client.listObjects(request);
 
     assertEquals(2, objectListing.getObjectSummaries().size());
+    assertEquals(1000, objectListing.getMaxKeys());
   }
 
   @Test
-  public void returnsAllIfMaxKeysEqualToAmountOfObjects() {
+  public void returnsAllObjectsIfMaxKeysEqualToAmountOfObjects() {
     ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
             .withMaxKeys(2);
     ObjectListing objectListing = s3Client.listObjects(request);
 
     assertEquals(2, objectListing.getObjectSummaries().size());
+    assertEquals(2, objectListing.getMaxKeys());
   }
 
   @Test
-  public void returnsAllIfMaxKeysMoreThanAmountOfObjects() {
+  public void returnsAllObjectsIfMaxKeysMoreThanAmountOfObjects() {
     ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
             .withMaxKeys(3);
     ObjectListing objectListing = s3Client.listObjects(request);
 
     assertEquals(2, objectListing.getObjectSummaries().size());
+    assertEquals(3, objectListing.getMaxKeys());
   }
 
   @Test
-  public void returnsNoOnbjectsIfMaxKeysIsZero() {
+  public void returnsEmptyListIfMaxKeysIsZero() {
     ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
             .withMaxKeys(0);
     ObjectListing objectListing = s3Client.listObjects(request);
 
     assertEquals(0, objectListing.getObjectSummaries().size());
+    assertEquals(0, objectListing.getMaxKeys());
   }
 
   @Test
-  public void returnsAllOnbjectsIfMaxKeysIsNegative() {
+  public void returnsAllObjectsIfMaxKeysIsNegative() {
     ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName)
             .withMaxKeys(-1);
     ObjectListing objectListing = s3Client.listObjects(request);
 
     // Apparently, the Amazon SDK rejects negative max keys, and by default it's 1000
     assertEquals(2, objectListing.getObjectSummaries().size());
+    assertEquals(1000, objectListing.getMaxKeys());
   }
 }


### PR DESCRIPTION
## Description
The implementations of the List Objects V1 API doesn't honor the `max-keys` parameters of `ListObjectsRequest`. It would be nice if s3-mock supported it to reduce the disparity with the features provided by the actual S3 service.

Docs: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html

## Related Issue
Fixes #99

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.