### PR TITLE
Handles trailing slash in `objectNameToFileName`

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -1386,7 +1386,8 @@ class FileStoreController {
 
       // the following characters need escaping
       if (c < ' ' || c >= 0x7f || c == '<' || c == '>' || c == ':' || c == '"' || c == '\\'
-          || c == '|' || c == '?' || c == '*' || c == '.' || c == '%') {
+          || c == '|' || c == '?' || c == '*' || c == '.' || c == '%' || (i == len - 1
+          && c == '/')) {
         if (buffer == null) {
           buffer = new StringBuffer(objectName.length() * 2);
           buffer.append(objectName, 0, i);

--- a/server/src/test/java/com/adobe/testing/s3mock/KeyEncodingTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/KeyEncodingTest.java
@@ -39,6 +39,9 @@ public class KeyEncodingTest {
     assertThat("mixed encoding", 
         objectNameToFileName("foo" + (char) 0x00 + "bar:%baz"), 
         equalTo("foo%0000bar%003A%0025baz"));
+    assertThat("trailing slash encoding",
+        objectNameToFileName("foo/bar/"),
+        equalTo("foo/bar%002F"));
   }
   
   @Test
@@ -49,11 +52,14 @@ public class KeyEncodingTest {
         fileNameToObjectName("%003A"), equalTo(":"));
     assertThat("single char (\\u12AB) decoding", 
         fileNameToObjectName("%12AB"), equalTo("" + (char) 0x12ab));
-    assertThat("multiple chars encoding", 
+    assertThat("multiple chars decoding",
         fileNameToObjectName("%0000%003A%003C%003E%0025%007F"), 
         equalTo((char) 0x00 + ":<>%" + (char) 0x7f));
-    assertThat("mixed encoding", 
+    assertThat("mixed decoding",
         fileNameToObjectName("foo%0000bar%003A%0025baz"), 
         equalTo("foo" + (char) 0x00 + "bar:%baz"));
+    assertThat("trailing slash decoding",
+        fileNameToObjectName("foo/bar%002F"),
+        equalTo("foo/bar/"));
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Handles trailing slash in `objectNameToFileName`
* Adds *trailing slash* tests
* Fixes typo in a few test names

## Related Issue
Closes #165 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
