### PR TITLE
kms-key-ref can be empty

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
@@ -29,6 +29,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 class KmsValidationFilter extends OncePerRequestFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(KmsValidationFilter.class);
+
+  private static final String AWS_KMS = "aws:kms";
 
   private final KmsKeyStore keystore;
 
@@ -67,7 +70,9 @@ class KmsValidationFilter extends OncePerRequestFilter {
       final String encryptionTypeHeader = request.getHeader(SERVER_SIDE_ENCRYPTION);
       final String encryptionKeyRef = request.getHeader(SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID);
 
-      if ("aws:kms".equals(encryptionTypeHeader) && !keystore.validateKeyRef(encryptionKeyRef)) {
+      if (AWS_KMS.equals(encryptionTypeHeader)
+          && !StringUtils.isBlank(encryptionKeyRef)
+          && !keystore.validateKeyRef(encryptionKeyRef)) {
         LOG.debug("Received invalid key, sending error response.");
 
         request.getInputStream().close();

--- a/server/src/test/java/com/adobe/testing/s3mock/its/PlainHttpIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/PlainHttpIT.java
@@ -78,6 +78,18 @@ public class PlainHttpIT extends S3TestBase {
   }
 
   @Test
+  public void putObjectEncryptedWithAbsentKeyRef() throws IOException {
+    final Bucket targetBucket = s3Client.createBucket(UUID.randomUUID().toString());
+    final HttpPut putObject = new HttpPut(SLASH + targetBucket.getName());
+    putObject.addHeader("x-amz-server-side-encryption", "aws:kms");
+    putObject.setEntity(new ByteArrayEntity(UUID.randomUUID().toString().getBytes()));
+
+    final HttpResponse putObjectResponse =
+        httpClient.execute(new HttpHost(getHost(), getHttpPort()), putObject);
+    assertThat(putObjectResponse.getStatusLine().getStatusCode(), is(SC_OK));
+  }
+
+  @Test
   public void listWithPrefixAndMissingSlash() throws IOException {
     final Bucket targetBucket = s3Client.createBucket(UUID.randomUUID().toString());
     s3Client.putObject(targetBucket.getName(), "prefix", "Test");
@@ -141,7 +153,7 @@ public class PlainHttpIT extends S3TestBase {
   public void headObjectWithUnknownContentType() throws IOException {
     final Bucket targetBucket = s3Client.createBucket(UUID.randomUUID().toString());
 
-    byte[] contentAsBytes = new byte[0];
+    final byte[] contentAsBytes = new byte[0];
     final ObjectMetadata md = new ObjectMetadata();
     md.setContentLength(contentAsBytes.length);
     md.setContentType(UUID.randomUUID().toString());


### PR DESCRIPTION
## Description

If request header `x-amz-server-side-encryption:aws:kms` is given, but `x-amz-server-side-encryption-aws-kms-key-id` isn't, the request will be accepted.

## Related Issue

https://github.com/adobe/S3Mock/issues/190

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
