### PR TITLE
Support for CORS headers on bucket contents

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -101,6 +101,7 @@ import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -113,6 +114,7 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 /**
  * Controller to handle http requests.
  */
+@CrossOrigin(origins = "*")
 @RestController
 class FileStoreController {
 


### PR DESCRIPTION
## Description
Adds CORS support (for any domain) to the files stored in s3mock, this allows browser based clients to connect to the s3mock server. (e.g. via pre-signed URLs)

Can't really write ITs for this as I don't have docker installed.

## Related Issue
#74 Support for CORS headers

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
