### PR TITLE
Fixes #145: `Content-encoding` support is missing

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,12 +26,15 @@ class MultipartUploadInfo {
 
   final MultipartUpload upload;
   final String contentType;
+  final String contentEncoding;
   final Map<String, String> userMetadata;
 
   MultipartUploadInfo(final MultipartUpload upload, final String contentType,
+      final String contentEncoding,
       final Map<String, String> userMetadata) {
     this.upload = upload;
     this.contentType = contentType;
+    this.contentEncoding = contentEncoding;
     this.userMetadata = userMetadata;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ public class S3Object {
   private String md5;
 
   private String contentType;
+
+  private String contentEncoding;
 
   private String kmsEncryption;
 
@@ -98,6 +100,14 @@ public class S3Object {
 
   public void setContentType(final String contentType) {
     this.contentType = contentType;
+  }
+
+  public String getContentEncoding() {
+    return contentEncoding;
+  }
+
+  public void setContentEncoding(String contentEncoding) {
+    this.contentEncoding = contentEncoding;
   }
 
   public File getDataFile() {


### PR DESCRIPTION
## Description
`Content-Encoding` was completely missing.
- added content-encoding field
- cleaned up some content-type issues
- modified tests for check of the new functionality

## Related Issue
Fixes #145: `Content-encoding` support is missing

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
