### PR TITLE
Fix some spelling errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `S3MockExtension` can currently be used in two ways:
 
 1. Declaratively using `@ExtendWith(S3MockExtension.class)` and by injecting a properly configured instance of `AmazonS3` client and/or the started `S3MockApplication` to the tests.
 See examples: [`S3MockExtensionDeclarativeTest`](testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionDeclarativeTest.java)  (for SDKv1) 
-or [`S3MockExtensionDeclaritiveTest`](testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java) (for SDKv2)
+or [`S3MockExtensionDeclarativeTest`](testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java) (for SDKv2)
 
 1. Programmatically using `@RegisterExtension` and by creating and configuring the `S3MockExtension` using a _builder_.
 See examples: [`S3MockExtensionProgrammaticTest`](testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionProgrammaticTest.java) (for SDKv1)

--- a/build-config/src/main/resources/build-config/checkstyle.xml
+++ b/build-config/src/main/resources/build-config/checkstyle.xml
@@ -26,7 +26,7 @@
 
     Changes AbbreviationAsWordInName#allowedAbbreviationLength to '4'
     - to enable Integration Test type names ending with 'IT'
-    - supporting existing interace methods like registerKMSKeyRef
+    - supporting existing interface methods like registerKMSKeyRef
  -->
 
 <module name="Checker">

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -1025,11 +1025,11 @@ class FileStoreController {
 
     // delimiter / prefix search not supported
     final String delimiter = null;
-    final List<String> commmonPrefixes = Collections.emptyList();
+    final List<String> commonPrefixes = Collections.emptyList();
 
     return new ListMultipartUploadsResult(bucketName, keyMarker, delimiter, prefix, uploadIdMarker,
         maxUploads, isTruncated, nextKeyMarker, nextUploadIdMarker, multipartUploads,
-        commmonPrefixes);
+        commonPrefixes);
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
@@ -42,7 +42,7 @@ public class Owner {
    * Constructs a new {@link Owner}.
    *
    * @param id of the owner.
-   * @param displayName name of ther owner.
+   * @param displayName name of the owner.
    */
   public Owner(final long id, final String displayName) {
     this.id = id;

--- a/server/src/main/java/com/adobe/testing/s3mock/util/MetadataUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/MetadataUtil.java
@@ -43,7 +43,7 @@ public final class MetadataUtil {
   }
 
   /**
-   * Retrives user metadata from request.
+   * Retrieves user metadata from request.
    * @param request {@link HttpServletRequest}
    * @return map containing user meta-data
    */

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -317,7 +317,7 @@ class AmazonClientUploadIT extends S3TestBase {
     final ListObjectsRequest lor = new ListObjectsRequest(BUCKET_NAME, prefix, null, null, null);
     lor.setEncodingType(""); // don't use encoding
 
-    // we expect an SdkClientException wich a message pointing to XML
+    // we expect an SdkClientException with a message pointing to XML
     // parsing issues.
     assertThat(assertThrows(SdkClientException.class, () -> s3Client.listObjects(lor)).getMessage(),
         containsString("Failed to parse XML document")
@@ -343,7 +343,7 @@ class AmazonClientUploadIT extends S3TestBase {
     lorv2.setPrefix(prefix);
     lorv2.setEncodingType(""); // don't use encoding
 
-    // we expect an SdkClientException wich a message pointing to XML
+    // we expect an SdkClientException with a message pointing to XML
     // parsing issues.
     assertThat(
         assertThrows(SdkClientException.class, () -> s3Client.listObjectsV2(lorv2)).getMessage(),
@@ -848,7 +848,7 @@ class AmazonClientUploadIT extends S3TestBase {
     final ObjectListing objectListingResult =
         s3Client.listObjects(BUCKET_NAME, UPLOAD_FILE_NAME);
 
-    assertThat("ObjectListinig has no S3Objects.",
+    assertThat("ObjectListing has no S3Objects.",
         objectListingResult.getObjectSummaries().size(),
         is(greaterThan(0)));
     assertThat("The Name of the first S3ObjectSummary item has not expected the key name.",
@@ -980,7 +980,7 @@ class AmazonClientUploadIT extends S3TestBase {
     // There should be 'foo:bar' here
     assertThat("Couldn't find that the tag that was placed",
         getObjectTaggingResult.getTagSet().size(), is(1));
-    assertThat("The vaule of the tag placed did not match",
+    assertThat("The value of the tag placed did not match",
         getObjectTaggingResult.getTagSet().get(0).getValue(), is("bar"));
   }
 
@@ -1013,12 +1013,12 @@ class AmazonClientUploadIT extends S3TestBase {
     // There should be 'foo:bar' here
     assertThat("Couldn't find that the tag that was placed",
         getObjectTaggingResult.getTagSet().size(), is(1));
-    assertThat("The vaule of the tag placed did not match",
+    assertThat("The value of the tag placed did not match",
         getObjectTaggingResult.getTagSet().get(0).getValue(), is("bar"));
   }
 
   /**
-   * Creates a bucket, stores a file, get files with eTag requrements.
+   * Creates a bucket, stores a file, get files with eTag requirements.
    */
   @Test
   void shouldCreateAndRespectEtag() throws Exception {
@@ -1052,10 +1052,10 @@ class AmazonClientUploadIT extends S3TestBase {
     final String uploadHash = HashUtil.getDigest(uploadFileIs);
 
     assertThat("The uploaded file and the recived file should be the same, "
-            + "when requeting file which matchin eTag given same eTag",
+            + "when requesting file with matching eTag given same eTag",
         uploadHash, is(equalTo(s3ObjectWithEtagDownloadedHash)));
     assertThat("The uploaded file and the recived file should be the same, "
-            + "when requeting file with  non-matchin eTag but given different eTag",
+            + "when requesting file with  non-matching eTag but given different eTag",
         uploadHash, is(equalTo(s3ObjectWithHoutEtagDownloadedHash)));
 
     // wit eTag

--- a/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
+++ b/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
@@ -111,7 +111,7 @@ public abstract class S3MockStarter {
         .withCredentials(new AWSStaticCredentialsProvider(credentials))
         .withClientConfiguration(
             configureClientToIgnoreInvalidSslCertificates(new ClientConfiguration()))
-        .withEndpointConfiguration(getEndpointCongiguration(region))
+        .withEndpointConfiguration(getEndpointConfiguration(region))
         .enablePathStyleAccess()
         .build();
   }
@@ -152,7 +152,7 @@ public abstract class S3MockStarter {
     return clientConfiguration;
   }
 
-  protected EndpointConfiguration getEndpointCongiguration(final String region) {
+  protected EndpointConfiguration getEndpointConfiguration(final String region) {
     return new EndpointConfiguration(getServiceEndpoint(), region);
   }
 


### PR DESCRIPTION
## Description

This PR fixes some spelling errors (mostly code comments, test descriptions, etc.), IMHO a purely cosmetic/non-functional change.

commmon -> common (2x)
congiguration -> configuration (2x)
declaritive -> declarative (1x)
interace -> interface (1x)
listinig -> listing (1x)
matchin -> matching (2x)
requrements -> requirements (1x)
requeting -> requesting (2x)
retrives -> retrieves (1x)
ther -> the (1x)
vaule -> value (2x)
wich -> with (2x)

## Related Issue

n/a

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.

This PR is purely cosmetic => adding a test doesn't apply. In general, one could add a (source code-aware) spell checker to the CI test suite.
