### PR TITLE
accept object tagging via PutObject requests

### DIFF
--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -1000,6 +1000,39 @@ public class AmazonClientUploadIT extends S3TestBase {
   }
 
   /**
+   * Creates a bucket, stores a file with tags, retrieves tags and checks them for consistency.
+   */
+  @Test
+  public void canAddTagsOnPutObject() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+
+    s3Client.createBucket(BUCKET_NAME);
+
+    final List<Tag> tagList = new ArrayList<>();
+    tagList.add(new Tag("foo", "bar"));
+
+    final PutObjectRequest putObjectRequest =
+            new PutObjectRequest(BUCKET_NAME, uploadFile.getName(), uploadFile)
+                    .withTagging(new ObjectTagging(tagList));
+
+    s3Client.putObject(putObjectRequest);
+
+    final S3Object s3Object = s3Client.getObject(BUCKET_NAME, uploadFile.getName());
+
+    GetObjectTaggingRequest getObjectTaggingRequest = new GetObjectTaggingRequest(BUCKET_NAME,
+            s3Object.getKey());
+
+    GetObjectTaggingResult getObjectTaggingResult = s3Client
+            .getObjectTagging(getObjectTaggingRequest);
+
+    // There should be 'foo:bar' here
+    assertThat("Couldn't find that the tag that was placed",
+            getObjectTaggingResult.getTagSet().size(), is(1));
+    assertThat("The vaule of the tag placed did not match",
+            getObjectTaggingResult.getTagSet().get(0).getValue(), is("bar"));
+  }
+
+  /**
    * Creates a bucket, stores a file, get files with eTag requrements.
    */
   @Test


### PR DESCRIPTION
## Description
* add extraction of tags from request to putObject() and putObjectEncrypted()
* add integration test to show it working

## Related Issue
should handle #142 

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html). (signed for Indeed).
- [x] I have written tests and verified that they fail without my change.
