### PR TITLE
Neatened up documentation punctuation

### DIFF
--- a/.travis/travis-release.sh
+++ b/.travis/travis-release.sh
@@ -7,15 +7,15 @@ if [ -z "$DOCKERHUB_PASSWORD" ]; then
   exit 1
 fi
 
-echo "Performing docker login"
+echo "Performing docker login..."
 echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
 
-echo "Importing GPG keys"
+echo "Importing GPG keys..."
 echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
 echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
 
 echo "Checkout master branch explicitly, as we run the release with a in detached head."
 git checkout -qf master;
 
-echo "Starting Maven release"
+echo "Starting Maven release..."
 mvn --settings ./.travis/settings.xml release:prepare release:perform

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Cody Moore <https://github.com/dotCipher>
 Sullis <https://github.com/sullis>
 Nils Plaschke <plaschke@adobe.com>
 Krishna Chaithanya Ganta <ganta@adobe.com>
+Lee Clench <https://github.com/leeclench>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Focusing on what is best for the community.
+* Showing empathy towards other community members.
 
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+advances.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment.
 * Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+  address, without explicit permission.
 * Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+  professional setting.
 
 ## Our Responsibilities
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To build this project, you need Docker, JDK 8 or higher, and Maven:
 
 You can run the S3Mock from the sources by either of the following methods:
 
-* Run or Debug the class `com.adobe.testing.s3mock.S3MockApplication` in the IDE
+* Run or Debug the class `com.adobe.testing.s3mock.S3MockApplication` in the IDE.
 * using Docker:
   * `mvn clean package -pl server -am -DskipTests`
   * `docker run -p 9090:9090 -p 9191:9191 -t adobe/s3mock:latest`


### PR DESCRIPTION
## Description
Amended the following documents:
- Readme
- Code-of-conduct
- travis-release.sh
To add in some missed punctuation within comments and the aforementioned documentation

## Related Issue
N/A

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
