### PR TITLE
Format the object dates with the correct timezone. Fixes #203

### DIFF
--- a/HOWTO_PUBLISH_FORK.md
+++ b/HOWTO_PUBLISH_FORK.md
@@ -1,0 +1,4 @@
+* `mvn versions:set -DnewVersion=2.1.19-datadobi-X`
+* `mvn clean`
+* `mvn deploy -Durl=https://mavenserver.dobi:8081/artifactory/libs-release-local -DrepositoryId=datadobi`
+* `mvn versions:set -DnewVersion=2.1.19-datadobi-(X+1)-SNAPSHOT`

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.1.19-SNAPSHOT</version>
+    <version>2.1.19-datadobi-1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.1.19-datadobi-1</version>
+    <version>2.1.19-datadobi-2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.1.19-datadobi-2</version>
+    <version>2.1.19-datadobi-3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/build-config/src/main/resources/build-config/checkstyle.xml
+++ b/build-config/src/main/resources/build-config/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>2.1.19-datadobi-1</version>
+  <version>2.1.19-datadobi-2</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>2.1.19-datadobi-2</version>
+  <version>2.1.19-datadobi-3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>2.1.19-SNAPSHOT</version>
+  <version>2.1.19-datadobi-1</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>
@@ -37,12 +37,12 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>datadobi</id>
+      <url>http://mavenserver.dobi:8081/artifactory/libs-snapshot-local</url>
     </snapshotRepository>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>datadobi</id>
+      <url>http://mavenserver.dobi:8081/artifactory/libs-release-local</url>
     </repository>
   </distributionManagement>
 
@@ -246,19 +246,19 @@
             <tagNameFormat>@{project.version}</tagNameFormat>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.8</version>
