### PR TITLE
Set bucket for multipart uploads, return by bucket.

### DIFF
--- a/integration-tests/src/test/java/com/adobe/testing/s3mock/its/MultiPartUploadIT.java
+++ b/integration-tests/src/test/java/com/adobe/testing/s3mock/its/MultiPartUploadIT.java
@@ -58,6 +58,7 @@ public class MultiPartUploadIT extends S3TestBase {
 
   private static final Random random = new Random();
   private static final int BUFFER_SIZE = 128 * 1024;
+  private static final String BUCKET_NAME_2 = "testbucket2";
 
   /**
    * Tests if user metadata can be passed by multipart upload.
@@ -185,6 +186,39 @@ public class MultiPartUploadIT extends S3TestBase {
 
     assertThat(listing.getMultipartUploads()).hasSize(1);
     assertThat(listing.getMultipartUploads().get(0).getKey()).isEqualTo("key2");
+  }
+
+  /**
+   * Tests if multipart uploads are stored and can be retrieved by bucket.
+   */
+  @Test
+  void shouldListMultipartUploadsWithBucket() {
+    // create multipart upload 1
+    s3Client.createBucket(BUCKET_NAME);
+    s3Client.initiateMultipartUpload(
+        new InitiateMultipartUploadRequest(BUCKET_NAME, "key1"));
+    // create multipart upload 2
+    s3Client.createBucket(BUCKET_NAME_2);
+    s3Client.initiateMultipartUpload(
+        new InitiateMultipartUploadRequest(BUCKET_NAME_2, "key2"));
+
+    // assert multipart upload 1
+    final ListMultipartUploadsRequest listMultipartUploadsRequest1 =
+        new ListMultipartUploadsRequest(BUCKET_NAME);
+    final MultipartUploadListing listing1
+        = s3Client.listMultipartUploads(listMultipartUploadsRequest1);
+
+    assertThat(listing1.getMultipartUploads()).hasSize(1);
+    assertThat(listing1.getMultipartUploads().get(0).getKey()).isEqualTo("key1");
+
+    // assert multipart upload 2
+    final ListMultipartUploadsRequest listMultipartUploadsRequest2 =
+        new ListMultipartUploadsRequest(BUCKET_NAME_2);
+    final MultipartUploadListing listing2
+        = s3Client.listMultipartUploads(listMultipartUploadsRequest2);
+
+    assertThat(listing2.getMultipartUploads()).hasSize(1);
+    assertThat(listing2.getMultipartUploads().get(0).getKey()).isEqualTo("key2");
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -425,7 +425,7 @@ class FileStoreController {
     verifyBucketExistence(bucketName);
 
     final List<MultipartUpload> multipartUploads =
-        fileStore.listMultipartUploads().stream()
+        fileStore.listMultipartUploads(bucketName).stream()
             .filter(m -> isBlank(prefix) || m.getKey().startsWith(prefix))
             .map(m -> new MultipartUpload(decode(m.getKey()), m.getUploadId(),
                 m.getOwner(), m.getInitiator(), m.getInitiated()))

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/FileStore.java
@@ -785,7 +785,7 @@ public class FileStore {
     final MultipartUpload upload =
         new MultipartUpload(fileName, uploadId, owner, initiator, new Date());
     uploadIdToInfo.put(uploadId, new MultipartUploadInfo(upload,
-        contentType, contentEncoding, userMetadata));
+        contentType, contentEncoding, userMetadata, bucketName));
 
     return upload;
   }
@@ -812,12 +812,27 @@ public class FileStore {
   }
 
   /**
-   * Lists the not-yet completed parts of an multipart upload.
+   * Lists the not-yet completed parts of a multipart upload across all buckets.
+   *
+   * @return the list of not-yet completed multipart uploads.
+   * @deprecated use {@link #listMultipartUploads(String)} with null as parameter instead.
+   */
+  @Deprecated //forRemoval = true
+  public Collection<MultipartUpload> listMultipartUploads() {
+    return listMultipartUploads(null);
+  }
+
+  /**
+   * Lists the not-yet completed parts of a multipart upload.
    *
    * @return the list of not-yet completed multipart uploads.
    */
-  public Collection<MultipartUpload> listMultipartUploads() {
-    return uploadIdToInfo.values().stream().map(info -> info.upload).collect(Collectors.toList());
+  public Collection<MultipartUpload> listMultipartUploads(String bucketName) {
+    return uploadIdToInfo.values()
+        .stream()
+        .filter(info -> bucketName == null || bucketName.equals(info.bucket))
+        .map(info -> info.upload)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/domain/MultipartUploadInfo.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2021 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -28,13 +28,16 @@ class MultipartUploadInfo {
   final String contentType;
   final String contentEncoding;
   final Map<String, String> userMetadata;
+  final String bucket;
 
   MultipartUploadInfo(final MultipartUpload upload, final String contentType,
       final String contentEncoding,
-      final Map<String, String> userMetadata) {
+      final Map<String, String> userMetadata,
+      String bucket) {
     this.upload = upload;
     this.contentType = contentType;
     this.contentEncoding = contentEncoding;
     this.userMetadata = userMetadata;
+    this.bucket = bucket;
   }
 }


### PR DESCRIPTION
## Description
Multipart uploads now support buckets.

## Related Issue
#292

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
