### PR TITLE
More Specific Response Content Type

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -164,7 +164,7 @@ class FileStoreController {
    * @return a list of all Buckets
    */
   @RequestMapping(value = "/", method = RequestMethod.GET, produces = {
-      "application/x-www-form-urlencoded"})
+      "application/xml"})
   @ResponseBody
   public ListAllMyBucketsResult listBuckets() {
     return new ListAllMyBucketsResult(TEST_OWNER, fileStore.listBuckets());
@@ -288,7 +288,7 @@ class FileStoreController {
   @RequestMapping(
       value = "/{bucketName}",
       method = RequestMethod.GET,
-      produces = {"application/x-www-form-urlencoded"})
+      produces = {"application/xml"})
   @ResponseBody
   public ListBucketResult listObjectsInsideBucket(@PathVariable final String bucketName,
       @RequestParam(required = false) final String prefix,
@@ -397,7 +397,7 @@ class FileStoreController {
    */
   @RequestMapping(value = "/{bucketName}", params = "list-type=2",
       method = RequestMethod.GET,
-      produces = {"application/x-www-form-urlencoded"})
+      produces = {"application/xml"})
   @ResponseBody
   public ListBucketResultV2 listObjectsInsideBucketV2(@PathVariable final String bucketName,
       @RequestParam(required = false) final String prefix,
@@ -625,7 +625,7 @@ class FileStoreController {
           COPY_SOURCE,
           NOT_SERVER_SIDE_ENCRYPTION
       },
-      produces = "application/x-www-form-urlencoded; charset=utf-8")
+      produces = "application/xml; charset=utf-8")
   @ResponseBody
   public CopyObjectResult copyObject(@PathVariable final String destinationBucket,
       @RequestHeader(value = COPY_SOURCE) final ObjectRef objectRef,
@@ -665,7 +665,7 @@ class FileStoreController {
           COPY_SOURCE,
           SERVER_SIDE_ENCRYPTION
       },
-      produces = "application/x-www-form-urlencoded; charset=utf-8")
+      produces = "application/xml; charset=utf-8")
   @ResponseBody
   public CopyObjectResult copyObject(@PathVariable final String destinationBucket,
       @RequestHeader(value = COPY_SOURCE) final ObjectRef objectRef,
@@ -725,7 +725,7 @@ class FileStoreController {
   @RequestMapping(
       value = "/{bucketName:.+}/**",
       method = RequestMethod.GET,
-      produces = "application/x-www-form-urlencoded")
+      produces = "application/xml")
   public void getObject(@PathVariable final String bucketName,
       @RequestHeader(value = RANGE, required = false) final Range range,
       @RequestHeader(value = IF_MATCH, required = false) final List<String> match,
@@ -843,7 +843,7 @@ class FileStoreController {
       value = "/{bucketName}",
       params = "delete",
       method = RequestMethod.POST,
-      produces = {"application/x-www-form-urlencoded"})
+      produces = {"application/xml"})
   public BatchDeleteResponse batchDeleteObjects(@PathVariable final String bucketName,
       @RequestBody final BatchDeleteRequest body) {
     verifyBucketExistence(bucketName);
@@ -939,7 +939,7 @@ class FileStoreController {
       value = "/{bucketName:.+}/**",
       params = "uploads",
       method = RequestMethod.POST,
-      produces = "application/x-www-form-urlencoded")
+      produces = "application/xml")
   public InitiateMultipartUploadResult initiateMultipartUpload(
       @PathVariable final String bucketName,
       final HttpServletRequest request) {
@@ -967,7 +967,7 @@ class FileStoreController {
           SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID
       },
       method = RequestMethod.POST,
-      produces = "application/x-www-form-urlencoded")
+      produces = "application/xml")
   public InitiateMultipartUploadResult initiateMultipartUpload(
       @PathVariable final String bucketName,
       @RequestHeader(value = SERVER_SIDE_ENCRYPTION) final String encryption,
@@ -1002,7 +1002,7 @@ class FileStoreController {
       value = "/{bucketName:.+}/",
       params = {"uploads"},
       method = RequestMethod.GET,
-      produces = "application/x-www-form-urlencoded")
+      produces = "application/xml")
   public ListMultipartUploadsResult listMultipartUploads(@PathVariable final String bucketName,
       @RequestParam(required = false) final String prefix,
       @RequestParam final String /*unused */ uploads) {
@@ -1044,7 +1044,7 @@ class FileStoreController {
       value = "/{bucketName:.+}/**",
       params = {"uploadId"},
       method = RequestMethod.DELETE,
-      produces = "application/x-www-form-urlencoded")
+      produces = "application/xml")
   public void abortMultipartUpload(@PathVariable final String bucketName,
       @RequestParam final String uploadId,
       final HttpServletRequest request) {
@@ -1068,7 +1068,7 @@ class FileStoreController {
       value = "/{bucketName:.+}/**",
       params = {"uploadId"},
       method = RequestMethod.GET,
-      produces = "application/x-www-form-urlencoded")
+      produces = "application/xml")
   public ListPartsResult multipartListParts(@PathVariable final String bucketName,
       @RequestParam final String uploadId,
       final HttpServletRequest request) {


### PR DESCRIPTION

## Description
Some of the S3Mock endoints return a `application/x-www-form-urlencoded` Content-Type, which is ignored by most clients but is HTTP specification wise not correct. The AWS API spec doesn't explicitly describe the Content-Type, but the the actual response body is XML and the Content-Type `application/octet-stream`

Some strict clients (e.g. Akka HTTP, Alpakka), correctly reject parsing a Content-Type of `application/x-www-form-urlencoded` as XML, but rather expect `application/octet-stream` or `application/xml`.

I've tried changing the Content-Type to `application/octet-stream`, but the Spring Framework always returns a `400 - Bad Request` then in the IT tests. I couldn't figure out why, but my guess is that it doesn't know that this response should be marshalled XML. Changing the Content-Type to return `application/xml` works on the other hand. Both, the IT tests and the Akka HTTP client are happy then. I know that's not ideal as it's not an accurate implementation of the S3 API, but I'd argue it is still more correct than the current implementation.

## Related Issue
https://github.com/adobe/S3Mock/issues/35

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
