### PR TITLE
Adds serialization tests for the DTO layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <license-maven-plugin-git.version>3.0</license-maven-plugin-git.version>
     <checkstyle.version>8.44</checkstyle.version>
     <testng.version>7.4.0</testng.version>
+    <xmlunit-assertj3.version>2.8.2</xmlunit-assertj3.version>
   </properties>
 
   <modules>
@@ -135,7 +136,11 @@
         <artifactId>testng</artifactId>
         <version>${testng.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.xmlunit</groupId>
+        <artifactId>xmlunit-assertj3</artifactId>
+        <version>${xmlunit-assertj3.version}</version>
+      </dependency>
       <!--
           S3 Mock doesn't need spring-security-oauth2. We ran into trouble
           when dependency was on classpath where server did not accept any

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -119,6 +119,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-assertj3</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/MultipartUpload.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class MultipartUpload {
   @JsonProperty("StorageClass")
   private final String storageClass = "STANDARD";
   @JsonProperty("Initiated")
-  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   private final Date initiated;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Part.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2020 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class Part {
   private Integer partNumber;
 
   @JsonProperty("LastModified")
-  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   private Date lastModified;
 
   @JsonProperty("ETag")

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/BatchDeleteResponseTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/BatchDeleteResponseTest.java
@@ -17,28 +17,23 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
-
+class BatchDeleteResponseTest {
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    BatchDeleteResponse iut = new BatchDeleteResponse();
+    int count = 2;
+    for (int i = 0; i < count; i++) {
+      DeletedObject deletedObject = new DeletedObject();
+      deletedObject.setKey("key" + i);
+      deletedObject.setVersionId("versionId" + i);
+      iut.addDeletedObject(deletedObject);
+    }
 
     serializeAndAssert(iut, testInfo);
   }
-
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResultTest.java
@@ -17,28 +17,17 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
-
+class CompleteMultipartUploadResultTest {
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    CompleteMultipartUploadResult iut =
+        new CompleteMultipartUploadResult("location", "bucket", "key", "etag");
 
     serializeAndAssert(iut, testInfo);
   }
-
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/CopyObjectResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/CopyObjectResultTest.java
@@ -17,28 +17,17 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
-
+class CopyObjectResultTest {
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    CopyObjectResult iut =
+        new CopyObjectResult("2017-12-28T16:03:28.120Z", "99f2fdceebf20fb2e891810adfb0eb71");
 
     serializeAndAssert(iut, testInfo);
   }
-
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/DtoTestUtil.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/DtoTestUtil.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2017-2021 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import static org.apache.commons.lang3.StringUtils.replace;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.TestInfo;
+import org.xmlunit.assertj3.XmlAssert;
+
+class DtoTestUtil {
+
+  private static final ObjectMapper MAPPER = new XmlMapper();
+
+  static void serializeAndAssert(Object iut, TestInfo testInfo) throws IOException {
+    String out = MAPPER.writeValueAsString(iut);
+    assertThat(out).isNotNull();
+    String expected = getExpected(testInfo);
+    XmlAssert.assertThat(out).and(expected)
+        .ignoreChildNodesOrder()
+        .ignoreWhitespace()
+        .ignoreComments()
+        .areIdentical();
+  }
+
+  /**
+   * Reads a test file like "ListBucketResultV2Test_testSerialization.xml" and returns its contents
+   */
+  static String getExpected(TestInfo testInfo) throws IOException {
+    Class<?> testClass = testInfo.getTestClass().get();
+    String packageName = testClass.getPackage().getName();
+    String className = testClass.getSimpleName();
+    String methodName = testInfo.getTestMethod().get().getName();
+    String fileName =
+        String.format("%s/%s_%s.xml", replace(packageName, ".", "/"), className, methodName);
+
+    ClassLoader classLoader = testClass.getClassLoader();
+    File file = new File(classLoader.getResource(fileName).getFile());
+    return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ErrorResponseTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ErrorResponseTest.java
@@ -17,28 +17,20 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
-
+class ErrorResponseTest {
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    ErrorResponse iut = new ErrorResponse();
+    iut.setCode("code");
+    iut.setMessage("message");
+    iut.setRequestId("requestId");
+    iut.setResource("resource");
 
     serializeAndAssert(iut, testInfo);
   }
-
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResultTest.java
@@ -17,28 +17,17 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
-
+class InitiateMultipartUploadResultTest {
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    InitiateMultipartUploadResult iut =
+        new InitiateMultipartUploadResult("bucketName", "fileName", "uploadId");
 
     serializeAndAssert(iut, testInfo);
   }
-
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResultTest.java
@@ -17,28 +17,32 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
+import com.adobe.testing.s3mock.domain.Bucket;
 import java.io.IOException;
-import java.util.Date;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
+class ListAllMyBucketsResultTest {
 
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    ListAllMyBucketsResult iut =
+        new ListAllMyBucketsResult(new Owner(10L, "displayName"), createBuckets(2));
 
     serializeAndAssert(iut, testInfo);
+  }
+
+  private List<Bucket> createBuckets(int count) {
+    List<Bucket> buckets = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      Bucket bucket = new Bucket(Paths.get("/tmp/foo"), "name", "creationDate");
+      buckets.add(bucket);
+    }
+    return buckets;
   }
 
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultTest.java
@@ -17,28 +17,35 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
+import com.adobe.testing.s3mock.domain.BucketContents;
 import java.io.IOException;
-import java.util.Date;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
+class ListBucketResultTest {
 
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    ListBucketResult iut =
+        new ListBucketResult("bucketName", "prefix/", "marker", 1000, false, "url", "nextMarker",
+            createBucketContents(2), Arrays.asList("prefix1/", "prefix2/"));
 
     serializeAndAssert(iut, testInfo);
   }
 
+  private List<BucketContents> createBucketContents(int count) {
+    List<BucketContents> bucketContentsList = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      BucketContents bucketContents =
+          new BucketContents("key" + i, "2009-10-12T17:50:30.000Z",
+              "fba9dede5f27731c9771645a39863328", "434234", "STANDARD",
+              new Owner(10L + i, "displayName"));
+      bucketContentsList.add(bucketContents);
+    }
+    return bucketContentsList;
+  }
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultV2Test.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultV2Test.java
@@ -17,28 +17,36 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
+import com.adobe.testing.s3mock.domain.BucketContents;
 import java.io.IOException;
-import java.util.Date;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
+class ListBucketResultV2Test {
 
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    ListBucketResultV2 iut =
+        new ListBucketResultV2("bucketName", "prefix/", "1000", false, createBucketContents(2),
+            Arrays.asList("prefix1/", "prefix2/"), "continuationToken", "2",
+            "nextContinuationToken", "startAfter", "url");
 
     serializeAndAssert(iut, testInfo);
   }
 
+  private List<BucketContents> createBucketContents(int count) {
+    List<BucketContents> bucketContentsList = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      BucketContents bucketContents =
+          new BucketContents("key" + i, "2009-10-12T17:50:30.000Z",
+              "fba9dede5f27731c9771645a39863328", "434234", "STANDARD",
+              new Owner(10L + i, "displayName"));
+      bucketContentsList.add(bucketContents);
+    }
+    return bucketContentsList;
+  }
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResultTest.java
@@ -17,28 +17,37 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
-
+class ListMultipartUploadsResultTest {
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    ListMultipartUploadsResult iut =
+        new ListMultipartUploadsResult("bucketName", "keyMarker", "/", "prefix/", "uploadIdMarker",
+            2, false,
+            "nextKeyMarker", "nextUploadIdMarker", createMultipartUploads(2),
+            Arrays.asList("prefix1/", "prefix2/"));
 
     serializeAndAssert(iut, testInfo);
   }
 
+  private List<MultipartUpload> createMultipartUploads(int count) {
+    List<MultipartUpload> multipartUploads = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      MultipartUpload multipartUpload =
+          new MultipartUpload("key" + i, "uploadId" + i,
+              new Owner(10L + i, "displayName10" + i),
+              new Owner(100L + i, "displayName100" + i),
+              new Date(1514477008120L));
+      multipartUploads.add(multipartUpload);
+    }
+    return multipartUploads;
+  }
 }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListPartsResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListPartsResultTest.java
