### PR TITLE
#87 Fix handling requests without content type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2018 Adobe.
+     Copyright 2017-2019 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -50,12 +50,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
 
-    <adoptopenjdk11.image.version>jdk-11.0.1.13-alpine</adoptopenjdk11.image.version>
+    <adoptopenjdk11.image.version>jdk-11.0.2.7-alpine</adoptopenjdk11.image.version>
     <alpine-glibc.image.version>alpine-3.8_glibc-2.28</alpine-glibc.image.version>
 
-    <aws.version>1.11.473</aws.version>
+    <aws.version>1.11.488</aws.version>
 
-    <spring-boot.version>2.1.1.RELEASE</spring-boot.version>
+    <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
     <spring-security-oauth2.version>2.3.4.RELEASE</spring-security-oauth2.version>
     <commons-codec.version>1.11</commons-codec.version>
     <commons-io.version>2.6</commons-io.version>

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -284,7 +284,8 @@ public class S3MockApplication {
 
     @Override
     public void configureContentNegotiation(final ContentNegotiationConfigurer configurer) {
-      configurer.defaultContentType(MediaType.APPLICATION_FORM_URLENCODED);
+      configurer
+          .defaultContentType(MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_XML);
       configurer.favorPathExtension(false);
       configurer.mediaType("xml", MediaType.TEXT_XML);
     }
@@ -299,6 +300,7 @@ public class S3MockApplication {
       final List<MediaType> mediaTypes = new ArrayList<>();
       mediaTypes.add(MediaType.APPLICATION_XML);
       mediaTypes.add(MediaType.APPLICATION_FORM_URLENCODED);
+      mediaTypes.add(MediaType.APPLICATION_OCTET_STREAM);
 
       final MappingJackson2XmlHttpMessageConverter xmlConverter =
           new MappingJackson2XmlHttpMessageConverter();

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017-2018 Adobe.
+#  Copyright 2017-2019 Adobe.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -19,3 +19,4 @@ server.ssl.key-store-password=password
 server.ssl.key-password=password
 
 logging.level.org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver=ERROR
+logging.level.org.eclipse.jetty.util.ssl.SslContextFactory.config=ERROR


### PR DESCRIPTION
## Description

- When handling requests without a content type, support unmarshalling the XML payload
- Update JDK, SpringBoot and AWS SDK version to latest.

## Related Issue
fixes #87 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
