### PR TITLE
Fix #130: exclude ManagementWebSecurityAutoConfiguration by class name

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -65,7 +65,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * File Store Application that mocks Amazon S3.
  */
 @Configuration
-@EnableAutoConfiguration(exclude = {SecurityAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = {SecurityAutoConfiguration.class},
+    /* 
+     * Also exclude ManagementWebSecurityAutoConfiguration, to prevent the
+     * erroneous activation of the CsrfFilter, which would cause access denied
+     * errors upon accesses when spring-boot-actuator is on the class path.
+     * This may be due to a bug in Spring Boot 2.1.2+. For details see 
+     * https://github.com/adobe/S3Mock/issues/130
+     */
+    excludeName = {"org.springframework.boot.actuate.autoconfigure.security.servlet."
+      + "ManagementWebSecurityAutoConfiguration"})
 @ComponentScan
 public class S3MockApplication {
 
@@ -323,7 +332,7 @@ public class S3MockApplication {
     Cache fileStorePagingStateCache() {
       return new ConcurrentMapCache("fileStorePagingStateCache");
     }
-
+    
     String getInitialBuckets() {
       return initialBuckets;
     }

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>spring-security-oauth2</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- included only in order to verify the fix for issue #130 -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description
Exclude `org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration` by class name, in order to prevent an erroneous `CsrfFilter` activation.

## Related Issue
#130 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.

Please note that this time there is no dedicated test case. Instead, `s3mock-junit4`'s POM was modified to include `spring-boot-starter-actuator` which triggers the issue. 