### PR TITLE
Add encodingType as return parameter of ListObjects and ListObjectsV2

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -334,8 +334,8 @@ class FileStoreController {
         contents = applyUrlEncoding(contents);
       }
 
-      return new ListBucketResult(bucketName, prefix, marker, maxKeys, isTruncated, nextMarker,
-          contents, commonPrefixes);
+      return new ListBucketResult(bucketName, prefix, marker, maxKeys, isTruncated, encodingtype,
+          nextMarker, contents, commonPrefixes);
     } catch (final IOException e) {
       LOG.error(String.format("Object(s) could not retrieved from bucket %s", bucketName));
       response.sendError(500, e.getMessage());
@@ -459,7 +459,7 @@ class FileStoreController {
       return new ListBucketResultV2(bucketName, prefix, maxKeysParam,
           isTruncated, filteredContents, commonPrefixes,
           continuationToken, String.valueOf(filteredContents.size()),
-          nextContinuationToken, startAfter);
+          nextContinuationToken, startAfter, encodingtype);
     } catch (final IOException e) {
       LOG.error(String.format("Object(s) could not retrieved from bucket %s", bucketName));
       response.sendError(500, e.getMessage());

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2020 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -47,6 +47,9 @@ public class ListBucketResult implements Serializable {
   @JsonProperty("IsTruncated")
   private boolean isTruncated;
 
+  @JsonProperty("EncodingType")
+  private String encodingType;
+
   @JsonProperty("NextMarker")
   private String nextMarker;
 
@@ -72,6 +75,7 @@ public class ListBucketResult implements Serializable {
    * @param marker {@link String}
    * @param maxKeys {@link String}
    * @param isTruncated {@link Boolean}
+   * @param encodingType {@link String}
    * @param nextMarker {@link String}
    * @param contents {@link List}
    * @param commonPrefixes {@link String}
@@ -81,6 +85,7 @@ public class ListBucketResult implements Serializable {
       final String marker,
       final int maxKeys,
       final boolean isTruncated,
+      final String encodingType,
       final String nextMarker,
       final List<BucketContents> contents,
       final Collection<String> commonPrefixes) {
@@ -89,6 +94,7 @@ public class ListBucketResult implements Serializable {
     this.marker = marker;
     this.maxKeys = maxKeys;
     this.isTruncated = isTruncated;
+    this.encodingType = encodingType;
     this.nextMarker = nextMarker;
     this.contents = new ArrayList<>();
     this.contents.addAll(contents);
@@ -118,6 +124,11 @@ public class ListBucketResult implements Serializable {
   @XmlElement(name = "IsTruncated")
   public boolean isTruncated() {
     return isTruncated;
+  }
+
+  @XmlElement(name = "EncodingType")
+  public String getEncodingType() {
+    return encodingType;
   }
 
   @XmlElement(name = "NextMarker")

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -63,6 +63,9 @@ public class ListBucketResultV2 implements Serializable {
   @JsonProperty("StartAfter")
   private String startAfter;
 
+  @JsonProperty("EncodingType")
+  private String encodingType;
+
   /**
    * Constructs a new {@link ListBucketResultV2}.
    */
@@ -83,11 +86,13 @@ public class ListBucketResultV2 implements Serializable {
    * @param keyCount {@link String}
    * @param nextContinuationToken {@link String}
    * @param startAfter {@link String}
+   * @param encodingType {@link String}
    */
   public ListBucketResultV2(final String name, final String prefix, final String maxKeys,
       final boolean isTruncated, final List<BucketContents> contents,
       final Collection<String> commonPrefixes, final String continuationToken,
-      final String keyCount, final String nextContinuationToken, final String startAfter) {
+      final String keyCount, final String nextContinuationToken, final String startAfter,
+      final String encodingType) {
     this.name = name;
     this.prefix = prefix;
     this.maxKeys = Integer.valueOf(maxKeys);
@@ -99,6 +104,7 @@ public class ListBucketResultV2 implements Serializable {
     this.keyCount = keyCount;
     this.nextContinuationToken = nextContinuationToken;
     this.startAfter = startAfter;
+    this.encodingType = encodingType;
   }
 
   @XmlElement(name = "Name")
@@ -146,5 +152,10 @@ public class ListBucketResultV2 implements Serializable {
   @XmlElement(name = "StartAfter")
   public String getStartAfter() {
     return startAfter;
+  }
+
+  @XmlElement(name = "EncodingType")
+  public String getEncodingType() {
+    return encodingType;
   }
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/its/ListObjectIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
This PR adds the encoding type in the return of the ListObjects and ListObjectsV2.
It's adding some tests for verifying that the encoding type is null if not specified or "url" if it is specified.

## Related Issue
https://github.com/adobe/S3Mock/issues/199

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
