### PR TITLE
fixed inconsistent file name encoding

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package com.adobe.testing.s3mock;
 
 import static com.adobe.testing.s3mock.util.BetterHeaders.COPY_SOURCE;

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package com.adobe.testing.s3mock;
 
 import static com.adobe.testing.s3mock.util.BetterHeaders.COPY_SOURCE;

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -79,6 +79,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
+import org.eclipse.jetty.util.UrlEncoded;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1213,7 +1214,9 @@ class FileStoreController {
   private static String filenameFrom(final @PathVariable String bucketName,
       final HttpServletRequest request) {
     final String requestUri = request.getRequestURI();
-    return requestUri.substring(requestUri.indexOf(bucketName) + bucketName.length() + 1);
+    return UrlEncoded.decodeString(
+            requestUri.substring(requestUri.indexOf(bucketName) + bucketName.length() + 1)
+    );
   }
 
   private void verifyObjectMatching(


### PR DESCRIPTION
## Description
The s3mock doesn't work correctly for the [Characters That Might Require Special Handling ](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys) those characters are not supported.

## Related Issue
https://github.com/adobe/S3Mock/issues/119

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
