### PR TITLE
Disable license header checks during maven release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,9 @@
             <properties>
               <project.inceptionYear>2017</project.inceptionYear>
             </properties>
+            <!-- Do not execute when skipping tests.
+              This also disables execution during a release. -->
+            <skip>${skipTests}</skip>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
## Description
With version 4.x, the license-maven-plugin checks the GIT history of a
file to determine when a file was created. This does not work on the GIT
clone the maven-release-plugin is creating just for the release.
We check the headers in the PRB _and_ in the "main" build after a PR is
merged. No need to check license headers again during a release.

## Related Issue
N/A

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
