### PR TITLE
Handle invalid MIME types in headObject

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -256,7 +256,7 @@ class FileStoreController {
    * @throws IOException IOException If an input or output exception occurs
    */
   @RequestMapping(
-      value = "/{bucketName}/",
+      value = "/{bucketName}",
       method = RequestMethod.GET,
       produces = {"application/x-www-form-urlencoded"})
   @ResponseBody

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -85,6 +85,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -216,9 +217,17 @@ class FileStoreController {
     if (s3Object != null) {
       final HttpHeaders responseHeaders = new HttpHeaders();
       responseHeaders.setContentLength(Long.valueOf(s3Object.getSize()));
-      if (!"".equals(s3Object.getContentType())) {
-        responseHeaders.setContentType(MediaType.parseMediaType(s3Object.getContentType()));
+
+      MediaType fileMediaType;
+
+      try {
+        fileMediaType = MediaType.parseMediaType(s3Object.getContentType());
+      } catch (InvalidMediaTypeException e) {
+        fileMediaType = new MediaType("binary","octet-stream");
       }
+
+      responseHeaders.setContentType(fileMediaType);
+
       responseHeaders.setETag("\"" + s3Object.getMd5() + "\"");
       responseHeaders.setLastModified(s3Object.getLastModified());
 


### PR DESCRIPTION
## Description
When accessing headObject, it is attempted to parse the given MIME type. If parsing fails, an exception is thrown. As putObject with a completely empty object is accepted, this will sometimes try to parse a MIME type of "null" and subsequently throw an exception.

Mimicking AWS' behaviour, it will now give a Content-Type of binary/octet-stream for unparsable MIME types.

## Related Issue
#126 

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
