### PR TITLE
Add AWS SDK 2.0 support for JUnit 5

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Nik Gil <https://github.com/nikmanG>
 Artem Prigoda <https://github.com/arteam>
 Clément Mathieu <https://github.com/cykl>
 Alin Pa <https://github.com/alinpa>
+Torben Neufeldt <https://github.com/tenjaa>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <alpine-glibc.image.version>alpine-3.8_glibc-2.28</alpine-glibc.image.version>
 
     <aws.version>1.11.488</aws.version>
+    <aws-v2.version>2.5.24</aws-v2.version>
 
     <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
     <spring-security-oauth2.version>2.3.5.RELEASE</spring-security-oauth2.version>
@@ -101,6 +102,16 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-s3</artifactId>
         <version>${aws.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>s3</artifactId>
+          <version>${aws-v2.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>url-connection-client</artifactId>
+          <version>${aws-v2.version}</version>
       </dependency>
 
       <dependency>

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -40,6 +40,14 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>
+    <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>s3</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>url-connection-client</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/testsupport/junit5/src/main/java/com/adobe/testing/s3mock/junit5/S3MockExtension.java
+++ b/testsupport/junit5/src/main/java/com/adobe/testing/s3mock/junit5/S3MockExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import software.amazon.awssdk.services.s3.S3Client;
 
 /**
  * JUnit extension to start and stop the S3Mock Application. After the tests, the S3Mock is
@@ -93,7 +94,8 @@ public class S3MockExtension extends S3MockStarter implements BeforeAllCallback,
   public boolean supportsParameter(final ParameterContext parameterContext,
       final ExtensionContext extensionContext) throws ParameterResolutionException {
     return paramHasType(parameterContext, S3MockApplication.class)
-        || paramHasType(parameterContext, AmazonS3.class);
+        || paramHasType(parameterContext, AmazonS3.class)
+        || paramHasType(parameterContext, S3Client.class);
   }
 
   @Override
@@ -106,6 +108,10 @@ public class S3MockExtension extends S3MockStarter implements BeforeAllCallback,
 
     if (paramHasType(parameterContext, AmazonS3.class)) {
       return createS3Client();
+    }
+
+    if (paramHasType(parameterContext, S3Client.class)) {
+      return createS3ClientV2();
     }
 
     return null;

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionDeclarativeTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionDeclarativeTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,10 +14,12 @@
  *  limitations under the License.
  */
 
-package com.adobe.testing.s3mock.junit5;
+package com.adobe.testing.s3mock.junit5.sdk1;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.adobe.testing.s3mock.util.HashUtil;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -25,30 +27,28 @@ import com.amazonaws.services.s3.model.S3Object;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Tests and demonstrates the usage of the {@link S3MockExtension}.
+ * Tests and demonstrates the usage of the {@link S3MockExtension} for the SDK v1.
  */
-public class S3MockExtensionProgrammaticTest {
-
-  @RegisterExtension
-  static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent()
-      .withSecureConnection(false).build();
+@ExtendWith(S3MockExtension.class)
+class S3MockExtensionDeclarativeTest {
 
   private static final String BUCKET_NAME = "mydemotestbucket";
   private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
 
-  private final AmazonS3 s3Client = S3_MOCK.createS3Client();
-
   /**
    * Creates a bucket, stores a file, downloads the file again and compares checksums.
+   *
+   * @param s3Client Client injected by the test framework
    *
    * @throws Exception if FileStreams can not be read
    */
   @Test
-  public void shouldUploadAndDownloadObject() throws Exception {
+  void shouldUploadAndDownloadObject(final AmazonS3 s3Client) throws Exception {
     final File uploadFile = new File(UPLOAD_FILE_NAME);
 
     s3Client.createBucket(BUCKET_NAME);
@@ -63,5 +63,14 @@ public class S3MockExtensionProgrammaticTest {
     s3Object.close();
 
     assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+  }
+
+  @Nested
+  class NestedTest {
+
+    @Test
+    void nestedTestShouldNotStartSecondInstanceOfMock(final AmazonS3 s3Client) {
+      assertNotNull(s3Client);
+    }
   }
 }

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionProgrammaticTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  *  limitations under the License.
  */
 
-package com.adobe.testing.s3mock.junit5;
+package com.adobe.testing.s3mock.junit5.sdk1;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.adobe.testing.s3mock.util.HashUtil;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -26,28 +26,30 @@ import com.amazonaws.services.s3.model.S3Object;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * Tests and demonstrates the usage of the {@link S3MockExtension}.
+ * Tests and demonstrates the usage of the {@link S3MockExtension} for the SDK v1.
  */
-@ExtendWith(S3MockExtension.class)
-public class S3MockExtensionDeclarativeTest {
+class S3MockExtensionProgrammaticTest {
+
+  @RegisterExtension
+  static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent()
+      .withSecureConnection(false).build();
 
   private static final String BUCKET_NAME = "mydemotestbucket";
   private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
 
+  private final AmazonS3 s3Client = S3_MOCK.createS3Client();
+
   /**
    * Creates a bucket, stores a file, downloads the file again and compares checksums.
-   *
-   * @param s3Client Client injected by the test framework
    *
    * @throws Exception if FileStreams can not be read
    */
   @Test
-  public void shouldUploadAndDownloadObject(final AmazonS3 s3Client) throws Exception {
+  void shouldUploadAndDownloadObject() throws Exception {
     final File uploadFile = new File(UPLOAD_FILE_NAME);
 
     s3Client.createBucket(BUCKET_NAME);
@@ -62,14 +64,5 @@ public class S3MockExtensionDeclarativeTest {
     s3Object.close();
 
     assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
-  }
-
-  @Nested
-  class NestedTest {
-
-    @Test
-    void nestedTestShouldNotStartSecondInstanceOfMock(final AmazonS3 s3Client) {
-      assertNotNull(s3Client);
-    }
   }
 }

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2017-2019 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.junit5.sdk2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
+import com.adobe.testing.s3mock.util.HashUtil;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Tests and demonstrates the usage of the {@link S3MockExtension}
+ * for the SDK v2.
+ * */
+@ExtendWith(S3MockExtension.class)
+class S3MockExtensionDeclarativeTest {
+
+  private static final String BUCKET_NAME = "mydemotestbucket";
+  private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
+
+  /**
+   * Creates a bucket, stores a file, downloads the file again and compares checksums.
+   *
+   * @param s3Client Client injected by the test framework
+   * @throws Exception if FileStreams can not be read
+   */
+  @Test
+  void shouldUploadAndDownloadObject(final S3Client s3Client) throws Exception {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
+    s3Client.putObject(
+        PutObjectRequest.builder().bucket(BUCKET_NAME).key(uploadFile.getName()).build(),
+        RequestBody.fromFile(uploadFile));
+
+    final ResponseInputStream<GetObjectResponse> response =
+        s3Client.getObject(
+            GetObjectRequest.builder().bucket(BUCKET_NAME).key(uploadFile.getName()).build());
+
+    final InputStream uploadFileIs = new FileInputStream(uploadFile);
+    final String uploadHash = HashUtil.getDigest(uploadFileIs);
+    final String downloadedHash = HashUtil.getDigest(response);
+    uploadFileIs.close();
+    response.close();
+
+    assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+  }
+
+  @Nested
+  class NestedTest {
+
+    @Test
+    void nestedTestShouldNotStartSecondInstanceOfMock(final S3Client s3Client) {
+      assertNotNull(s3Client);
+    }
+  }
+}

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionProgrammaticTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2017-2019 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.junit5.sdk2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
+import com.adobe.testing.s3mock.util.HashUtil;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Tests and demonstrates the usage of the {@link S3MockExtension}
+ * for the SDK v2.
+ * */
+class S3MockExtensionProgrammaticTest {
+
+  @RegisterExtension
+  static final S3MockExtension S3_MOCK =
+      S3MockExtension.builder().silent().withSecureConnection(false).build();
+
+  private static final String BUCKET_NAME = "mydemotestbucket";
+  private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
+
+  private final S3Client s3Client = S3_MOCK.createS3ClientV2();
+
+  /**
+   * Creates a bucket, stores a file, downloads the file again and compares checksums.
+   *
+   * @throws Exception if FileStreams can not be read
+   */
+  @Test
+  void shouldUploadAndDownloadObject() throws Exception {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
+    s3Client.putObject(
+        PutObjectRequest.builder().bucket(BUCKET_NAME).key(uploadFile.getName()).build(),
+        RequestBody.fromFile(uploadFile));
+
+    final ResponseInputStream<GetObjectResponse> response =
+        s3Client.getObject(
+            GetObjectRequest.builder().bucket(BUCKET_NAME).key(uploadFile.getName()).build());
+
+    final InputStream uploadFileIs = new FileInputStream(uploadFile);
+    final String uploadHash = HashUtil.getDigest(uploadFileIs);
+    final String downloadedHash = HashUtil.getDigest(response);
+    uploadFileIs.close();
+    response.close();
+
+    assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+  }
+}


### PR DESCRIPTION
## Description
Amazon released some time ago version 2 of their SDK. This PR adds support for it under JUnit 5.
In case that would be a blocker, I should probably be able to add it to the other test environment too.

## Tasks
Unrelated question: Why is the CLA website only reachable over http?

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
