### PR TITLE
Adds support for response header overrides

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Torben Neufeldt <https://github.com/tenjaa>
 Kirill Plyashkevich <https://github.com/412b>
 Aidan Coyne <https://github.com/raptros>
 Lennart Blom <https://github.com/lennartblom>
+Jan Schygulla <jaschygu@adobe.com>

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.28.0</version>
+          <version>0.30.0</version>
           <configuration>
             <skip>true</skip>
           </configuration>


### PR DESCRIPTION

## Description
<!--- Describe your changes -->
Adds support for response header overrides according to https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html#RESTObjectGET-requests

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
