### PR TITLE
Fix #131: apply URL-decoding to the copy source

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
@@ -18,6 +18,8 @@ package com.adobe.testing.s3mock.dto;
 
 import static java.util.Objects.requireNonNull;
 
+import org.eclipse.jetty.util.UrlEncoded;
+
 /**
  * Represents a S3 Object referenced by Bucket and Key.
  */
@@ -47,7 +49,7 @@ public final class ObjectRef {
   public static ObjectRef from(final String copySource) {
     requireNonNull(copySource, "copySource == null");
 
-    final String[] bucketAndKey = extractBucketAndKeyArray(copySource);
+    final String[] bucketAndKey = extractBucketAndKeyArray(UrlEncoded.decodeString(copySource));
 
     return new ObjectRef(bucketAndKey[0], bucketAndKey[1]);
   }


### PR DESCRIPTION
## Description
Fix issue #131

## Related Issue
#131

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [?] I have written tests and verified that they fail without my change.

Important - why did I place a ? in the checkbox above? There seems to be an issue with the tests run via the maven lifecycle. The build succeeds despite failing tests. And this doesn't seem to apply to my newly introduced tests only, but also to `AmazonClientUploadIT.defaultBucketsGotCreated()` and others. To reveal the failing tests I started `S3MockApplication` within the IDE then ran `AmazonClientUploadIT`. This revealed the (expected) failure of my new test as well as the others.

My newly introduced tests succeed, of course, but the aforementioned others still fail when run as described above.