### PR TITLE
#121 Fix handling of V4 signed requests that don't use chunking.

### DIFF
--- a/server/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
@@ -78,16 +78,17 @@ abstract class S3TestBase {
    */
   @BeforeEach
   public void prepareS3Client() {
-    final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
+    s3Client = defaultTestAmazonS3ClientBuilder().build();
+  }
 
-    s3Client = AmazonS3ClientBuilder.standard()
-        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+  protected AmazonS3ClientBuilder defaultTestAmazonS3ClientBuilder() {
+    return AmazonS3ClientBuilder.standard()
+        .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("foo", "bar")))
         .withClientConfiguration(ignoringInvalidSslCertificates(new ClientConfiguration()))
         .withEndpointConfiguration(
             new AwsClientBuilder.EndpointConfiguration("https://" + getHost() + ":" + getPort(),
                 "us-east-1"))
-        .enablePathStyleAccess()
-        .build();
+        .enablePathStyleAccess();
   }
 
   /**


### PR DESCRIPTION
## Description
The problem was that the code incorrectly assumed that anything signed with a V4 SHA signature is also using the V4 chunked encoding. That's fixed now, and a test was added to check uploading a file with all combinations of signing and chunking enabled/disabled.

## Related Issue
Fixes #107, fixes #121, fixes #147. 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
