### PR TITLE
Set a new Github release on tag push

### DIFF
--- a/.github/workflows/create-release-from-tag.yml
+++ b/.github/workflows/create-release-from-tag.yml
@@ -1,0 +1,32 @@
+#
+#  Copyright 2017-2021 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# For more information see: https://github.com/marketplace/actions/github-create-tag-release
+
+on:
+  push:
+    branches: [ main ]
+name: Release
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub Create Tag Release
+        uses: Roang-zero1/github-create-release-action@v2.1.0
+        with:
+          version_regex: ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## v2.1.34
+## 2.1.34
 
 * ETag value now enclosed in quotation marks
 * All dates are formatted in UTC timezone (Fixes #203)
 * "CommonPrefixes" are now serialized als multiple elements containing one "Prefix" (Fixes #215)
 * Removed several superfluous / erroneous elements like "truncated" or "part" from various responses
 
-## v2.1.33
+## 2.1.33
 
 * Updated spring-boot to 2.3.12.RELEASE
 * Updated aws-java-sdk-s3 to 1.12.15
@@ -22,32 +22,32 @@
 * Updated checkstyle to 8.44
 * Fixed potential NPE in FileStore
 
-## v2.1.32
+## 2.1.32
 
 * Fixes getS3Object with absolute path (Fixes #245 and #248)
 
-## v2.1.31
+## 2.1.31
 
 * Updated spring-security-oauth2 from 2.3.5.RELEASE to 2.3.6.RELEASE
 
-## v2.1.30
+## 2.1.30
 
 * Fix encoded responses for aws-cli (Fixes #257)
 * Updated commons-io from 2.6 to 2.7
 
-## v2.1.29
+## 2.1.29
 
 * Add encodingType as return parameter of ListBucket and ListBucketV2
 * Updated junit from 4.13-beta-1 to 4.13.1
 
-## v2.1.28
+## 2.1.28
 
 * Changes to build system, test release
 
-## v2.1.27
+## 2.1.27
 
 * Remove accidental JDK9+ bytecode dependency (Fixes #243)
 
-## v1.0.0
+## 1.0.0
 
 Initial Release


### PR DESCRIPTION
## Description
The tag is pushed by our Maven release.
Version headings in CHANGELOG.md must match tag pattern.

## Related Issue
N/A

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
