### PR TITLE
Remove duplicate CORS header in get object.

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -605,7 +605,6 @@ class FileStoreController {
         .eTag("\"" + s3Object.getMd5() + "\"")
         .header(HttpHeaders.CONTENT_ENCODING, s3Object.getContentEncoding())
         .header(HttpHeaders.ACCEPT_RANGES, RANGES_BYTES)
-        .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, ANY)
         .headers(headers -> headers.setAll(createUserMetadataHeaders(s3Object)))
         .lastModified(s3Object.getLastModified())
         .contentLength(s3Object.getDataFile().length())


### PR DESCRIPTION
## Description
Remove duplicate CORS header in get object.

## Related Issue
#74

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
