### PR TITLE
Retrieval of MultiPart upload parts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Alin Pa <https://github.com/alinpa>
 Torben Neufeldt <https://github.com/tenjaa>
 Kirill Plyashkevich <https://github.com/412b>
 Aidan Coyne <https://github.com/raptros>
+Lennart Blom <https://github.com/lennartblom>

--- a/pom.xml
+++ b/pom.xml
@@ -131,18 +131,9 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit-jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit-jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <!--

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -59,10 +59,7 @@ import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Part;
 import com.adobe.testing.s3mock.dto.Range;
 import com.adobe.testing.s3mock.dto.Tagging;
-
-import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -977,7 +974,6 @@ class FileStoreController {
     final String filename = filenameFrom(bucketName, request);
 
     final List<Part> parts = fileStore.getMultipartUploadParts(bucketName, filename, uploadId);
-
     return new ListPartsResult(bucketName, filename, uploadId, parts);
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -979,7 +979,6 @@ class FileStoreController {
     final List<Part> parts = fileStore.getMultipartUploadParts(bucketName, filename, uploadId);
 
     return new ListPartsResult(bucketName, filename, uploadId, parts);
-
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -82,7 +82,6 @@ import java.util.stream.Collectors;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.eclipse.jetty.util.TypeUtil;
@@ -973,19 +972,11 @@ class FileStoreController {
       produces = "application/x-www-form-urlencoded")
   public ListPartsResult multipartListParts(@PathVariable final String bucketName,
       @RequestParam final String uploadId,
-      final HttpServletRequest request) throws IOException {
+      final HttpServletRequest request) {
     verifyBucketExistence(bucketName);
     final String filename = filenameFrom(bucketName, request);
 
-    final File[] allParts = fileStore.getMultipartUploadParts(bucketName, filename, uploadId);
-    final Part[] parts = new Part[allParts.length];
-    for (int i = 0; i < allParts.length; i++) {
-      final Part part = new Part();
-      final String hashOfCurrentPart = DigestUtils.md5Hex(new FileInputStream(allParts[i]));
-      part.setEtag(hashOfCurrentPart);
-      part.setPartNumber((i + 1));
-      part.setSize(allParts[i].length());
-    }
+    final List<Part> parts = fileStore.getMultipartUploadParts(bucketName, filename, uploadId);
 
     return new ListPartsResult(bucketName, filename, uploadId, parts);
 

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -664,6 +664,7 @@ public class FileStore {
    * @param bucketName in which to upload
    * @param fileName of the file to upload
    * @param contentType the content type
+   * @param contentEncoding the content encoding
    * @param uploadId id of the upload
    * @param owner owner of the upload
    * @param initiator initiator of the upload
@@ -694,6 +695,7 @@ public class FileStore {
    * @param bucketName in which to upload
    * @param fileName of the file to upload
    * @param contentType the content type
+   * @param contentEncoding the content encoding
    * @param uploadId id of the upload
    * @param owner owner of the upload
    * @param initiator initiator of the upload

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -942,7 +942,6 @@ public class FileStore {
   }
 
   private String calculateHashOfFilePart(final File currentFilePart, final int partNumber) {
-
     try (final InputStream is = FileUtils.openInputStream(currentFilePart)) {
       final String partMd5 = DigestUtils.md5Hex(is);
       return String.format("%s-%s", partMd5, partNumber);

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -931,7 +931,7 @@ public class FileStore {
       final String partMd5 = calculateHashOfFilePart(currentFilePart, partNumber);
 
       final Part part = new Part();
-      part.setEtag(partMd5);
+      part.setETag(partMd5);
       part.setPartNumber((partNumber));
       part.setSize(currentFilePart.length());
 

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -39,10 +38,10 @@ public class ListPartsResult {
   private final String uploadId;
 
   @JsonProperty("PartNumberMarker")
-  private final String partnumber = "0";
+  private final String partNumberMarker = "0";
 
   @JsonProperty("NextPartNumberMarker")
-  private final String nextpartnumber = "1";
+  private final String nextPartNumberMarker = "1";
 
   @JsonProperty("IsTruncated")
   private final boolean truncated = false;
@@ -50,8 +49,8 @@ public class ListPartsResult {
   @JsonProperty("StorageClass")
   private final String storageClass = "STANDARD";
 
-  @JsonProperty("Parts")
-  private final List<Part> parts = new ArrayList<>();
+  @JsonProperty("Part")
+  private final List<Part> part = new ArrayList<>();
 
   /**
    * Constructs a new {@link ListPartsResult}.
@@ -68,6 +67,39 @@ public class ListPartsResult {
     bucket = bucketName;
     key = fileName;
     this.uploadId = uploadId;
-    this.parts.addAll(parts);
+    this.part.addAll(parts);
+  }
+
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getUploadId() {
+    return uploadId;
+  }
+
+  public String getPartNumberMarker() {
+    return partNumberMarker;
+  }
+
+  public String getNextPartNumberMarker() {
+    return nextPartNumberMarker;
+  }
+
+  public boolean isTruncated() {
+    return truncated;
+  }
+
+  public String getStorageClass() {
+    return storageClass;
+  }
+
+  public List<Part> getPart() {
+    return part;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
@@ -64,10 +64,10 @@ public class ListPartsResult {
   public ListPartsResult(final String bucketName,
                          final String fileName,
                          final String uploadId,
-                         final Part... parts) {
+                         final List<Part> parts) {
     bucket = bucketName;
     key = fileName;
     this.uploadId = uploadId;
-    this.parts.addAll(Arrays.asList(parts));
+    this.parts.addAll(parts);
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
@@ -18,7 +18,7 @@ package com.adobe.testing.s3mock.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
-
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +50,8 @@ public class ListPartsResult {
   private final String storageClass = "STANDARD";
 
   @JsonProperty("Part")
-  private final List<Part> part = new ArrayList<>();
+  @JacksonXmlElementWrapper(useWrapping = false)
+  private final List<Part> parts = new ArrayList<>();
 
   /**
    * Constructs a new {@link ListPartsResult}.
@@ -67,7 +68,7 @@ public class ListPartsResult {
     bucket = bucketName;
     key = fileName;
     this.uploadId = uploadId;
-    this.part.addAll(parts);
+    this.parts.addAll(parts);
   }
 
 
@@ -100,6 +101,6 @@ public class ListPartsResult {
   }
 
   public List<Part> getPart() {
-    return part;
+    return parts;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
@@ -19,6 +19,10 @@ package com.adobe.testing.s3mock.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * List-Parts result with some hard-coded values as this is sufficient for now.
  */
@@ -46,16 +50,24 @@ public class ListPartsResult {
   @JsonProperty("StorageClass")
   private final String storageClass = "STANDARD";
 
+  @JsonProperty("Parts")
+  private final List<Part> parts = new ArrayList<>();
+
   /**
    * Constructs a new {@link ListPartsResult}.
    *
    * @param bucketName of the bucket.
    * @param fileName of the file.
    * @param uploadId of the multipart upload.
+   * @param parts bla
    */
-  public ListPartsResult(final String bucketName, final String fileName, final String uploadId) {
+  public ListPartsResult(final String bucketName,
+                         final String fileName,
+                         final String uploadId,
+                         final Part... parts) {
     bucket = bucketName;
     key = fileName;
     this.uploadId = uploadId;
+    this.parts.addAll(Arrays.asList(parts));
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -16,15 +16,19 @@
 
 package com.adobe.testing.s3mock.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import java.util.Date;
 
+@JsonRootName("ListPartsResult")
 public class Part {
 
   @JsonProperty("PartNumber")
   private Integer partNumber;
 
   @JsonProperty("LastModified")
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
   private Date lastModified;
 
   @JsonProperty("ETag")

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -26,10 +26,13 @@ public class Part {
 
   @JsonProperty("PartNumber")
   private Integer partNumber;
+
   @JsonProperty("LastModified")
   private Date lastModified;
+
   @JsonProperty("ETag")
   private String etag;
+
   @JsonProperty("Size")
   private Long size;
 

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -17,11 +17,8 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
-
 import java.util.Date;
 
-@JsonRootName("Parts")
 public class Part {
 
   @JsonProperty("PartNumber")
@@ -52,11 +49,11 @@ public class Part {
     this.lastModified = lastModified;
   }
 
-  public String getEtag() {
+  public String getETag() {
     return etag;
   }
 
-  public void setEtag(final String etag) {
+  public void setETag(final String etag) {
     this.etag = etag;
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2018 Adobe.
+ *  Copyright 2017-2019 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2017-2018 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import java.util.Date;
+
+@JsonRootName("Parts")
+public class Part {
+
+  @JsonProperty("PartNumber")
+  private Integer partNumber;
+  @JsonProperty("LastModified")
+  private Date lastModified;
+  @JsonProperty("ETag")
+  private String etag;
+  @JsonProperty("Size")
+  private Long size;
+
+  public Integer getPartNumber() {
+    return partNumber;
+  }
+
+  public void setPartNumber(Integer partNumber) {
+    this.partNumber = partNumber;
+  }
+
+  public Date getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(Date lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public String getEtag() {
+    return etag;
+  }
+
+  public void setEtag(String etag) {
+    this.etag = etag;
+  }
+
+  public Long getSize() {
+    return size;
+  }
+
+  public void setSize(Long size) {
+    this.size = size;
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -37,7 +37,7 @@ public class Part {
     return partNumber;
   }
 
-  public void setPartNumber(Integer partNumber) {
+  public void setPartNumber(final Integer partNumber) {
     this.partNumber = partNumber;
   }
 
@@ -45,7 +45,7 @@ public class Part {
     return lastModified;
   }
 
-  public void setLastModified(Date lastModified) {
+  public void setLastModified(final Date lastModified) {
     this.lastModified = lastModified;
   }
 
@@ -53,7 +53,7 @@ public class Part {
     return etag;
   }
 
-  public void setEtag(String etag) {
+  public void setEtag(final String etag) {
     this.etag = etag;
   }
 
@@ -61,7 +61,7 @@ public class Part {
     return size;
   }
 
-  public void setSize(Long size) {
+  public void setSize(final Long size) {
     this.size = size;
   }
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -556,7 +556,7 @@ public class FileStoreTest {
   private Part prepareExpectedPart(final int partNumber, final String content,
       final InputStream inputStream) {
     Part part = new Part();
-    part.setEtag(String.format("%s-%s", DigestUtils.md5Hex(content), partNumber));
+    part.setETag(String.format("%s-%s", DigestUtils.md5Hex(content), partNumber));
     part.setPartNumber(partNumber);
     part.setSize((long) content.getBytes().length);
     return part;

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -547,6 +547,10 @@ public class FileStoreTest {
     List<Part> parts = fileStore.getMultipartUploadParts(TEST_BUCKET_NAME, fileName, uploadId);
 
     assertThat("Part quantity does not match", parts.size(), is(2));
+
+    expectedPart1.setLastModified(parts.get(0).getLastModified());
+    expectedPart2.setLastModified(parts.get(1).getLastModified());
+
     assertThat("Part 1 attributes doesn't match", parts.get(0),
         samePropertyValuesAs(expectedPart1));
     assertThat("Part 2 attributes doesn't match", parts.get(1),

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -28,14 +28,17 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 
 import com.adobe.testing.s3mock.dto.MultipartUpload;
 import com.adobe.testing.s3mock.dto.Owner;
+import com.adobe.testing.s3mock.dto.Part;
 import com.adobe.testing.s3mock.util.HashUtil;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,7 +49,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.http.entity.ContentType;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,12 +73,14 @@ public class FileStoreTest {
 
   private static final String TEST_FILE_PATH = "src/test/resources/sampleFile.txt";
 
+  private static final String TEST_MULTIPART_FILE_PATH = "src/test/resources/MultipartSample";
+
   private static final String TEST_ENC_TYPE = "aws:kms";
 
   private static final String TEST_ENC_KEY = "aws:kms" + UUID.randomUUID().toString();
 
   private static final String DEFAULT_CONTENT_TYPE =
-          ContentType.APPLICATION_OCTET_STREAM.toString();
+      ContentType.APPLICATION_OCTET_STREAM.toString();
 
   private static final Owner TEST_OWNER = new Owner(123, "s3-mock-file-store");
 
@@ -184,13 +188,13 @@ public class FileStoreTest {
 
     final S3Object returnedObject =
         fileStore.putS3Object(TEST_BUCKET_NAME, name, null, ENCODING_GZIP,
-                new FileInputStream(sourceFile), false);
+            new FileInputStream(sourceFile), false);
 
     assertThat("Name should be '" + name + "'", returnedObject.getName(), is(name));
     assertThat("ContentType should be '" + "binary/octet-stream" + "'",
-            returnedObject.getContentType(), is("binary/octet-stream"));
+        returnedObject.getContentType(), is("binary/octet-stream"));
     assertThat("ContentEncoding should be '" + ENCODING_GZIP + "'",
-            returnedObject.getContentEncoding(), is(ENCODING_GZIP));
+        returnedObject.getContentEncoding(), is(ENCODING_GZIP));
     assertThat("MD5 should be '" + md5 + "'", returnedObject.getMd5(), is(md5));
     assertThat("Size should be '" + size + "'", returnedObject.getSize(), is(size));
     assertThat("File should not be encrypted!", !returnedObject.isEncrypted());
@@ -275,15 +279,15 @@ public class FileStoreTest {
 
     fileStore
         .putS3Object(TEST_BUCKET_NAME, name, TEXT_PLAIN, ENCODING_GZIP,
-                new FileInputStream(sourceFile), false);
+            new FileInputStream(sourceFile), false);
 
     final S3Object returnedObject = fileStore.getS3Object(TEST_BUCKET_NAME, name);
 
     assertThat("Name should be '" + name + "'", returnedObject.getName(), is(name));
     assertThat("ContentType should be '" + TEXT_PLAIN + "'", returnedObject.getContentType(),
-            is(TEXT_PLAIN));
+        is(TEXT_PLAIN));
     assertThat("ContentEncoding should be '" + ENCODING_GZIP + "'",
-            returnedObject.getContentEncoding(), is(ENCODING_GZIP));
+        returnedObject.getContentEncoding(), is(ENCODING_GZIP));
     assertThat("M5 should be '" + md5 + "'", returnedObject.getMd5(), is(md5));
     assertThat("Size should be '" + size + "'", returnedObject.getSize(), is(size));
     assertThat("File should not be encrypted!", !returnedObject.isEncrypted());
@@ -315,7 +319,6 @@ public class FileStoreTest {
     assertThat("Tag should be present", returnedObject.getTags().get(0).getKey(), is("foo"));
     assertThat("Tag value should be bar", returnedObject.getTags().get(0).getValue(), is("bar"));
   }
-
 
   /**
    * Tests if an object can be copied from one to another bucket.
@@ -394,7 +397,7 @@ public class FileStoreTest {
 
     fileStore
         .putS3Object(TEST_BUCKET_NAME, objectName, TEXT_PLAIN, ENCODING_GZIP,
-                new FileInputStream(sourceFile),false);
+            new FileInputStream(sourceFile), false);
     final boolean objectDeleted = fileStore.deleteObject(TEST_BUCKET_NAME, objectName);
     final S3Object s3Object = fileStore.getS3Object(TEST_BUCKET_NAME, objectName);
 
@@ -415,7 +418,7 @@ public class FileStoreTest {
     fileStore.createBucket(TEST_BUCKET_NAME);
     fileStore
         .putS3Object(TEST_BUCKET_NAME, objectName, TEXT_PLAIN, ENCODING_GZIP,
-                new FileInputStream(sourceFile), false);
+            new FileInputStream(sourceFile), false);
 
     final boolean bucketDeleted = fileStore.deleteBucket(TEST_BUCKET_NAME);
 
@@ -524,6 +527,42 @@ public class FileStoreTest {
   }
 
   @Test
+  void returnsValidPartsFromMultipart() throws IOException {
+    final String fileName = "PartFile";
+    final String uploadId = "12345";
+    String part1 = "Part1";
+    ByteArrayInputStream part1Stream = new ByteArrayInputStream(part1.getBytes());
+    String part2 = "Part2";
+    ByteArrayInputStream part2Stream = new ByteArrayInputStream(part2.getBytes());
+
+    final Part expectedPart1 = prepareExpectedPart(1, part1, part1Stream);
+    final Part expectedPart2 = prepareExpectedPart(2, part2, part2Stream);
+
+    fileStore.prepareMultipartUpload(TEST_BUCKET_NAME, fileName, DEFAULT_CONTENT_TYPE,
+        ENCODING_GZIP, uploadId, TEST_OWNER, TEST_OWNER);
+
+    fileStore.putPart(TEST_BUCKET_NAME, fileName, uploadId, "1", part1Stream, false);
+    fileStore.putPart(TEST_BUCKET_NAME, fileName, uploadId, "2", part2Stream, false);
+
+    List<Part> parts = fileStore.getMultipartUploadParts(TEST_BUCKET_NAME, fileName, uploadId);
+
+    assertThat("Part quantity does not match", parts.size(), is(2));
+    assertThat("Part 1 attributes doesn't match", parts.get(0),
+        samePropertyValuesAs(expectedPart1));
+    assertThat("Part 2 attributes doesn't match", parts.get(1),
+        samePropertyValuesAs(expectedPart2));
+  }
+
+  private Part prepareExpectedPart(final int partNumber, final String content,
+      final InputStream inputStream) {
+    Part part = new Part();
+    part.setEtag(String.format("%s-%s", DigestUtils.md5Hex(content), partNumber));
+    part.setPartNumber(partNumber);
+    part.setSize((long) content.getBytes().length);
+    return part;
+  }
+
+  @Test
   public void deletesTemporaryMultipartUploadFolder() throws Exception {
     final String fileName = "PartFile";
     final String uploadId = "12345";
@@ -625,8 +664,8 @@ public class FileStoreTest {
   public void missingUploadPreparation() {
     IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () -> {
       fileStore.copyPart(
-              TEST_BUCKET_NAME, UUID.randomUUID().toString(), 0, 0, "1",
-              TEST_BUCKET_NAME, UUID.randomUUID().toString(), UUID.randomUUID().toString());
+          TEST_BUCKET_NAME, UUID.randomUUID().toString(), 0, 0, "1",
+          TEST_BUCKET_NAME, UUID.randomUUID().toString(), UUID.randomUUID().toString());
     });
 
     Assertions.assertEquals("Missed preparing Multipart Request", e.getMessage());
@@ -725,7 +764,7 @@ public class FileStoreTest {
             "UTF8");
 
     assertThat(s, contains(rangeClosed(0, 10).mapToObj(Integer::toString)
-        .collect(toList()).toArray(new String[]{})));
+        .collect(toList()).toArray(new String[] {})));
   }
 
   /**

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -55,6 +55,7 @@ import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ListPartsRequest;
 import com.amazonaws.services.s3.model.MultipartUpload;
 import com.amazonaws.services.s3.model.MultipartUploadListing;
 import com.amazonaws.services.s3.model.ObjectListing;
@@ -62,6 +63,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PartListing;
+import com.amazonaws.services.s3.model.PartSummary;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
@@ -90,6 +93,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -843,6 +847,45 @@ public class AmazonClientUploadIT extends S3TestBase {
 
     assertThat("User metadata should be identical!", metadataExisting.getUserMetadata(),
         is(equalTo(objectMetadata.getUserMetadata())));
+  }
+
+  @Test
+  public void shouldInitiateMultipartAndRetrieveParts() throws IOException {
+    s3Client.createBucket(BUCKET_NAME);
+
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+    final ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.addUserMetadata("key", "value");
+
+    final InitiateMultipartUploadResult initiateMultipartUploadResult = s3Client
+        .initiateMultipartUpload(
+            new InitiateMultipartUploadRequest(BUCKET_NAME, UPLOAD_FILE_NAME, objectMetadata));
+    final String uploadId = initiateMultipartUploadResult.getUploadId();
+    final String key = initiateMultipartUploadResult.getKey();
+
+    final UploadPartResult uploadPartResult = s3Client.uploadPart(new UploadPartRequest()
+        .withBucketName(initiateMultipartUploadResult.getBucketName())
+        .withKey(initiateMultipartUploadResult.getKey())
+        .withUploadId(uploadId)
+        .withFile(uploadFile)
+        .withFileOffset(0)
+        .withPartNumber(1)
+        .withPartSize(uploadFile.length())
+        .withLastPart(true));
+
+    ListPartsRequest listPartsRequest = new ListPartsRequest(
+        BUCKET_NAME,
+        key,
+        uploadId
+    );
+    final PartListing partListing = s3Client.listParts(listPartsRequest);
+
+    assertThat("Part listing should be 1", partListing.getParts().size(), is(1));
+    PartSummary partSummary = partListing.getParts().get(0);
+
+    assertThat("Part number should match", partSummary.getPartNumber(), is(1));
+    assertThat("Etag should match", partSummary.getETag(),
+        is(DigestUtils.md5Hex(new FileInputStream(uploadFile))));
   }
 
   /**

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -855,6 +856,8 @@ public class AmazonClientUploadIT extends S3TestBase {
 
     final File uploadFile = new File(UPLOAD_FILE_NAME);
     final ObjectMetadata objectMetadata = new ObjectMetadata();
+    final String hash = DigestUtils.md5Hex(new FileInputStream(uploadFile));
+    final String expectedEtag = String.format("%s-%s", hash, 1);
     objectMetadata.addUserMetadata("key", "value");
 
     final InitiateMultipartUploadResult initiateMultipartUploadResult = s3Client
@@ -883,9 +886,10 @@ public class AmazonClientUploadIT extends S3TestBase {
     assertThat("Part listing should be 1", partListing.getParts().size(), is(1));
     PartSummary partSummary = partListing.getParts().get(0);
 
+    assertThat("Etag should match", partSummary.getETag(), is(expectedEtag));
     assertThat("Part number should match", partSummary.getPartNumber(), is(1));
-    assertThat("Etag should match", partSummary.getETag(),
-        is(DigestUtils.md5Hex(new FileInputStream(uploadFile))));
+    assertThat("LastModified should be valid date", partSummary.getLastModified(), any(Date.class));
+
   }
 
   /**


### PR DESCRIPTION
To adapt to Amazon's S3 behaviour this pull request introduces an implementation of retrieving parts of a prepared S3 MultiPart upload.

**What the pull request includes:**
- new `parts` attribute in `ListPartsResult.java` DTO
- new `Part` class for representing a single S3 MultiPartUpload part
- Functionality getMultipartUploadParts in `FileStore.java` for retrieving the uploaded parts in the directory of the uploaded file
- encapsulation of `File` access in `FileStore.java` via `java.nio.file.Paths`
- Unit Test for retrieving upload parts of a S3 multipart upload (Chunked in 2 parts) -> Build upon `prepareMultipartUpload` 