### PR TITLE
Optional integration tests and docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Delete all files on JVM shutdown (Fixes #249)
 * Extract Docker build and integration tests to separate modules
+* Docker build and integration test is now optional, run with "-DskipDocker" to skip the Docker build and the integration tests. (Fixes #235)
 
 ## 2.1.34
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ To build this project, you need Docker, JDK 8 or higher, and Maven:
 
     mvn clean install
 
+If you want to skip the Docker build, pass the optional parameter "skipDocker":
+
+    mvn clean install -DskipDocker
+
 You can run the S3Mock from the sources by either of the following methods:
 
 * Run or Debug the class `com.adobe.testing.s3mock.S3MockApplication` in the IDE.

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -80,25 +80,38 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>build-docker-image</id>
-            <phase>package</phase>
-            <goals>
-              <goal>build</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
+    <profile>
+      <id>build-docker-image</id>
+      <activation>
+        <property>
+          <!-- If running with -DskipDocker, this profile won't be active. -->
+          <name>!skipDocker</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-docker-image</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>push-docker-image</id>
       <activation>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -132,26 +132,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>start-docker-image</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>start</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>stop-docker-image</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
@@ -160,26 +140,62 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-            <configuration>
-              <systemPropertyVariables>
-                <it.s3mock.host>${docker.host.ip}</it.s3mock.host>
-                <it.s3mock.port_https>${it.s3mock.port_https}</it.s3mock.port_https>
-                <it.s3mock.port_http>${it.s3mock.port_http}</it.s3mock.port_http>
-              </systemPropertyVariables>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>execute-tests</id>
+      <activation>
+        <!-- If running with -DskipTests, this profile won't be active. -->
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-docker-image</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-docker-image</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <it.s3mock.host>${docker.host.ip}</it.s3mock.host>
+                    <it.s3mock.port_https>${it.s3mock.port_https}</it.s3mock.port_https>
+                    <it.s3mock.port_http>${it.s3mock.port_http}</it.s3mock.port_http>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -147,11 +147,11 @@
 
   <profiles>
     <profile>
-      <id>execute-tests</id>
+      <id>start-docker-for-integration-tests</id>
       <activation>
-        <!-- If running with -DskipTests, this profile won't be active. -->
+        <!-- If running with -DskipDocker, this profile won't be active. -->
         <property>
-          <name>!skipTests</name>
+          <name>!skipDocker</name>
         </property>
       </activation>
       <build>
@@ -159,6 +159,11 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <!-- Even if this profile is active, we do not start the Docker container if the
+               tests are skipped, since it is only used for the integration tests. -->
+              <skip>${skipTests}</skip>
+            </configuration>
             <executions>
               <execution>
                 <id>start-docker-image</id>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
     <checkstyle.version>8.44</checkstyle.version>
     <testng.version>7.4.0</testng.version>
     <xmlunit-assertj3.version>2.8.2</xmlunit-assertj3.version>
+    <!-- Run Docker build by default -->
+    <skipDocker>false</skipDocker>
   </properties>
 
   <modules>


### PR DESCRIPTION
## Description
Docker build is now optional.
Run with "-DskipDocker" if you want to build the code only.

## Related Issue
Fixes #235

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
