### PR TITLE
Non-Empty bucket should not be deleted

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -34,6 +34,7 @@ import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.springframework.http.HttpHeaders.IF_MATCH;
 import static org.springframework.http.HttpHeaders.IF_NONE_MATCH;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NOT_MODIFIED;
@@ -214,6 +215,10 @@ class FileStoreController {
     final boolean deleted;
 
     try {
+      if (!fileStore.getS3Objects(bucketName, null).isEmpty()) {
+        throw new S3Exception(CONFLICT.value(), "BucketNotEmpty",
+            "The bucket you tried to delete is not empty.");
+      }
       deleted = fileStore.deleteBucket(bucketName);
     } catch (final IOException e) {
       LOG.error("Bucket could not be deleted!", e);

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -113,6 +113,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  * Test the application using the AmazonS3 client.
  */
 class AmazonClientUploadIT extends S3TestBase {
+
   /**
    * Verify that buckets can be created and listed.
    */
@@ -378,7 +379,7 @@ class AmazonClientUploadIT extends S3TestBase {
     final String resourceId = randomUUID().toString();
     final String contentEncoding = "gzip";
 
-    final byte[] resource = new byte[] {1, 2, 3, 4, 5};
+    final byte[] resource = new byte[]{1, 2, 3, 4, 5};
     final ByteArrayInputStream bais = new ByteArrayInputStream(resource);
 
     final ObjectMetadata objectMetadata = new ObjectMetadata();
@@ -837,6 +838,20 @@ class AmazonClientUploadIT extends S3TestBase {
   }
 
   /**
+   * Tests that a non-empty bucket cannot be deleted.
+   */
+  @Test
+  void shouldNotDeleteNonEmptyBucket() {
+    final File uploadFile = new File(UPLOAD_FILE_NAME);
+    s3Client.createBucket(BUCKET_NAME);
+
+    s3Client.putObject(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
+
+    assertThat(assertThrows(AmazonS3Exception.class, () -> s3Client.deleteBucket(BUCKET_NAME))
+        .getMessage(), containsString("Status Code: 409; Error Code: BucketNotEmpty"));
+  }
+
+  /**
    * Tests if the list objects can be retrieved.
    *
    * <p>For more detailed tests of the List Objects API see {@link ListObjectIT}.
@@ -1251,7 +1266,7 @@ class AmazonClientUploadIT extends S3TestBase {
 
   private URLConnection openUrlConnection(final URL resourceUrl)
       throws NoSuchAlgorithmException, KeyManagementException, IOException {
-    final TrustManager[] trustAllCerts = new TrustManager[] {
+    final TrustManager[] trustAllCerts = new TrustManager[]{
         new X509TrustManager() {
           @Override
           public X509Certificate[] getAcceptedIssuers() {

--- a/server/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
@@ -102,6 +102,8 @@ abstract class S3TestBase {
             .getMultipartUploads().forEach(upload -> s3Client.abortMultipartUpload(
             new AbortMultipartUploadRequest(bucket.getName(), upload.getKey(),
                 upload.getUploadId())));
+        s3Client.listObjects(bucket.getName()).getObjectSummaries().forEach(
+            (object -> s3Client.deleteObject(bucket.getName(), object.getKey())));
         s3Client.deleteBucket(bucket.getName());
       }
     }


### PR DESCRIPTION
## Description
Non-Empty bucket should not be deleted
Ref: https://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#delete-bucket

## Related Issue
#120 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
