### PR TITLE
Fixed errors produced when a bucket name lacks a final slash

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -234,7 +234,6 @@ class FileStoreController {
       method = RequestMethod.HEAD)
   public ResponseEntity<String> headObject(@PathVariable final String bucketName,
       final HttpServletRequest request) {
-
     verifyBucketExistence(bucketName);
     final String filename = filenameFrom(bucketName, request);
 
@@ -285,7 +284,6 @@ class FileStoreController {
       @RequestParam(name = "max-keys", defaultValue = "1000",
               required = false) final Integer maxKeys,
       final HttpServletResponse response) throws IOException {
-
     verifyBucketExistence(bucketName);
     if (maxKeys < 0) {
       throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
@@ -558,7 +556,8 @@ class FileStoreController {
       value = "/{bucketName:.+}/**",
       headers = {
           SERVER_SIDE_ENCRYPTION,
-          SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID
+          SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID,
+          NOT_COPY_SOURCE
       },
       method = RequestMethod.PUT)
   public ResponseEntity<String> putObjectEncrypted(@PathVariable final String bucketName,
@@ -703,7 +702,6 @@ class FileStoreController {
       @RequestHeader(value = IF_NONE_MATCH, required = false) final List<String> noMatch,
       final HttpServletRequest request,
       final HttpServletResponse response) throws IOException {
-
     final String filename = filenameFrom(bucketName, request);
 
     verifyBucketExistence(bucketName);

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -234,6 +234,7 @@ class FileStoreController {
       method = RequestMethod.HEAD)
   public ResponseEntity<String> headObject(@PathVariable final String bucketName,
       final HttpServletRequest request) {
+
     verifyBucketExistence(bucketName);
     final String filename = filenameFrom(bucketName, request);
 
@@ -273,7 +274,7 @@ class FileStoreController {
    * @throws IOException IOException If an input or output exception occurs
    */
   @RequestMapping(
-      value = "/{bucketName}/",
+      value = {"/{bucketName}/", "/{bucketName}"},
       method = RequestMethod.GET,
       produces = {"application/x-www-form-urlencoded"})
   @ResponseBody
@@ -284,6 +285,7 @@ class FileStoreController {
       @RequestParam(name = "max-keys", defaultValue = "1000",
               required = false) final Integer maxKeys,
       final HttpServletResponse response) throws IOException {
+
     verifyBucketExistence(bucketName);
     if (maxKeys < 0) {
       throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
@@ -556,8 +558,7 @@ class FileStoreController {
       value = "/{bucketName:.+}/**",
       headers = {
           SERVER_SIDE_ENCRYPTION,
-          SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID,
-          NOT_COPY_SOURCE
+          SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID
       },
       method = RequestMethod.PUT)
   public ResponseEntity<String> putObjectEncrypted(@PathVariable final String bucketName,
@@ -702,6 +703,7 @@ class FileStoreController {
       @RequestHeader(value = IF_NONE_MATCH, required = false) final List<String> noMatch,
       final HttpServletRequest request,
       final HttpServletResponse response) throws IOException {
+
     final String filename = filenameFrom(bucketName, request);
 
     verifyBucketExistence(bucketName);
@@ -1338,11 +1340,10 @@ class FileStoreController {
   private static String filenameFrom(final @PathVariable String bucketName,
       final HttpServletRequest request) {
     final String requestUri = request.getRequestURI();
+    int offset = requestUri.indexOf(bucketName) + bucketName.length() + 1;
     return objectNameToFileName(
-        UrlEncoded.decodeString(
-            requestUri.substring(requestUri.indexOf(bucketName) + bucketName.length() + 1)
-        )
-    );
+            offset < requestUri.length()
+            ? UrlEncoded.decodeString(requestUri.substring(offset)) : "");
   }
 
   /**


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Currently, if a client omits the slash after the bucket name when listing contents, S3Mock will throw an exception.  This patch fixes this bug.

For example, this query has always produced a list of objects:
http://example.com/bucket/?prefix=x

However, this query breaks:
http://example.com/bucket?prefix=x

The latter format, omitting the slash, is used by the "rclone" S3 client.

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
