### PR TITLE
Test startup and shutdown of S3MockApplication

### DIFF
--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -63,5 +63,10 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/testsupport/common/src/test/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarterTest.java
+++ b/testsupport/common/src/test/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,46 @@
 
 package com.adobe.testing.s3mock.testsupport.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.adobe.testing.s3mock.S3MockApplication;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Bucket;
 
 public class S3MockStarterTest {
-  @Test
-  void toBeDone() {
 
+  /**
+   * Tests startup and shutdown of S3MockApplication.
+   */
+  @Test
+  void testS3MockApplication() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(S3MockApplication.PROP_HTTPS_PORT, S3MockApplication.RANDOM_PORT);
+    properties.put(S3MockApplication.PROP_HTTP_PORT, S3MockApplication.RANDOM_PORT);
+    properties.put(S3MockApplication.PROP_INITIAL_BUCKETS, "bucket");
+
+    S3MockStarterTestImpl s3MockApplication = new S3MockStarterTestImpl(properties);
+    s3MockApplication.start();
+
+    assertThat(s3MockApplication.getHttpPort()).isPositive();
+    S3Client s3ClientV2 = s3MockApplication.createS3ClientV2();
+    List<Bucket> buckets = s3ClientV2.listBuckets().buckets();
+    assertThat(buckets.get(0).name()).isEqualTo("bucket");
+
+    s3MockApplication.stop();
+  }
+
+  /**
+   * Just needed to instantiate the S3MockStarter.
+   * The instance provides an S3Client that is pre-configured to connect to the S3MockApplication.
+   */
+  private static class S3MockStarterTestImpl extends S3MockStarter {
+    protected S3MockStarterTestImpl(Map<String, Object> properties) {
+      super(properties);
+    }
   }
 }


### PR DESCRIPTION
## Description
Not sure why the test was empty before.
S3MockStarter just adds a bit of convenience by providing a
preconfigured S3Client instance.


## Related Issue
#275 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
