### PR TITLE
Fixed list without trailing slash (eg. boto3)

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -275,7 +275,7 @@ class FileStoreController {
    * @throws IOException IOException If an input or output exception occurs
    */
   @RequestMapping(
-      value = "/{bucketName}/",
+      value = "/{bucketName}",
       method = RequestMethod.GET,
       produces = {"application/x-www-form-urlencoded"})
   @ResponseBody

--- a/server/src/test/java/com/adobe/testing/s3mock/its/PlainHttpIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/PlainHttpIT.java
@@ -28,6 +28,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ByteArrayEntity;
@@ -70,6 +71,19 @@ public class PlainHttpIT extends S3TestBase {
     final HttpResponse putObjectResponse =
         httpClient.execute(new HttpHost(getHost(), getHttpPort()), putObject);
     assertThat(putObjectResponse.getStatusLine().getStatusCode(), is(SC_OK));
+  }
+
+  @Test
+  public void listWithPrefixAndMissingSlash() throws IOException {
+    final Bucket targetBucket = s3Client.createBucket(UUID.randomUUID().toString());
+    s3Client.putObject(targetBucket.getName(), "prefix", "Test");
+
+    final HttpGet getObject = new HttpGet(SLASH + targetBucket.getName()
+        + "?prefix=prefix%2F&encoding-type=url");
+
+    final HttpResponse getObjectResponse =
+        httpClient.execute(new HttpHost(getHost(), getHttpPort()), getObject);
+    assertThat(getObjectResponse.getStatusLine().getStatusCode(), is(SC_OK));
   }
 
   @Test


### PR DESCRIPTION
## Description

This fixes a bug that occurs with e.g. boto3 when you list objects in a bucket.
The problem is that the S3Mock expects a listObject request to end with a trailing slash like `127.0.0.1:9090/my-bucket/?prefix=foo%2F&encoding-type=url`.
Unfortunately boto3 will send a request like this: `127.0.0.1:9090/my-bucket?prefix=foo%2F&encoding-type=url`

This changes fixes that behaviour and adds a test to verify it (before a 500 response would be thrown)

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
