### PR TITLE
Move root folder to environment variable docker

### DIFF
--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -46,10 +46,11 @@ ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8 \
     JAVA_HOME=/opt/jdk-minimal \
-    PATH="$PATH:/opt/jdk-minimal/bin"
+    PATH="$PATH:/opt/jdk-minimal/bin" \
+    root=/s3mockroot
 
 EXPOSE 9090 9191
 
 COPY maven /opt/
 
-ENTRYPOINT java -XX:+UseContainerSupport -Xmx128m --illegal-access=warn -Djava.security.egd=file:/dev/./urandom -Droot=/s3mockroot -jar /opt/service/*.jar
+ENTRYPOINT java -XX:+UseContainerSupport -Xmx128m --illegal-access=warn -Djava.security.egd=file:/dev/./urandom -jar /opt/service/*.jar


### PR DESCRIPTION
## Description
Overriding the root folder thanks to the environment variable `root` in Docker container was not possible because of java system property (-D).
Moving this default value to environment variable solve the issue.

## Related Issue
No related issue.

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
