### PR TITLE
Honor Marker, NextMarker and IsTruncated parameters in List Objects v1 API

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -47,6 +47,9 @@ public class ListBucketResult implements Serializable {
   @JsonProperty("IsTruncated")
   private boolean isTruncated;
 
+  @JsonProperty("NextMarker")
+  private String nextMarker;
+
   @JsonProperty("Contents")
   @JacksonXmlElementWrapper(useWrapping = false)
   private List<BucketContents> contents;
@@ -69,6 +72,7 @@ public class ListBucketResult implements Serializable {
    * @param marker {@link String}
    * @param maxKeys {@link String}
    * @param isTruncated {@link Boolean}
+   * @param nextMarker {@link String}
    * @param contents {@link List}
    * @param commonPrefixes {@link String}
    */
@@ -77,6 +81,7 @@ public class ListBucketResult implements Serializable {
       final String marker,
       final int maxKeys,
       final boolean isTruncated,
+      final String nextMarker,
       final List<BucketContents> contents,
       final Collection<String> commonPrefixes) {
     this.name = name;
@@ -84,6 +89,7 @@ public class ListBucketResult implements Serializable {
     this.marker = marker;
     this.maxKeys = maxKeys;
     this.isTruncated = isTruncated;
+    this.nextMarker = nextMarker;
     this.contents = new ArrayList<>();
     this.contents.addAll(contents);
     this.commonPrefixes = new CommonPrefixes(commonPrefixes);
@@ -92,6 +98,11 @@ public class ListBucketResult implements Serializable {
   @XmlElement(name = "Name")
   public String getName() {
     return name;
+  }
+
+  @XmlElement(name = "Prefix")
+  public String getPrefix() {
+    return prefix;
   }
 
   @XmlElement(name = "Marker")
@@ -107,6 +118,11 @@ public class ListBucketResult implements Serializable {
   @XmlElement(name = "IsTruncated")
   public boolean isTruncated() {
     return isTruncated;
+  }
+
+  @XmlElement(name = "NextMarker")
+  public String getNextMarker() {
+    return nextMarker;
   }
 
   public List<BucketContents> getContents() {

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2017-2019 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ListObjectV1PaginationIT extends S3TestBase {
+
+  private final String bucketName = "some-bucket";
+
+  @BeforeEach
+  @Override
+  public void prepareS3Client() {
+    super.prepareS3Client();
+    s3Client.createBucket(bucketName);
+    s3Client.putObject(bucketName, "a", "");
+    s3Client.putObject(bucketName, "b", "");
+  }
+
+  @Test
+  public void shouldTruncateAndReturnNextMarker() {
+    final ListObjectsRequest request =
+        new ListObjectsRequest().withBucketName(bucketName).withMaxKeys(1);
+    final ObjectListing objectListing = s3Client.listObjects(request);
+
+    assertEquals(1, objectListing.getObjectSummaries().size());
+    assertEquals(1, objectListing.getMaxKeys());
+    assertEquals("a", objectListing.getNextMarker());
+    assertEquals(true, objectListing.isTruncated());
+
+    final ListObjectsRequest continueRequest = new ListObjectsRequest().withBucketName(bucketName)
+        .withMarker(objectListing.getNextMarker());
+    final ObjectListing continueObjectListing = s3Client.listObjects(continueRequest);
+    assertEquals(1, continueObjectListing.getObjectSummaries().size());
+    assertEquals("b", continueObjectListing.getObjectSummaries().get(0).getKey());
+  }
+}


### PR DESCRIPTION
## Description
Honor **Marker**, **NextMarker** and **IsTruncated** parameters to enable pagination while listing objects

## Related Issue
https://github.com/adobe/S3Mock/issues/166

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
