### PR TITLE
Bugfix/issue 133 escape characters in file names

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/KeyEncodingTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/KeyEncodingTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2017-2019 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock;
+
+import static com.adobe.testing.s3mock.FileStoreController.fileNameToObjectName;
+import static com.adobe.testing.s3mock.FileStoreController.objectNameToFileName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+
+public class KeyEncodingTest {
+  @Test
+  public void testKeyEncoding() {
+    assertThat("single char (0x00) encoding", 
+        objectNameToFileName("" + (char) 0x00), equalTo("%0000"));
+    assertThat("single char (':') encoding", 
+        objectNameToFileName(":"), equalTo("%003A"));
+    assertThat("single char (\\u12AB) encoding", 
+        objectNameToFileName("" + (char) 0x12ab), equalTo("%12AB"));
+    assertThat("multiple chars encoding", 
+        objectNameToFileName((char) 0x00 + ":<>%" + (char) 0x7f), 
+        equalTo("%0000%003A%003C%003E%0025%007F"));
+    assertThat("mixed encoding", 
+        objectNameToFileName("foo" + (char) 0x00 + "bar:%baz"), 
+        equalTo("foo%0000bar%003A%0025baz"));
+  }
+  
+  @Test
+  public void testKeyDecoding() {
+    assertThat("single char (0x00) decoding", 
+        fileNameToObjectName("%0000"), equalTo("" + (char) 0x00));
+    assertThat("single char (':') decoding", 
+        fileNameToObjectName("%003A"), equalTo(":"));
+    assertThat("single char (\\u12AB) decoding", 
+        fileNameToObjectName("%12AB"), equalTo("" + (char) 0x12ab));
+    assertThat("multiple chars encoding", 
+        fileNameToObjectName("%0000%003A%003C%003E%0025%007F"), 
+        equalTo((char) 0x00 + ":<>%" + (char) 0x7f));
+    assertThat("mixed encoding", 
+        fileNameToObjectName("foo%0000bar%003A%0025baz"), 
+        equalTo("foo" + (char) 0x00 + "bar:%baz"));
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -78,6 +78,7 @@ import com.amazonaws.services.s3.transfer.model.UploadResult;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
@@ -200,6 +201,33 @@ public class AmazonClientUploadIT extends S3TestBase {
 
     final S3Object s3Object = s3Client.getObject(BUCKET_NAME, uploadFile.getName());
 
+    verifyObjectContent(uploadFile, s3Object);
+  }
+
+  /**
+   * Uses weird, but valid characters in the key used to store an object.
+   * 
+   * @see #shouldUploadAndDownloadObject()
+   * @throws Exception if FileStreams can not be read 
+   */
+  @Test
+  public void shouldTolerateWeirdCharactersInObjectKey() throws Exception {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(BUCKET_NAME);
+
+    String weirdStuff = "\\$%&_+.,~|\"':^😀👍🏻\u0000\u0001";
+    String key = weirdStuff + uploadFile.getName() + weirdStuff;
+
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, key, uploadFile));
+
+    final S3Object s3Object = s3Client.getObject(BUCKET_NAME, key);
+
+    verifyObjectContent(uploadFile, s3Object);
+  }
+
+  private void verifyObjectContent(final File uploadFile, final S3Object s3Object)
+      throws FileNotFoundException, NoSuchAlgorithmException, IOException {
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
     final String uploadHash = HashUtil.getDigest(uploadFileIs);
     final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
@@ -209,7 +237,7 @@ public class AmazonClientUploadIT extends S3TestBase {
     assertThat("Up- and downloaded Files should have equal Hashes", uploadHash,
         is(equalTo(downloadedHash)));
   }
-
+  
   /**
    * Stores a file in a previously created bucket. Downloads the file again and compares checksums
    *


### PR DESCRIPTION
## Description
This PR fixes #133 as well as unit test failures under Windows

The failing tests were related to a slash-flipping-issue in `FileStore.getS3Objects` and have been fixed on the go. For the individual fix see 569bf3961592bee1f.

## Related Issue
#133 
#131 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.