### PR TITLE
Fix encoded responses for aws-cli

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Krishna Chaithanya Ganta <ganta@adobe.com>
 Lee Clench <https://github.com/leeclench>
 Vladimir Sitnikov <https://github.com/vlsi>
 Florian Froese <https://github.com/froesef>
+Arne Franken <https://github.com/afranken>

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResult.java
@@ -17,6 +17,7 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.adobe.testing.s3mock.domain.BucketContents;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -30,6 +31,7 @@ import javax.xml.bind.annotation.XmlElement;
  * Represents a result of listing objects that reside in a Bucket.
  */
 @JsonRootName("ListBucketResult")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ListBucketResult implements Serializable {
 
   @JsonProperty("Name")
@@ -98,7 +100,8 @@ public class ListBucketResult implements Serializable {
     this.nextMarker = nextMarker;
     this.contents = new ArrayList<>();
     this.contents.addAll(contents);
-    this.commonPrefixes = new CommonPrefixes(commonPrefixes);
+    this.commonPrefixes = commonPrefixes == null || commonPrefixes.isEmpty() ? null :
+        new CommonPrefixes(commonPrefixes);
   }
 
   @XmlElement(name = "Name")

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ListBucketResultV2.java
@@ -17,6 +17,7 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.adobe.testing.s3mock.domain.BucketContents;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -30,6 +31,7 @@ import javax.xml.bind.annotation.XmlElement;
  * Represents a result of listing objects that reside in a Bucket.
  */
 @JsonRootName("ListBucketResult")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ListBucketResultV2 implements Serializable {
 
   @JsonProperty("Name")
@@ -95,11 +97,12 @@ public class ListBucketResultV2 implements Serializable {
       final String encodingType) {
     this.name = name;
     this.prefix = prefix;
-    this.maxKeys = Integer.valueOf(maxKeys);
+    this.maxKeys = Integer.parseInt(maxKeys);
     this.isTruncated = isTruncated;
     this.contents = new ArrayList<>();
     this.contents.addAll(contents);
-    this.commonPrefixes = new CommonPrefixes(commonPrefixes);
+    this.commonPrefixes = commonPrefixes == null || commonPrefixes.isEmpty() ? null :
+        new CommonPrefixes(commonPrefixes);
     this.continuationToken = continuationToken;
     this.keyCount = keyCount;
     this.nextContinuationToken = nextContinuationToken;


### PR DESCRIPTION
## Description
aws-cli expects no empty elements in encoded responses and will fail
the request if it encounters an empty element.
At least aws-java-sdk V1 and V2 worked fine with the current
implementation, though.

Add Arne Franken to AUTHORS

## Related Issue
#257

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
