### PR TITLE
Fixed ambuguity of encrypted copy requests.

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -556,7 +556,8 @@ class FileStoreController {
       value = "/{bucketName:.+}/**",
       headers = {
           SERVER_SIDE_ENCRYPTION,
-          SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID
+          SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID,
+          NOT_COPY_SOURCE
       },
       method = RequestMethod.PUT)
   public ResponseEntity<String> putObjectEncrypted(@PathVariable final String bucketName,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Changed requirements of putObjectEncrypted to not match copy requests.

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