-          <extensions>true</extensions>
-          <configuration>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            <nexusUrl>
-              https://oss.sonatype.org/
-            </nexusUrl>
-            <serverId>ossrh</serverId>
-          </configuration>
-        </plugin>
+<!--        <plugin>-->
+<!--          <groupId>org.sonatype.plugins</groupId>-->
+<!--          <artifactId>nexus-staging-maven-plugin</artifactId>-->
+<!--          <version>1.6.8</version>-->
+<!--          <extensions>true</extensions>-->
+<!--          <configuration>-->
+<!--            <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
+<!--            <nexusUrl>-->
+<!--              https://oss.sonatype.org/-->
+<!--            </nexusUrl>-->
+<!--            <serverId>ossrh</serverId>-->
+<!--          </configuration>-->
+<!--        </plugin>-->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M3</version>
@@ -387,10 +387,10 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.sonatype.plugins</groupId>-->
+<!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
+<!--      </plugin>-->
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-2</version>
+    <version>2.1.19-datadobi-3-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-1</version>
+    <version>2.1.19-datadobi-2</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-SNAPSHOT</version>
+    <version>2.1.19-datadobi-1</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/src/main/docker/Dockerfile
+++ b/server/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017-2019 Adobe.
+#  Copyright 2017-2020 Adobe.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -273,8 +273,7 @@ class FileStoreController {
   }
 
   /**
-   * Retrieve list of objects of a bucket see http://docs.aws.amazon
-   * .com/AmazonS3/latest/API/RESTBucketGET.html
+   * Retrieve list of objects of a bucket see http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
    *
    * @param bucketName {@link String} set bucket name
    * @param prefix {@link String} find object names they starts with prefix
@@ -291,9 +290,9 @@ class FileStoreController {
       produces = {"application/xml"})
   @ResponseBody
   public ListBucketResult listObjectsInsideBucket(@PathVariable final String bucketName,
-      @RequestParam(required = false) final String prefix,
+      @RequestParam(required = false) String prefix,
       @RequestParam(required = false) final String delimiter,
-      @RequestParam(required = false) final String marker,
+      @RequestParam(required = false) String marker,
       @RequestParam(name = "encoding-type", required = false) final String encodingtype,
       @RequestParam(name = "max-keys", defaultValue = "1000",
           required = false) final Integer maxKeys,
@@ -331,6 +330,9 @@ class FileStoreController {
 
       if (useUrlEncoding) {
         contents = applyUrlEncoding(contents);
+        marker = marker != null ? UrlEncoded.encodeString(marker) : null;
+        nextMarker = nextMarker != null ? UrlEncoded.encodeString(nextMarker) : null;
+        prefix = prefix != null ? UrlEncoded.encodeString(prefix) : null;
       }
 
       return new ListBucketResult(bucketName, prefix, marker, maxKeys, isTruncated, nextMarker,
@@ -403,10 +405,10 @@ class FileStoreController {
       @RequestParam(required = false) final String prefix,
       @RequestParam(required = false) final String delimiter,
       @RequestParam(name = "encoding-type", required = false) final String encodingtype,
-      @RequestParam(name = "start-after", required = false) final String startAfter,
+      @RequestParam(name = "start-after", required = false) String startAfter,
       @RequestParam(name = "max-keys",
           defaultValue = "1000", required = false) final String maxKeysParam,
-      @RequestParam(name = "continuation-token", required = false) final String continuationToken,
+      @RequestParam(name = "continuation-token", required = false) String continuationToken,
       final HttpServletResponse response) throws IOException {
     if (!StringUtils.isEmpty(encodingtype) && !"url".equals(encodingtype)) {
       throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
@@ -453,6 +455,10 @@ class FileStoreController {
 
       if (useUrlEncoding) {
         filteredContents = applyUrlEncoding(filteredContents);
+        startAfter = startAfter != null ? UrlEncoded.encodeString(startAfter) : null;
+        continuationToken = continuationToken != null
+                ? UrlEncoded.encodeString(continuationToken)
+                : null;
       }
 
       return new ListBucketResultV2(bucketName, prefix, maxKeysParam,

--- a/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/KmsValidationFilter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/Bucket.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/Bucket.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/BucketContents.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/BucketContents.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/Buckets.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/Buckets.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -44,7 +44,8 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -75,8 +76,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class FileStore {
 
-  private static final SimpleDateFormat S3_OBJECT_DATE_FORMAT =
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.000Z'");
+  private static final DateTimeFormatter S3_OBJECT_DATE_FORMAT = DateTimeFormatter
+          .ofPattern("yyyy-MM-dd'T'HH:mm:ss'.000Z'")
+          .withZone(ZoneId.of("UTC"));
 
   private static final String META_FILE = "metadata";
   private static final String DATA_FILE = "fileData";
@@ -186,7 +188,7 @@ public class FileStore {
       result =
           new Bucket(path,
               path.getFileName().toString(),
-              S3_OBJECT_DATE_FORMAT.format(new Date(attributes.creationTime().toMillis())));
+              S3_OBJECT_DATE_FORMAT.format(attributes.creationTime().toInstant()));
     } catch (final IOException e) {
       LOG.error("File can not be read!", e);
     }
@@ -260,9 +262,9 @@ public class FileStore {
     final BasicFileAttributes attributes =
         Files.readAttributes(dataFile.toPath(), BasicFileAttributes.class);
     s3Object.setCreationDate(
-        S3_OBJECT_DATE_FORMAT.format(new Date(attributes.creationTime().toMillis())));
+        S3_OBJECT_DATE_FORMAT.format(attributes.creationTime().toInstant()));
     s3Object.setModificationDate(
-        S3_OBJECT_DATE_FORMAT.format(new Date(attributes.lastModifiedTime().toMillis())));
+        S3_OBJECT_DATE_FORMAT.format(attributes.lastModifiedTime().toInstant()));
     s3Object.setLastModified(attributes.lastModifiedTime().toMillis());
 
     s3Object.setMd5(digest(null, dataFile));
@@ -355,9 +357,9 @@ public class FileStore {
     final BasicFileAttributes attributes =
         Files.readAttributes(dataFile.toPath(), BasicFileAttributes.class);
     s3Object.setCreationDate(
-        S3_OBJECT_DATE_FORMAT.format(new Date(attributes.creationTime().toMillis())));
+        S3_OBJECT_DATE_FORMAT.format(attributes.creationTime().toInstant()));
     s3Object.setModificationDate(
-        S3_OBJECT_DATE_FORMAT.format(new Date(attributes.lastModifiedTime().toMillis())));
+        S3_OBJECT_DATE_FORMAT.format(attributes.lastModifiedTime().toInstant()));
     s3Object.setLastModified(attributes.lastModifiedTime().toMillis());
 
     s3Object.setMd5(digest(kmsKeyId, dataFile));
@@ -930,9 +932,9 @@ public class FileStore {
         final BasicFileAttributes attributes =
             Files.readAttributes(entireFile.toPath(), BasicFileAttributes.class);
         s3Object.setCreationDate(S3_OBJECT_DATE_FORMAT.format(
-            new Date(attributes.creationTime().toMillis())));
+                attributes.creationTime().toInstant()));
         s3Object.setModificationDate(S3_OBJECT_DATE_FORMAT.format(
-            new Date(attributes.lastModifiedTime().toMillis())));
+                attributes.lastModifiedTime().toInstant()));
         s3Object.setLastModified(attributes.lastModifiedTime().toMillis());
         s3Object.setMd5(DigestUtils.md5Hex(allMd5s) + "-" + partNames.length);
         s3Object.setSize(Long.toString(size));

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/KmsKeyStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/KmsKeyStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/S3Exception.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/S3Exception.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/S3Object.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/Tag.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/Tag.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteRequest.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteResponse.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/BatchDeleteResponse.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CommonPrefixes.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CommonPrefixes.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CopyObjectResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CopyObjectResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/DeletedObject.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/DeletedObject.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ErrorResponse.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListPartsResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Range.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Range.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Tagging.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Tagging.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsChunkDecodingInputStream.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsChunkDecodingInputStream.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/util/HashUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/HashUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/util/MetadataUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/MetadataUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/util/ObjectRefConverter.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/ObjectRefConverter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/util/RangeConverter.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/RangeConverter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/util/S3MockExceptionHandler.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/S3MockExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017-2019 Adobe.
+#  Copyright 2017-2020 Adobe.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/KeyEncodingTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/KeyEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/RangeConverterTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/RangeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/FileStoreTest.java
@@ -61,7 +61,9 @@ import org.springframework.http.MediaType;
 
 public class FileStoreTest {
 
-  private static final DateTimeFormatter DATE_TIME_PARSER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'.000Z'").withZone(ZoneId.of("UTC"));
+  private static final DateTimeFormatter DATE_TIME_PARSER = DateTimeFormatter
+          .ofPattern("yyyy-MM-dd'T'HH:mm:ss'.000Z'")
+          .withZone(ZoneId.of("UTC"));
 
   private static final String SIGNED_CONTENT =
       "24;chunk-signature=11707b33deb094881a16c70e9cbd5d79053a0bb235c25674e3cf0fed601683b5\r\n"
@@ -209,7 +211,8 @@ public class FileStoreTest {
         is(contentOf(returnedObject.getDataFile(), UTF_8)));
 
     assertThat("The modification time should be formatted with the appropriate timezone",
-            toInstant(returnedObject.getModificationDate(), ChronoUnit.SECONDS), is(toInstant(returnedObject.getLastModified(), ChronoUnit.SECONDS)));
+            toInstant(returnedObject.getModificationDate(), ChronoUnit.SECONDS),
+            is(toInstant(returnedObject.getLastModified(), ChronoUnit.SECONDS)));
   }
 
   /**
@@ -798,7 +801,10 @@ public class FileStoreTest {
   }
 
   private static Instant toInstant(String dateString, ChronoUnit precision) {
-    return DATE_TIME_PARSER.parse(dateString, temporal -> Instant.from(temporal).truncatedTo(precision));
+    return DATE_TIME_PARSER.parse(
+        dateString,
+        temporal -> Instant.from(temporal).truncatedTo(precision)
+    );
   }
 
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/domain/ObjectRefTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/domain/ObjectRefTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/CopyPartResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/CopyPartResultTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
@@ -79,7 +79,7 @@ public class ListObjectIT extends S3TestBase {
 
     @Override
     public String toString() {
-      return String.format("prefix=%s, delimiter=%s", prefix, delimiter);
+      return String.format("prefix=%s, delimiter=%s, startAfter=%s", prefix, delimiter, startAfter);
     }
   }
 
@@ -109,7 +109,8 @@ public class ListObjectIT extends S3TestBase {
         param("b", null, "b/1/1").keys("b/1/2", "b/2"), //
         // start after non-existing key
         param("b", null, "b/0").keys("b/1", "b/1/1", "b/1/2", "b/2"),
-        param("3330/", null, null).keys("3330/0")
+        param("3330/", null, null).keys("3330/0"),
+        param(null, null, "!%-_.*,()").keys(ALL_OBJECTS)
     );
   }
 

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/MultiPartUploadIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/MultiPartUploadIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/PlainHttpIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/PlainHttpIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/adobe/testing/s3mock/util/EtagInputStream.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/util/EtagInputStream.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/test/resources/logback.xml
+++ b/server/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-SNAPSHOT</version>
+    <version>2.1.19-datadobi-1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-2</version>
+    <version>2.1.19-datadobi-3-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-1</version>
+    <version>2.1.19-datadobi-2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
+++ b/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/common/src/test/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarterTest.java
+++ b/testsupport/common/src/test/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-SNAPSHOT</version>
+    <version>2.1.19-datadobi-1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-2</version>
+    <version>2.1.19-datadobi-3-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-1</version>
+    <version>2.1.19-datadobi-2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit4/src/main/java/com/adobe/testing/s3mock/junit4/S3MockRule.java
+++ b/testsupport/junit4/src/main/java/com/adobe/testing/s3mock/junit4/S3MockRule.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/junit4/src/test/java/com/adobe/testing/s3mock/junit4/S3MockRuleTest.java
+++ b/testsupport/junit4/src/test/java/com/adobe/testing/s3mock/junit4/S3MockRuleTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-SNAPSHOT</version>
+    <version>2.1.19-datadobi-1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-2</version>
+    <version>2.1.19-datadobi-3-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.1.19-datadobi-1</version>
+    <version>2.1.19-datadobi-2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/junit5/src/main/java/com/adobe/testing/s3mock/junit5/S3MockExtension.java
+++ b/testsupport/junit5/src/main/java/com/adobe/testing/s3mock/junit5/S3MockExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionDeclarativeTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionDeclarativeTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionProgrammaticTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionProgrammaticTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.testing</groupId>
         <artifactId>s3mock-parent</artifactId>
-        <version>2.1.19-datadobi-2</version>
+        <version>2.1.19-datadobi-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.testing</groupId>
         <artifactId>s3mock-parent</artifactId>
-        <version>2.1.19-SNAPSHOT</version>
+        <version>2.1.19-datadobi-1</version>
     </parent>
 
     <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.testing</groupId>
         <artifactId>s3mock-parent</artifactId>
-        <version>2.1.19-datadobi-1</version>
+        <version>2.1.19-datadobi-2</version>
     </parent>
 
     <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.1.19-datadobi-2</version>
+    <version>2.1.19-datadobi-3-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.1.19-SNAPSHOT</version>
+    <version>2.1.19-datadobi-1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>s3mock-parent</artifactId>
     <groupId>com.adobe.testing</groupId>
-    <version>2.1.19-datadobi-1</version>
+    <version>2.1.19-datadobi-2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
+++ b/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3Mock.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3MockListener.java
+++ b/testsupport/testng/src/main/java/com/adobe/testing/s3mock/testng/S3MockListener.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXmlConfigurationTest.java
+++ b/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXmlConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2020 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/testsupport/testng/src/test/resources/testng.xml
+++ b/testsupport/testng/src/test/resources/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2019 Adobe.
+     Copyright 2017-2020 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Use the thread-safe `java.time.format.DateTimeFormatter` with the correct timezone to format the S3-object related times.

## Related Issue
#203 

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
