### PR TITLE
copy object part encode source key and produce xml response

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -770,7 +770,8 @@ class FileStoreController {
       headers = {
           COPY_SOURCE,
           COPY_SOURCE_RANGE
-      })
+      },
+      produces = "application/xml")
   public ResponseEntity<CopyPartResult> copyObjectPart(
       @RequestHeader(value = COPY_SOURCE) final ObjectRef copySource,
       @RequestHeader(value = COPY_SOURCE_RANGE) final Range copyRange,
@@ -786,7 +787,7 @@ class FileStoreController {
 
     final String destinationFile = filenameFrom(destinationBucket, request);
     final String partEtag = fileStore.copyPart(copySource.getBucket(),
-        copySource.getKey(),
+        encode(copySource.getKey()),
         (int) copyRange.getStart(),
         (int) copyRange.getEnd(),
         partNumber,

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -789,8 +789,8 @@ class FileStoreController {
     final String destinationFile = filenameFrom(destinationBucket, request);
     final String partEtag = fileStore.copyPart(copySource.getBucket(),
         encode(copySource.getKey()),
-        (int) copyRange.getStart(),
-        (int) copyRange.getEnd(),
+        copyRange.getStart(),
+        copyRange.getEnd(),
         partNumber,
         destinationBucket,
         destinationFile,

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -756,6 +756,7 @@ class FileStoreController {
    * @param copyRange Defines the byte range for this part.
    * @param encryption The encryption type.
    * @param kmsKeyId The KMS encryption key id.
+   * @param destinationBucket name of the destination bucket.
    * @param uploadId id of the upload. Has to match all other part's uploads.
    * @param partNumber number of the part to upload.
    * @param request {@link HttpServletRequest} of this request.

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -1120,8 +1120,8 @@ public class FileStore {
    */
   public String copyPart(final String bucket,
       final String key,
-      final int from,
-      final int to,
+      final long from,
+      final long to,
       final String partNumber,
       final String destinationBucket,
       final String destinationFilename,
@@ -1137,10 +1137,10 @@ public class FileStore {
 
   private String copyPart(final String bucket,
       final String key,
-      final int from,
-      final int to,
+      final long from,
+      final long to,
       final File partFile) throws IOException {
-    final int len = to - from + 1;
+    final long len = to - from + 1;
     final S3Object s3Object = resolveS3Object(bucket, key);
 
     try (final InputStream sourceStream = FileUtils.openInputStream(s3Object.getDataFile());


### PR DESCRIPTION
## Description

Encode source key and produce XML for copy object part endpoint.

## Related Issue

https://github.com/adobe/S3Mock/issues/279

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
