### PR TITLE
Fixes #181: Listing bucket with a prefix can give wrong results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,9 +212,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.1</version>
           <configuration>
             <quiet>true</quiet>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
           </configuration>
           <executions>
             <execution>

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
@@ -43,7 +43,7 @@ public class ListObjectIT extends S3TestBase {
   private static final String BUCKET_NAME = "list-objects-test";
 
   private static final String[] ALL_OBJECTS =
-      new String[]{"a",
+      new String[]{"3330/0", "33309/0", "a",
           "b", "b/1", "b/1/1", "b/1/2", "b/2",
           "c/1", "c/1/1",
           "d:1", "d:1:1",
@@ -108,7 +108,8 @@ public class ListObjectIT extends S3TestBase {
         // start after existing key
         param("b", null, "b/1/1").keys("b/1/2", "b/2"), //
         // start after non-existing key
-        param("b", null, "b/0").keys("b/1", "b/1/1", "b/1/2", "b/2")
+        param("b", null, "b/0").keys("b/1", "b/1/1", "b/1/2", "b/2"),
+        param("3330/", null, null).keys("3330/0")
     );
   }
 
@@ -175,7 +176,7 @@ public class ListObjectIT extends S3TestBase {
         parameters.startAfter, //
         l.getObjectSummaries().stream().map(s -> URLDecoder.decode(s.getKey()))
             .collect(joining("\n    ")), //
-        l.getCommonPrefixes().stream().collect(joining("\n    ")) //
+            String.join("\n    ", l.getCommonPrefixes()) //
     );
 
     assertThat("Returned keys are correct",


### PR DESCRIPTION
also includes changes to be able to run javadoc on java 11

## Description
Fixes normalization of the prefix

## Related Issue
Fixes #181 

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
