### PR TITLE
Fix accidental JDK9+ bytecode dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
+    <java.version>8</java.version>
 
     <adoptopenjdk11.image.version>jdk-11.0.3_7-alpine</adoptopenjdk11.image.version>
     <alpine-glibc.image.version>alpine-3.9_glibc-2.29</alpine-glibc.image.version>
@@ -188,8 +188,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
-            <source>${java.version}</source>
-            <target>${java.version}</target>
+            <release>${java.version}</release>
             <encoding>${project.build.sourceEncoding}</encoding>
           </configuration>
         </plugin>
@@ -216,7 +215,7 @@
           <configuration>
             <quiet>true</quiet>
             <source>${java.version}</source>
-            <target>${java.version}</target>
+            <detectJavaApiLink>false</detectJavaApiLink>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
## Description

Source/Target parameters were deprecated in JDK8 and can cause errors when running bytecode compiled in JDK9+ on JDKs lower than JDK9.
Use newly added `release` parameter instead.

## Related Issue
See #243 where @HackerTheMonkey analysed this issue pretty thoroughly, and the official documentation:
https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-77874D97-46F3-4DB5-85E4-2ACB5F8D760B

Fixes #243

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
