### PR TITLE
Fixes copy part / copy object encoding issues

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -770,7 +770,7 @@ class FileStoreController {
       headers = {
           COPY_SOURCE,
           COPY_SOURCE_RANGE
-      })
+      }, produces = "application/xml")
   public ResponseEntity<CopyPartResult> copyObjectPart(
       @RequestHeader(value = COPY_SOURCE) final ObjectRef copySource,
       @RequestHeader(value = COPY_SOURCE_RANGE) final Range copyRange,
@@ -787,8 +787,8 @@ class FileStoreController {
     final String destinationFile = filenameFrom(destinationBucket, request);
     final String partEtag = fileStore.copyPart(copySource.getBucket(),
         copySource.getKey(),
-        (int) copyRange.getStart(),
-        (int) copyRange.getEnd(),
+        copyRange.getStart(),
+        copyRange.getEnd(),
         partNumber,
         destinationBucket,
         destinationFile,
@@ -869,8 +869,7 @@ class FileStoreController {
       method = RequestMethod.PUT,
       headers = {
           COPY_SOURCE
-      },
-      produces = "application/xml; charset=utf-8")
+      }, produces = "application/xml")
   public ResponseEntity<CopyObjectResult> copyObject(@PathVariable final String destinationBucket,
       @RequestHeader(value = COPY_SOURCE) final ObjectRef objectRef,
       @RequestHeader(value = METADATA_DIRECTIVE,
@@ -886,7 +885,7 @@ class FileStoreController {
     final CopyObjectResult copyObjectResult;
     if (MetadataDirective.REPLACE == metadataDirective) {
       copyObjectResult = fileStore.copyS3ObjectEncrypted(objectRef.getBucket(),
-          encode(objectRef.getKey()),
+          objectRef.getKey(),
           destinationBucket,
           destinationFile,
           encryption,
@@ -894,7 +893,7 @@ class FileStoreController {
           getUserMetadata(request));
     } else {
       copyObjectResult = fileStore.copyS3ObjectEncrypted(objectRef.getBucket(),
-          encode(objectRef.getKey()),
+          objectRef.getKey(),
           destinationBucket,
           destinationFile,
           encryption,

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -1120,8 +1120,8 @@ public class FileStore {
    */
   public String copyPart(final String bucket,
       final String key,
-      final int from,
-      final int to,
+      final long from,
+      final long to,
       final String partNumber,
       final String destinationBucket,
       final String destinationFilename,
@@ -1137,10 +1137,10 @@ public class FileStore {
 
   private String copyPart(final String bucket,
       final String key,
-      final int from,
-      final int to,
+      final long from,
+      final long to,
       final File partFile) throws IOException {
-    final int len = to - from + 1;
+    final long len = to - from + 1;
     final S3Object s3Object = resolveS3Object(bucket, key);
 
     try (final InputStream sourceStream = FileUtils.openInputStream(s3Object.getDataFile());

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectRef.java
@@ -45,7 +45,7 @@ public final class ObjectRef {
     final String[] bucketAndKey = extractBucketAndKeyArray(StringEncoding.decode(copySource));
 
     this.bucket = bucketAndKey[0];
-    this.key = bucketAndKey[1];
+    this.key = StringEncoding.encode(bucketAndKey[1]);
   }
 
   public String getBucket() {


### PR DESCRIPTION
## Description
Adds integration tests for CopyParts API.
APIs must return "application/xml".
Incoming key reference must undergo decode&encode cycle just like the
destinationFile name we take from the incoming request path. ObjectRef
now does this for every incoming request. Before, clients of ObjectRef
would need to remember to encode the key again before usage. D'OH!
From/To values are of type "long" in the request, not "int". Copying
of parts larger than Integer.MAX_VALUE would have failed.

Special thanks to user @wwelling for spotting these issues and providing
the fix, I just refactored and added an integration test.

## Related Issue
fixes #279, makes #278 obsolete.

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
