### PR TITLE
Add Content-MD5 header handling

### DIFF
--- a/integration-tests/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
+++ b/integration-tests/src/test/java/com/adobe/testing/s3mock/its/AmazonClientUploadIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,8 +22,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.adobe.testing.s3mock.util.HashUtil;
-import com.amazonaws.SdkClientException;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.Headers;
@@ -222,13 +221,13 @@ class AmazonClientUploadIT extends S3TestBase {
   private void verifyObjectContent(final File uploadFile, final S3Object s3Object)
       throws NoSuchAlgorithmException, IOException {
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedDigest = DigestUtil.getHexDigest(s3Object.getObjectContent());
     uploadFileIs.close();
     s3Object.close();
 
-    assertThat(uploadHash).as("Up- and downloaded Files should have equal Hashes")
-        .isEqualTo(downloadedHash);
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 
   /**
@@ -374,12 +373,12 @@ class AmazonClientUploadIT extends S3TestBase {
         .as("Uploaded File should have Encoding-Type set")
         .isEqualTo(contentEncoding);
 
-    final String uploadHash = HashUtil.getDigest(new ByteArrayInputStream(resource));
-    final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
+    final String uploadDigest = DigestUtil.getHexDigest(new ByteArrayInputStream(resource));
+    final String downloadedDigest = DigestUtil.getHexDigest(s3Object.getObjectContent());
     s3Object.close();
 
-    assertThat(uploadHash).as("Up- and downloaded Files should have equal Hashes")
-        .isEqualTo(downloadedHash);
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 
   /**
@@ -470,10 +469,10 @@ class AmazonClientUploadIT extends S3TestBase {
     final S3Object copiedObject =
         s3Client.getObject(destinationBucketName, destinationKey);
 
-    final String copiedHash = HashUtil.getDigest(copiedObject.getObjectContent());
+    final String copiedDigest = DigestUtil.getHexDigest(copiedObject.getObjectContent());
     copiedObject.close();
 
-    assertThat(copiedHash).as("Sourcefile and copied File should have same Hashes")
+    assertThat(copiedDigest).as("Sourcefile and copied File should have same digests")
         .isEqualTo(putObjectResult.getETag());
   }
 
@@ -506,10 +505,10 @@ class AmazonClientUploadIT extends S3TestBase {
     final S3Object copiedObject =
         s3Client.getObject(destinationBucketName, destinationKey);
 
-    final String copiedHash = HashUtil.getDigest(copiedObject.getObjectContent());
+    final String copiedDigest = DigestUtil.getHexDigest(copiedObject.getObjectContent());
     copiedObject.close();
 
-    assertThat(copiedHash).as("Source file and copied File should have same Hashes")
+    assertThat(copiedDigest).as("Source file and copied File should have same digests")
         .isEqualTo(putObjectResult.getETag());
     assertThat(copiedObject.getObjectMetadata().getUserMetadata()).as(
             "User metadata should be identical!")
@@ -547,10 +546,10 @@ class AmazonClientUploadIT extends S3TestBase {
     final S3Object copiedObject =
         s3Client.getObject(destinationBucketName, destinationKey);
 
-    final String copiedHash = HashUtil.getDigest(copiedObject.getObjectContent());
+    final String copiedDigest = DigestUtil.getHexDigest(copiedObject.getObjectContent());
     copiedObject.close();
 
-    assertThat(copiedHash).as("Source file and copied File should have same Hashes")
+    assertThat(copiedDigest).as("Source file and copied File should have same digests")
         .isEqualTo(putObjectResult.getETag());
     assertThat(copiedObject.getObjectMetadata().getUserMetadata()).as(
             "User metadata should be identical!")
@@ -581,10 +580,10 @@ class AmazonClientUploadIT extends S3TestBase {
     final S3Object copiedObject =
         s3Client.getObject(destinationBucketName, destinationKey);
 
-    final String copiedHash = HashUtil.getDigest(copiedObject.getObjectContent());
+    final String copiedDigest = DigestUtil.getHexDigest(copiedObject.getObjectContent());
     copiedObject.close();
 
-    assertThat(copiedHash).as("Source file and copied File should have same Hashes")
+    assertThat(copiedDigest).as("Source file and copied File should have same digests")
         .isEqualTo(putObjectResult.getETag());
   }
 
@@ -612,10 +611,10 @@ class AmazonClientUploadIT extends S3TestBase {
     final S3Object copiedObject =
         s3Client.getObject(destinationBucketName, destinationKey);
 
-    final String copiedHash = HashUtil.getDigest(copiedObject.getObjectContent());
+    final String copiedDigest = DigestUtil.getHexDigest(copiedObject.getObjectContent());
     copiedObject.close();
 
-    assertThat(copiedHash).as("Source file and copied File should have same Hashes")
+    assertThat(copiedDigest).as("Source file and copied File should have same digests")
         .isEqualTo(putObjectResult.getETag());
   }
 
@@ -646,8 +645,8 @@ class AmazonClientUploadIT extends S3TestBase {
         s3Client.getObjectMetadata(destinationBucketName, destinationKey);
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(TEST_ENC_KEYREF, uploadFileIs);
-    assertThat(copyObjectResult.getETag()).as("ETag should match").isEqualTo(uploadHash);
+    final String uploadDigest = DigestUtil.getHexDigest(TEST_ENC_KEYREF, uploadFileIs);
+    assertThat(copyObjectResult.getETag()).as("ETag should match").isEqualTo(uploadDigest);
     assertThat(metadata.getContentLength()).as("Files should have the same length")
         .isEqualTo(uploadFile.length());
   }
@@ -1024,20 +1023,20 @@ class AmazonClientUploadIT extends S3TestBase {
     final S3Object s3ObjectWithEtag = s3Client.getObject(requestWithEtag);
     final S3Object s3ObjectWithHoutEtag = s3Client.getObject(requestWithHoutEtag);
 
-    final String s3ObjectWithEtagDownloadedHash = HashUtil
-        .getDigest(s3ObjectWithEtag.getObjectContent());
-    final String s3ObjectWithHoutEtagDownloadedHash = HashUtil
-        .getDigest(s3ObjectWithHoutEtag.getObjectContent());
+    final String s3ObjectWithEtagDownloadedDigest = DigestUtil
+        .getHexDigest(s3ObjectWithEtag.getObjectContent());
+    final String s3ObjectWithHoutEtagDownloadedDigest = DigestUtil
+        .getHexDigest(s3ObjectWithHoutEtag.getObjectContent());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
 
-    assertThat(uploadHash).as("The uploaded file and the recived file should be the same, "
+    assertThat(uploadDigest).as("The uploaded file and the received file should be the same, "
             + "when requesting file with matching eTag given same eTag")
-        .isEqualTo(s3ObjectWithEtagDownloadedHash);
-    assertThat(uploadHash).as("The uploaded file and the recived file should be the same, "
+        .isEqualTo(s3ObjectWithEtagDownloadedDigest);
+    assertThat(uploadDigest).as("The uploaded file and the received file should be the same, "
             + "when requesting file with  non-matching eTag but given different eTag")
-        .isEqualTo(s3ObjectWithHoutEtagDownloadedHash);
+        .isEqualTo(s3ObjectWithHoutEtagDownloadedDigest);
 
     // wit eTag
     requestWithEtag = new GetObjectRequest(BUCKET_NAME, uploadFile.getName());

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -547,7 +547,7 @@ class FileStoreController {
             }
           })
           .contentType(parseMediaType(s3Object.getContentType()))
-          .eTag("\"" + s3Object.getMd5() + "\"")
+          .eTag("\"" + s3Object.getEtag() + "\"")
           .contentLength(Long.parseLong(s3Object.getSize()))
           .lastModified(s3Object.getLastModified())
           .build();
@@ -640,7 +640,7 @@ class FileStoreController {
 
     final S3Object s3Object = verifyObjectExistence(bucketName, filename);
 
-    verifyObjectMatching(match, noMatch, s3Object.getMd5());
+    verifyObjectMatching(match, noMatch, s3Object.getEtag());
 
     if (range != null) {
       return getObjectWithRange(range, s3Object);
@@ -648,7 +648,7 @@ class FileStoreController {
 
     return ResponseEntity
         .ok()
-        .eTag("\"" + s3Object.getMd5() + "\"")
+        .eTag("\"" + s3Object.getEtag() + "\"")
         .header(HttpHeaders.CONTENT_ENCODING, s3Object.getContentEncoding())
         .header(HttpHeaders.ACCEPT_RANGES, RANGES_BYTES)
         .headers(headers -> headers.setAll(createUserMetadataHeaders(s3Object)))
@@ -686,7 +686,7 @@ class FileStoreController {
 
     return ResponseEntity
         .ok()
-        .eTag("\"" + s3Object.getMd5() + "\"")
+        .eTag("\"" + s3Object.getEtag() + "\"")
         .lastModified(s3Object.getLastModified())
         .body(result);
   }
@@ -749,7 +749,7 @@ class FileStoreController {
       fileStore.setObjectTags(bucketName, filename, body.getTagSet());
       return ResponseEntity
           .ok()
-          .eTag("\"" + s3Object.getMd5() + "\"")
+          .eTag("\"" + s3Object.getEtag() + "\"")
           .lastModified(s3Object.getLastModified())
           .build();
     } catch (final IOException e) {
@@ -916,7 +916,7 @@ class FileStoreController {
 
       return ResponseEntity
           .ok()
-          .eTag("\"" + s3Object.getMd5() + "\"")
+          .eTag("\"" + s3Object.getEtag() + "\"")
           .lastModified(s3Object.getLastModified())
           .header(X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID, kmsKeyId)
           .build();
@@ -1097,7 +1097,7 @@ class FileStoreController {
         .header(HttpHeaders.CONTENT_RANGE,
             String.format("bytes %s-%s/%s",
                 range.getStart(), bytesToRead + range.getStart() - 1, s3Object.getSize()))
-        .eTag("\"" + s3Object.getMd5() + "\"")
+        .eTag("\"" + s3Object.getEtag() + "\"")
         .contentType(parseMediaType(s3Object.getContentType()))
         .lastModified(s3Object.getLastModified())
         .contentLength(bytesToRead)
@@ -1194,7 +1194,7 @@ class FileStoreController {
     LOG.debug(String.format("Found %s objects in bucket %s", s3Objects.size(), bucketName));
     return s3Objects.stream().map(s3Object -> new BucketContents(
             decode(s3Object.getName()),
-            s3Object.getModificationDate(), s3Object.getMd5(),
+            s3Object.getModificationDate(), s3Object.getEtag(),
             s3Object.getSize(), "STANDARD", TEST_OWNER))
         // List Objects results are expected to be sorted by key
         .sorted(BUCKET_CONTENTS_COMPARATOR)

--- a/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
@@ -29,7 +29,7 @@ import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Part;
 import com.adobe.testing.s3mock.dto.Range;
 import com.adobe.testing.s3mock.dto.Tag;
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.FileInputStream;
@@ -328,7 +328,7 @@ public class FileStore {
         S3_OBJECT_DATE_FORMAT.format(attributes.lastModifiedTime().toInstant()));
     s3Object.setLastModified(attributes.lastModifiedTime().toMillis());
 
-    s3Object.setMd5(digest(kmsKeyId, dataFile));
+    s3Object.setEtag(digest(kmsKeyId, dataFile));
 
     File metaFile = new File(objectRootFolder, META_FILE);
     if (!retainFilesOnExit) {
@@ -713,7 +713,7 @@ public class FileStore {
             encryption,
             kmsKeyId);
 
-    return new CopyObjectResult(copiedObject.getModificationDate(), copiedObject.getMd5());
+    return new CopyObjectResult(copiedObject.getModificationDate(), copiedObject.getEtag());
   }
 
   /**
@@ -970,7 +970,7 @@ public class FileStore {
         s3Object.setModificationDate(S3_OBJECT_DATE_FORMAT.format(
             attributes.lastModifiedTime().toInstant()));
         s3Object.setLastModified(attributes.lastModifiedTime().toMillis());
-        s3Object.setMd5(DigestUtils.md5Hex(allMd5s) + "-" + partNames.length);
+        s3Object.setEtag(DigestUtils.md5Hex(allMd5s) + "-" + partNames.length);
         s3Object.setSize(Long.toString(size));
         s3Object.setContentType(
             uploadInfo.contentType != null ? uploadInfo.contentType : DEFAULT_CONTENT_TYPE);
@@ -991,7 +991,7 @@ public class FileStore {
         throw new IllegalStateException("Could not write metadata-file", e);
       }
 
-      return s3Object.getMd5();
+      return s3Object.getEtag();
     });
   }
 
@@ -1061,7 +1061,7 @@ public class FileStore {
       final File currentFilePart = retrieveFile(bucketName, fileName, filePartPath);
 
       final int partNumber = i + 1;
-      final String partMd5 = calculateHashOfFilePart(currentFilePart);
+      final String partMd5 = calculateDigestOfFilePart(currentFilePart);
       final Date lastModified = new Date(currentFilePart.lastModified());
 
       final Part part = new Part();
@@ -1077,12 +1077,12 @@ public class FileStore {
     return parts;
   }
 
-  private String calculateHashOfFilePart(final File currentFilePart) {
+  private String calculateDigestOfFilePart(final File currentFilePart) {
     try (final InputStream is = FileUtils.openInputStream(currentFilePart)) {
       final String partMd5 = DigestUtils.md5Hex(is);
       return String.format("%s", partMd5);
     } catch (final IOException e) {
-      LOG.error("Hash could not be calculated. File access did not succeed", e);
+      LOG.error("Digest could not be calculated. File access did not succeed", e);
       return "";
     }
   }
@@ -1133,9 +1133,9 @@ public class FileStore {
 
   private String digest(final String salt, final File dataFile) throws IOException {
     try (final FileInputStream inputStream = new FileInputStream(dataFile)) {
-      return HashUtil.getDigest(salt, inputStream);
+      return DigestUtil.getHexDigest(salt, inputStream);
     } catch (final NoSuchAlgorithmException e) {
-      LOG.error("Hash can not be calculated!", e);
+      LOG.error("Digest can not be calculated!", e);
       return null;
     }
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
@@ -29,6 +29,7 @@ import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Part;
 import com.adobe.testing.s3mock.dto.Range;
 import com.adobe.testing.s3mock.dto.Tag;
+import com.adobe.testing.s3mock.util.AwsChunkedDecodingInputStream;
 import com.adobe.testing.s3mock.util.DigestUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;

--- a/server/src/main/java/com/adobe/testing/s3mock/store/S3Object.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/S3Object.java
@@ -38,6 +38,8 @@ public class S3Object {
 
   private String md5;
 
+  private String etag;
+
   private String contentType;
 
   private String contentEncoding;
@@ -86,6 +88,14 @@ public class S3Object {
 
   public void setModificationDate(final String modificationDate) {
     this.modificationDate = modificationDate;
+  }
+
+  public String getEtag() {
+    return etag;
+  }
+
+  public void setEtag(String etag) {
+    this.etag = etag;
   }
 
   public String getMd5() {

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsChunkedDecodingInputStream.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsChunkedDecodingInputStream.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package com.adobe.testing.s3mock.store;
+package com.adobe.testing.s3mock.util;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,7 +42,7 @@ import java.nio.charset.StandardCharsets;
  * <a href="http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AwsChunkedEncodingInputStream.html">
  *     AwsChunkedEncodingInputStream</a>
  */
-class AwsChunkedDecodingInputStream extends InputStream {
+public class AwsChunkedDecodingInputStream extends InputStream {
 
   /**
    * That's the max chunk buffer size used in the AWS implementation.
@@ -64,7 +64,7 @@ class AwsChunkedDecodingInputStream extends InputStream {
    *
    * @param source The {@link InputStream} to wrap.
    */
-  AwsChunkedDecodingInputStream(final InputStream source) {
+  public AwsChunkedDecodingInputStream(final InputStream source) {
     this.source = source;
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
@@ -41,6 +41,7 @@ public final class AwsHttpHeaders {
 
   public static final String X_AMZ_CONTENT_SHA256 = "x-amz-content-sha256";
   public static final String X_AMZ_TAGGING = "x-amz-tagging";
+  public static final String CONTENT_MD5 = "Content-MD5";
 
   private AwsHttpHeaders() {
     // empty private constructor

--- a/server/src/main/java/com/adobe/testing/s3mock/util/DigestUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/DigestUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,47 +25,46 @@ import java.security.NoSuchAlgorithmException;
 import org.apache.commons.codec.binary.Hex;
 
 /**
- * A util-Class for the creation of Hashes.
+ * Util-Class for the creation of Digests.
  */
-public class HashUtil {
+public class DigestUtil {
 
   /**
-   * Calculates a base64 MD5 Hash for the content of an inputStream.
+   * Calculates a hex encoded MD5 digest for the content of an inputStream.
    *
    * <p>Mainly used for comparison of files. E.g. After PUTting a File to the Server, the Amazon
-   * S3-Client expects a base64 MD5 Hash, ETag, as part of the response Header to verify the
-   * validity of the transferred file.</p>
+   * S3-Client expects a hex encoded MD5 digest as the ETag, as part of the response Header to
+   * verify the validity of the transferred file.</p>
    *
    * @param inputStream the InputStream.
    *
-   * @return String Base64 MD5 Hash.
+   * @return String Hex MD5 digest.
    *
    * @throws NoSuchAlgorithmException if no md5 can be found
    * @throws IOException if InputStream can't be read
    */
-  public static String getDigest(final InputStream inputStream)
+  public static String getHexDigest(final InputStream inputStream)
       throws NoSuchAlgorithmException, IOException {
-    return getDigest(null, inputStream);
+    return getHexDigest(null, inputStream);
   }
 
   /**
-   * Calculates a base64 MD5 Hash for the content of an inputStream.
+   * Calculates a hex encoded MD5 digest for the content of an inputStream.
    *
    * <p>Mainly used for comparison of files. E.g. After PUTting a File to the Server, the Amazon
-   * S3-Client expects a base64 MD5 Hash, ETag, as part of the response Header to verify the
-   * validity of the transferred file. For encrypted uploads, the returned hash may not be the same
-   * as the local client hash value.</p>
+   * S3-Client expects a hex encoded MD5 digest as the ETag, as part of the response Header to
+   * verify the validity of the transferred file. For encrypted uploads, the returned digest may not
+   * be the same as the local client digest value.</p>
    *
-   * @param salt Optional salt to add to be digested, for simulating encryption dependent
-   *     hashing.
+   * @param salt Optional salt to add to be digested, for simulating encryption dependent digest.
    * @param inputStream the InputStream.
    *
-   * @return String Base64 MD5 Hash.
+   * @return String Hex MD5 digest.
    *
    * @throws NoSuchAlgorithmException if no md5 can be found.
    * @throws IOException if InputStream can't be read.
    */
-  public static String getDigest(final String salt, final InputStream inputStream)
+  public static String getHexDigest(final String salt, final InputStream inputStream)
       throws NoSuchAlgorithmException, IOException {
     final MessageDigest messageDigest = MessageDigest.getInstance("MD5");
     messageDigest.reset();

--- a/server/src/test/java/com/adobe/testing/s3mock/FileStoreControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/FileStoreControllerTest.java
@@ -293,7 +293,7 @@ class FileStoreControllerTest {
     S3Object s3Object = new S3Object();
     s3Object.setName(id);
     s3Object.setModificationDate("1234");
-    s3Object.setMd5("etag");
+    s3Object.setEtag("etag");
     s3Object.setSize("size");
     return s3Object;
   }

--- a/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
@@ -28,7 +28,7 @@ import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Part;
 import com.adobe.testing.s3mock.dto.Range;
 import com.adobe.testing.s3mock.dto.Tag;
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -167,7 +167,7 @@ class FileStoreTest {
   void shouldStoreFileInBucket() throws Exception {
     final File sourceFile = new File(TEST_FILE_PATH);
     final String name = sourceFile.getName();
-    final String md5 = HashUtil.getDigest(new FileInputStream(sourceFile));
+    final String md5 = DigestUtil.getHexDigest(new FileInputStream(sourceFile));
     final String size = Long.toString(sourceFile.length());
 
     final S3Object returnedObject =
@@ -179,7 +179,7 @@ class FileStoreTest {
         "ContentType should be '" + "binary/octet-stream" + "'").isEqualTo("binary/octet-stream");
     assertThat(returnedObject.getContentEncoding()).as(
         "ContentEncoding should be '" + ENCODING_GZIP + "'").isEqualTo(ENCODING_GZIP);
-    assertThat(returnedObject.getMd5()).as("MD5 should be '" + md5 + "'").isEqualTo(md5);
+    assertThat(returnedObject.getEtag()).as("MD5 should be '" + md5 + "'").isEqualTo(md5);
     assertThat(returnedObject.getSize()).as("Size should be '" + size + "'").isEqualTo(size);
     assertThat(returnedObject.isEncrypted()).as("File should not be encrypted!").isFalse();
 
@@ -198,7 +198,7 @@ class FileStoreTest {
 
     final String name = sourceFile.getName();
     final String contentType = ContentType.TEXT_PLAIN.toString();
-    final String md5 = HashUtil.getDigest(TEST_ENC_KEY,
+    final String md5 = DigestUtil.getHexDigest(TEST_ENC_KEY,
         new ByteArrayInputStream(UNSIGNED_CONTENT.getBytes(UTF_8)));
 
     final S3Object storedObject =
@@ -217,7 +217,7 @@ class FileStoreTest {
     assertThat(storedObject.getKmsEncryption()).as("Encryption Type matches")
         .isEqualTo(TEST_ENC_TYPE);
     assertThat(storedObject.getKmsKeyId()).as("Encryption Key matches").isEqualTo(TEST_ENC_KEY);
-    assertThat(storedObject.getMd5()).as("MD5 should not match").isEqualTo(md5);
+    assertThat(storedObject.getEtag()).as("MD5 should not match").isEqualTo(md5);
   }
 
   /**
@@ -231,7 +231,7 @@ class FileStoreTest {
 
     final String name = sourceFile.getName();
     final String contentType = ContentType.TEXT_PLAIN.toString();
-    final String md5 = HashUtil.getDigest(TEST_ENC_KEY,
+    final String md5 = DigestUtil.getHexDigest(TEST_ENC_KEY,
         new ByteArrayInputStream(UNSIGNED_CONTENT.getBytes(UTF_8)));
 
     fileStore.putS3Object(TEST_BUCKET_NAME,
@@ -250,7 +250,7 @@ class FileStoreTest {
     assertThat(returnedObject.getKmsEncryption()).as("Encryption Type matches")
         .isEqualTo(TEST_ENC_TYPE);
     assertThat(returnedObject.getKmsKeyId()).as("Encryption Key matches").isEqualTo(TEST_ENC_KEY);
-    assertThat(returnedObject.getMd5()).as("MD5 should not match").isEqualTo(md5);
+    assertThat(returnedObject.getEtag()).as("MD5 should not match").isEqualTo(md5);
   }
 
   /**
@@ -263,7 +263,7 @@ class FileStoreTest {
     final File sourceFile = new File(TEST_FILE_PATH);
 
     final String name = sourceFile.getName();
-    final String md5 = HashUtil.getDigest(new FileInputStream(sourceFile));
+    final String md5 = DigestUtil.getHexDigest(new FileInputStream(sourceFile));
     final String size = Long.toString(sourceFile.length());
 
     fileStore
@@ -277,7 +277,7 @@ class FileStoreTest {
         "ContentType should be '" + TEXT_PLAIN + "'").isEqualTo(TEXT_PLAIN);
     assertThat(returnedObject.getContentEncoding()).as(
         "ContentEncoding should be '" + ENCODING_GZIP + "'").isEqualTo(ENCODING_GZIP);
-    assertThat(returnedObject.getMd5()).as("MD5 should be '" + md5 + "'").isEqualTo(md5);
+    assertThat(returnedObject.getEtag()).as("MD5 should be '" + md5 + "'").isEqualTo(md5);
     assertThat(returnedObject.getSize()).as("Size should be '" + size + "'").isEqualTo(size);
     assertThat(returnedObject.isEncrypted()).as("File should not be encrypted!").isFalse();
 
@@ -295,7 +295,7 @@ class FileStoreTest {
     final File sourceFile = new File(TEST_FILE_PATH);
 
     final String name = "/app/config/" + sourceFile.getName();
-    final String md5 = HashUtil.getDigest(new FileInputStream(sourceFile));
+    final String md5 = DigestUtil.getHexDigest(new FileInputStream(sourceFile));
     final String size = Long.toString(sourceFile.length());
 
     fileStore
@@ -309,7 +309,7 @@ class FileStoreTest {
         "ContentType should be '" + TEXT_PLAIN + "'").isEqualTo(TEXT_PLAIN);
     assertThat(returnedObject.getContentEncoding()).as(
         "ContentEncoding should be '" + ENCODING_GZIP + "'").isEqualTo(ENCODING_GZIP);
-    assertThat(returnedObject.getMd5()).as("MD5 should be '" + md5 + "'").isEqualTo(md5);
+    assertThat(returnedObject.getEtag()).as("MD5 should be '" + md5 + "'").isEqualTo(md5);
     assertThat(returnedObject.getSize()).as("Size should be '" + size + "'").isEqualTo(size);
     assertThat(returnedObject.isEncrypted()).as("File should not be encrypted!").isFalse();
 
@@ -385,7 +385,7 @@ class FileStoreTest {
 
     final String sourceBucketName = "sourceBucket";
     final String sourceObjectName = sourceFile.getName();
-    final String md5 = HashUtil.getDigest(TEST_ENC_KEY, new FileInputStream(sourceFile));
+    final String md5 = DigestUtil.getHexDigest(TEST_ENC_KEY, new FileInputStream(sourceFile));
 
     fileStore.putS3Object(sourceBucketName, sourceObjectName, TEXT_PLAIN, ENCODING_GZIP,
         new FileInputStream(sourceFile), false);
@@ -403,7 +403,7 @@ class FileStoreTest {
     assertThat(copiedObject.isEncrypted()).as("File should be encrypted!").isTrue();
     assertThat(copiedObject.getSize()).as("Files should have the same length").isEqualTo(
         String.valueOf(sourceFile.length()));
-    assertThat(copiedObject.getMd5()).as("MD5 should match").isEqualTo(md5);
+    assertThat(copiedObject.getEtag()).as("MD5 should match").isEqualTo(md5);
   }
 
   /**

--- a/testsupport/junit4/src/test/java/com/adobe/testing/s3mock/junit4/S3MockRuleTest.java
+++ b/testsupport/junit4/src/test/java/com/adobe/testing/s3mock/junit4/S3MockRuleTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.adobe.testing.s3mock.junit4;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
@@ -56,8 +56,8 @@ public class S3MockRuleTest {
     final S3Object s3Object = s3Client.getObject(BUCKET_NAME, uploadFile.getName());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
+    final String uploadHash = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedHash = DigestUtil.getHexDigest(s3Object.getObjectContent());
     uploadFileIs.close();
     s3Object.close();
 

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -45,5 +45,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionDeclarativeTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionDeclarativeTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
 
 package com.adobe.testing.s3mock.junit5.sdk1;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
@@ -57,12 +56,13 @@ class S3MockExtensionDeclarativeTest {
     final S3Object s3Object = s3Client.getObject(BUCKET_NAME, uploadFile.getName());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedDigest = DigestUtil.getHexDigest(s3Object.getObjectContent());
     uploadFileIs.close();
     s3Object.close();
 
-    assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 
   @Nested
@@ -70,7 +70,7 @@ class S3MockExtensionDeclarativeTest {
 
     @Test
     void nestedTestShouldNotStartSecondInstanceOfMock(final AmazonS3 s3Client) {
-      assertNotNull(s3Client);
+      assertThat(s3Client).isNotNull();
     }
   }
 }

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk1/S3MockExtensionProgrammaticTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package com.adobe.testing.s3mock.junit5.sdk1;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
@@ -58,11 +58,12 @@ class S3MockExtensionProgrammaticTest {
     final S3Object s3Object = s3Client.getObject(BUCKET_NAME, uploadFile.getName());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedDigest = DigestUtil.getHexDigest(s3Object.getObjectContent());
     uploadFileIs.close();
     s3Object.close();
 
-    assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 }

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionDeclarativeTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
 
 package com.adobe.testing.s3mock.junit5.sdk2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -65,12 +64,13 @@ class S3MockExtensionDeclarativeTest {
             GetObjectRequest.builder().bucket(BUCKET_NAME).key(uploadFile.getName()).build());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(response);
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedDigest = DigestUtil.getHexDigest(response);
     uploadFileIs.close();
     response.close();
 
-    assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 
   @Nested
@@ -78,7 +78,7 @@ class S3MockExtensionDeclarativeTest {
 
     @Test
     void nestedTestShouldNotStartSecondInstanceOfMock(final S3Client s3Client) {
-      assertNotNull(s3Client);
+      assertThat(s3Client).isNotNull();
     }
   }
 }

--- a/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionProgrammaticTest.java
+++ b/testsupport/junit5/src/test/java/com/adobe/testing/s3mock/junit5/sdk2/S3MockExtensionProgrammaticTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package com.adobe.testing.s3mock.junit5.sdk2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -67,11 +67,12 @@ class S3MockExtensionProgrammaticTest {
             GetObjectRequest.builder().bucket(BUCKET_NAME).key(uploadFile.getName()).build());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(response);
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedDigest = DigestUtil.getHexDigest(response);
     uploadFileIs.close();
     response.close();
 
-    assertEquals(uploadHash, downloadedHash, "Up- and downloaded Files should have equal Hashes");
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 }

--- a/testsupport/testcontainers/src/test/java/com/adobe/testing/s3mock/testcontainers/S3MockContainerTestBase.java
+++ b/testsupport/testcontainers/src/test/java/com/adobe/testing/s3mock/testcontainers/S3MockContainerTestBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
 
-import com.adobe.testing.s3mock.util.HashUtil;
+import com.adobe.testing.s3mock.util.DigestUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -78,13 +78,13 @@ abstract class S3MockContainerTestBase {
             GetObjectRequest.builder().bucket(BUCKET_NAME).key(uploadFile.getName()).build());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(response);
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedDigest = DigestUtil.getHexDigest(response);
     uploadFileIs.close();
     response.close();
 
-    assertThat(uploadHash).as("Up- and downloaded Files should have equal Hashes")
-        .isEqualTo(downloadedHash);
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 
   /**

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -39,6 +39,11 @@
       <groupId>com.adobe.testing</groupId>
       <artifactId>s3mock-testsupport-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXmlConfigurationTest.java
+++ b/testsupport/testng/src/test/java/com/adobe/testing/s3mock/testng/S3MockListenerXmlConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2019 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 
 package com.adobe.testing.s3mock.testng;
 
-import com.adobe.testing.s3mock.util.HashUtil;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.adobe.testing.s3mock.util.DigestUtil;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test
@@ -49,12 +50,12 @@ public class S3MockListenerXmlConfigurationTest {
     final S3Object s3Object = s3Client.getObject(BUCKET_NAME, uploadFile.getName());
 
     final InputStream uploadFileIs = new FileInputStream(uploadFile);
-    final String uploadHash = HashUtil.getDigest(uploadFileIs);
-    final String downloadedHash = HashUtil.getDigest(s3Object.getObjectContent());
+    final String uploadDigest = DigestUtil.getHexDigest(uploadFileIs);
+    final String downloadedDigest = DigestUtil.getHexDigest(s3Object.getObjectContent());
     uploadFileIs.close();
     s3Object.close();
 
-    Assert.assertEquals(uploadHash, downloadedHash,
-        "Up- and downloaded Files should have equal Hashes");
+    assertThat(uploadDigest).isEqualTo(downloadedDigest).as(
+        "Up- and downloaded Files should have equal digests");
   }
 }


### PR DESCRIPTION
## Description
Fixed etag handling. Not sure why this was all mixed with MD5 handling.
Added Content-MD5 handling.

## Related Issue
#208

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
