### PR TITLE
Honoring x-amz-metadata-directive in CopyObject API

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
@@ -16,8 +16,8 @@
 
 package com.adobe.testing.s3mock;
 
-import static com.adobe.testing.s3mock.util.BetterHeaders.SERVER_SIDE_ENCRYPTION;
-import static com.adobe.testing.s3mock.util.BetterHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID;
+import static com.adobe.testing.s3mock.util.AwsHttpHeaders.SERVER_SIDE_ENCRYPTION;
+import static com.adobe.testing.s3mock.util.AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
@@ -18,6 +18,7 @@ package com.adobe.testing.s3mock.domain;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -151,7 +152,7 @@ public class S3Object {
   }
 
   public Map<String, String> getUserMetadata() {
-    return userMetadata;
+    return userMetadata == null ? Collections.emptyMap() : userMetadata;
   }
 
   public void setUserMetadata(final Map<String, String> userMetadata) {

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
@@ -19,7 +19,7 @@ package com.adobe.testing.s3mock.util;
 /**
  * Holds Header used in HTTP requests from AWS S3 Client.
  */
-public final class BetterHeaders {
+public final class AwsHttpHeaders {
 
   private static final String NOT = "!";
 
@@ -37,7 +37,9 @@ public final class BetterHeaders {
   public static final String COPY_SOURCE_RANGE = "x-amz-copy-source-range";
   public static final String NOT_COPY_SOURCE_RANGE = NOT + COPY_SOURCE_RANGE;
 
-  private BetterHeaders() {
+  public static final String METADATA_DIRECTIVE = "x-amz-metadata-directive";
+
+  private AwsHttpHeaders() {
     // empty private constructor
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/util/MetadataUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/MetadataUtil.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2017-2019 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.util;
+
+import com.adobe.testing.s3mock.domain.S3Object;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+
+public final class MetadataUtil {
+
+  private static final String HEADER_X_AMZ_META_PREFIX = "x-amz-meta-";
+
+  /**
+   * Adds user metadata to response headers from S3Object.
+   * @param responseHeaders {@link BiConsumer} representing
+   * {@link org.springframework.http.HttpHeaders#add(String, String)}.
+   * @param s3Object {@link S3Object} S3Object where user metadata will be extracted
+   */
+  public static void addUserMetadata(final BiConsumer<String, String> responseHeaders,
+      final S3Object s3Object) {
+    if (s3Object.getUserMetadata() != null) {
+      s3Object.getUserMetadata().forEach((key, value) ->
+          responseHeaders.accept(HEADER_X_AMZ_META_PREFIX + key, value)
+      );
+    }
+  }
+
+  /**
+   * Retrives user metadata from request.
+   * @param request {@link HttpServletRequest}
+   * @return map containing user meta-data
+   */
+  public static Map<String, String> getUserMetadata(final HttpServletRequest request) {
+    return Collections.list(request.getHeaderNames()).stream()
+        .filter(header -> header.startsWith(HEADER_X_AMZ_META_PREFIX))
+        .collect(Collectors.toMap(
+            header -> header.substring(HEADER_X_AMZ_META_PREFIX.length()),
+            request::getHeader
+        ));
+  }
+}


### PR DESCRIPTION
# Description
1. Copying user-metadata based on **x-amz-metadata-directive** header.
2. Refactored metadata related functionality to a separate class `MetadataUtil`

## TODO

- For header value **REPLACE**, all the content metadata specified through headers (like _content-type_, _cache-control_, _content-encoding_ etc.,) also needs to be replaced not only user-metadata, that would require a bit of refactoring (due to the way in which code is organised currently), can be taken as a separate check-in. In case of **COPY**, source metadata has to be copied which is happening by default already.
Ref: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html

## Related Issue
<!--- if applicable -->
#124 - Issue talks about CopyPart API, although this PR address CopyObject API

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
