### PR TITLE
Delete all files on JVM shutdown

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -130,7 +130,7 @@ public class FileStore {
   public Bucket createBucket(final String bucketName) throws IOException {
     final File newBucket = new File(rootFolder, bucketName);
     FileUtils.forceMkdir(newBucket);
-
+    newBucket.deleteOnExit();
     return bucketFromPath(newBucket.toPath());
   }
 
@@ -253,6 +253,7 @@ public class FileStore {
     final Bucket theBucket = getBucketOrCreateNewOne(bucketName);
 
     final File objectRootFolder = createObjectRootFolder(theBucket, s3Object.getName());
+    objectRootFolder.deleteOnExit();
 
     final File dataFile =
         inputStreamToFile(wrapStream(dataStream, useV4ChunkedWithSigningFormat),
@@ -270,7 +271,9 @@ public class FileStore {
 
     s3Object.setMd5(digest(null, dataFile));
 
-    objectMapper.writeValue(new File(objectRootFolder, META_FILE), s3Object);
+    File metaFile = new File(objectRootFolder, META_FILE);
+    metaFile.deleteOnExit();
+    objectMapper.writeValue(metaFile, s3Object);
 
     return s3Object;
   }
@@ -421,7 +424,7 @@ public class FileStore {
     final Path bucketPath = theBucket.getPath();
     final File objectRootFolder = new File(bucketPath.toFile(), objectName);
     objectRootFolder.mkdirs();
-
+    objectRootFolder.deleteOnExit();
     return objectRootFolder;
   }
 
@@ -439,6 +442,7 @@ public class FileStore {
     try {
       if (!targetFile.exists()) {
         targetFile.createNewFile();
+        targetFile.deleteOnExit();
       }
 
       outputStream = new FileOutputStream(targetFile);


### PR DESCRIPTION
## Description

All files that are created by a JVM need to be registered separately to
be deleted on exit. Simply registering the S3Mock root does not suffice.
Unfortunately, this only works when the JVM is shut down in an orderly
fashion.
If the JVM crashes, or if the Docker container crashes, there is no way
for us to delete the files uploaded to the S3Mock.

This was easily reproduced by running `com.adobe.testing.s3mock.junit5.sdk2.S3MockExtensionDeclarativeTest` from the IDE. This left all test files in my tmp directory:
```
/var/folders/ll/l9wcy04j4ssfm2cb7zxkp5hh0000gn/T>
ls s3mockFileStore1625647*

s3mockFileStore1625647422582:
./                ../               mydemotestbucket/

s3mockFileStore1625647575190:
./                ../               mydemotestbucket/

s3mockFileStore1625647731348:
./                ../               mydemotestbucket/
```

With the proposed changes, all files created by the S3Mock instance are successfully deleted.

I can't see any residual files from my many Maven runs - I'm guessing that Maven uses it's own tmp folder for a run and cleans up after itself.

## Related Issue
Fixes #249

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