@@ -17,28 +17,35 @@
 package com.adobe.testing.s3mock.dto;
 
 import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class CopyPartResultTest {
-
-  @Test
-  public void testCreationFromDate() {
-    final CopyPartResult result = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
-    assertThat(result.getLastModified()).isEqualTo("2017-12-28T16:03:28.120Z");
-  }
+class ListPartsResultTest {
 
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
-    CopyPartResult iut = CopyPartResult
-        .from(new Date(1514477008120L), "99f2fdceebf20fb2e891810adfb0eb71");
+    ListPartsResult iut =
+        new ListPartsResult("bucketName", "fileName", "uploadId",
+            createParts(2));
 
     serializeAndAssert(iut, testInfo);
   }
 
+  private List<Part> createParts(int count) {
+    List<Part> parts = new ArrayList<>();
+    for (int i = 1; i <= count; i++) {
+      Part part = new Part();
+      part.setPartNumber(i);
+      part.setETag("etag" + i);
+      part.setLastModified(new Date(1514477008120L));
+      part.setSize(10L + i);
+      parts.add(part);
+    }
+    return parts;
+  }
 }

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/BatchDeleteResponseTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/BatchDeleteResponseTest_testSerialization.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<DeleteResult>
+  <Deleted>
+    <Key>key0</Key>
+    <VersionId>versionId0</VersionId>
+  </Deleted>
+  <Deleted>
+    <Key>key1</Key>
+    <VersionId>versionId1</VersionId>
+  </Deleted>
+</DeleteResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResultTest_testSerialization.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<CompleteMultipartUploadResult>
+  <Location>location</Location>
+  <Bucket>bucket</Bucket>
+  <Key>key</Key>
+  <ETag>etag</ETag>
+</CompleteMultipartUploadResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/CopyObjectResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/CopyObjectResultTest_testSerialization.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<CopyObjectResult>
+  <LastModified>2017-12-28T16:03:28.120Z</LastModified>
+  <ETag>99f2fdceebf20fb2e891810adfb0eb71</ETag>
+</CopyObjectResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/CopyPartResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/CopyPartResultTest_testSerialization.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<CopyPartResult>
+  <LastModified>2017-12-28T16:03:28.120Z</LastModified>
+  <ETag>99f2fdceebf20fb2e891810adfb0eb71</ETag>
+</CopyPartResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ErrorResponseTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ErrorResponseTest_testSerialization.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<Error>
+  <Code>code</Code>
+  <Message>message</Message>
+  <Resource>resource</Resource>
+  <RequestId>requestId</RequestId>
+</Error>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/InitiateMultipartUploadResultTest_testSerialization.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<InitiateMultipartUploadResult>
+  <Bucket>bucketName</Bucket>
+  <Key>fileName</Key>
+  <UploadId>uploadId</UploadId>
+</InitiateMultipartUploadResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ListAllMyBucketsResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ListAllMyBucketsResultTest_testSerialization.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<ListAllMyBucketsResult>
+  <Owner>
+    <ID>10</ID>
+    <DisplayName>displayName</DisplayName>
+  </Owner>
+  <Buckets>
+    <Bucket>
+      <path>file:///tmp/foo</path>
+      <Name>name</Name>
+      <CreationDate>creationDate</CreationDate>
+    </Bucket>
+    <Bucket>
+      <path>file:///tmp/foo</path>
+      <Name>name</Name>
+      <CreationDate>creationDate</CreationDate>
+    </Bucket>
+  </Buckets>
+</ListAllMyBucketsResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultTest_testSerialization.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<ListBucketResult>
+  <truncated>false</truncated>
+  <Name>bucketName</Name>
+  <Prefix>prefix/</Prefix>
+  <Marker>marker</Marker>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <EncodingType>url</EncodingType>
+  <NextMarker>nextMarker</NextMarker>
+  <Contents>
+    <Key>key0</Key>
+    <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <Size>434234</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>10</ID>
+      <DisplayName>displayName</DisplayName>
+    </Owner>
+  </Contents>
+  <Contents>
+    <Key>key1</Key>
+    <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <Size>434234</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>11</ID>
+      <DisplayName>displayName</DisplayName>
+    </Owner>
+  </Contents>
+  <CommonPrefixes>
+    <Prefix>prefix1/</Prefix>
+    <Prefix>prefix2/</Prefix>
+  </CommonPrefixes>
+</ListBucketResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultV2Test_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultV2Test_testSerialization.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<ListBucketResult>
+  <truncated>false</truncated>
+  <Name>bucketName</Name>
+  <Prefix>prefix/</Prefix>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>key0</Key>
+    <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <Size>434234</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>10</ID>
+      <DisplayName>displayName</DisplayName>
+    </Owner>
+  </Contents>
+  <Contents>
+    <Key>key1</Key>
+    <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <Size>434234</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>11</ID>
+      <DisplayName>displayName</DisplayName>
+    </Owner>
+  </Contents>
+  <CommonPrefixes>
+    <Prefix>prefix1/</Prefix>
+    <Prefix>prefix2/</Prefix>
+  </CommonPrefixes>
+  <ContinuationToken>continuationToken</ContinuationToken>
+  <KeyCount>2</KeyCount>
+  <NextContinuationToken>nextContinuationToken</NextContinuationToken>
+  <StartAfter>startAfter</StartAfter>
+  <EncodingType>url</EncodingType>
+</ListBucketResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ListMultipartUploadsResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ListMultipartUploadsResultTest_testSerialization.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<ListMultipartUploadsResult>
+  <Bucket>bucketName</Bucket>
+  <KeyMarker>keyMarker</KeyMarker>
+  <Delimiter>/</Delimiter>
+  <Prefix>prefix/</Prefix>
+  <UploadIdMarker>uploadIdMarker</UploadIdMarker>
+  <MaxUploads>2</MaxUploads>
+  <IsTruncated>false</IsTruncated>
+  <NextKeyMarker>nextKeyMarker</NextKeyMarker>
+  <NextUploadIdMarker>nextUploadIdMarker</NextUploadIdMarker>
+  <Upload>
+    <Key>key0</Key>
+    <UploadId>uploadId0</UploadId>
+    <Owner>
+      <ID>10</ID>
+      <DisplayName>displayName100</DisplayName>
+    </Owner>
+    <Initiator>
+      <ID>100</ID>
+      <DisplayName>displayName1000</DisplayName>
+    </Initiator>
+    <StorageClass>STANDARD</StorageClass>
+    <Initiated>2017-12-28T16:03:28.120Z</Initiated>
+  </Upload>
+  <Upload>
+    <Key>key1</Key>
+    <UploadId>uploadId1</UploadId>
+    <Owner>
+      <ID>11</ID>
+      <DisplayName>displayName101</DisplayName>
+    </Owner>
+    <Initiator>
+      <ID>101</ID>
+      <DisplayName>displayName1001</DisplayName>
+    </Initiator>
+    <StorageClass>STANDARD</StorageClass>
+    <Initiated>2017-12-28T16:03:28.120Z</Initiated>
+  </Upload>
+  <CommonPrefixes>
+    <prefix>prefix1/</prefix>
+  </CommonPrefixes>
+  <CommonPrefixes>
+    <prefix>prefix2/</prefix>
+  </CommonPrefixes>
+</ListMultipartUploadsResult>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ListPartsResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ListPartsResultTest_testSerialization.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2021 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<ListPartsResult>
+  <part>
+    <part>
+      <PartNumber>1</PartNumber>
+      <LastModified>2017-12-28T16:03:28.120Z</LastModified>
+      <ETag>etag1</ETag>
+      <Size>11</Size>
+    </part>
+    <part>
+      <PartNumber>2</PartNumber>
+      <LastModified>2017-12-28T16:03:28.120Z</LastModified>
+      <ETag>etag2</ETag>
+      <Size>12</Size>
+    </part>
+  </part>
+  <Bucket>bucketName</Bucket>
+  <Key>fileName</Key>
+  <UploadId>uploadId</UploadId>
+  <PartNumberMarker>0</PartNumberMarker>
+  <NextPartNumberMarker>1</NextPartNumberMarker>
+  <IsTruncated>false</IsTruncated>
+  <StorageClass>STANDARD</StorageClass>
+  <Part>
+    <PartNumber>1</PartNumber>
+    <LastModified>2017-12-28T16:03:28.120Z</LastModified>
+    <ETag>etag1</ETag>
+    <Size>11</Size>
+  </Part>
+  <Part>
+    <PartNumber>2</PartNumber>
+    <LastModified>2017-12-28T16:03:28.120Z</LastModified>
+    <ETag>etag2</ETag>
+    <Size>12</Size>
+  </Part>
+</ListPartsResult>


### PR DESCRIPTION
## Description
This only adds tests and serialized responses to see what changes when
refactoring the code.

There are several issues with the current serialization:
Typos in fields. (e.g. "prefix" instead of "Prefix")
Superfluous fields (e.g. "truncated" or "part")
Some lists are not serialized correctly, as can be seen in
currently open issues.
Several types are not enforced, where fields in the POJOs are Strings
which should be Integer or enum.
Etag fields contain quoted values in all Amazon examples, while in
our serialization, they are all unquoted.
Date field serialization seems to be broken right now. Also, for dates,
we should be using "java.time" classes in favor of "java.util.Date".

## Related Issue
There are several issues dealing with serialization issues, e.g. #215

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
