### PR TITLE
Add a possibility to use only the FileStoreController as an applicati…

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -136,8 +136,8 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
  * Controller to handle http requests.
  */
 @CrossOrigin(origins = "*")
-@RequestMapping
-class FileStoreController {
+@RequestMapping("${http.mapping.contextPath:}")
+public class FileStoreController {
   private static final String RANGES_BYTES = "bytes";
 
   private static final String STREAMING_AWS_4_HMAC_SHA_256_PAYLOAD =

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -53,6 +53,8 @@ public class S3MockApplication {
   public static final int DEFAULT_HTTP_PORT = 9090;
   public static final int RANDOM_PORT = 0;
 
+  public static final String DEFAULT_HTTP_CONTEXT_PATH = "";
+
   public static final String DEFAULT_SERVER_SSL_KEY_STORE = "classpath:s3mock.jks";
   public static final String DEFAULT_SERVER_SSL_KEY_STORE_PASSWORD = "password";
   public static final String DEFAULT_SERVER_SSL_KEY_ALIAS = "selfsigned";
@@ -79,6 +81,15 @@ public class S3MockApplication {
    * to {@value RANDOM_PORT}, a random port will be chosen.
    */
   public static final String PROP_HTTP_PORT = "http.port";
+
+
+  /**
+   * Property name for passing the global context path to use.
+   * Defaults to {@value DEFAULT_HTTP_CONTEXT_PATH}.
+   * For example if set to `/s3-mock` all endpoints will be available at
+   * `http://host:port/s3-mock` instead of `http://host:port/`
+   */
+  public static final String PROP_HTTP_CONTEXT_PATH = " http.mapping.contextPath";
 
   /**
    * Property name for passing the path to the keystore to use.
@@ -160,6 +171,8 @@ public class S3MockApplication {
     final Map<String, Object> defaults = new HashMap<>();
     defaults.put(PROP_HTTPS_PORT, DEFAULT_HTTPS_PORT);
     defaults.put(PROP_HTTP_PORT, DEFAULT_HTTP_PORT);
+
+    defaults.put(PROP_HTTP_CONTEXT_PATH, DEFAULT_HTTP_CONTEXT_PATH);
 
     // Specify the default SSL parameters here. Users can override them
     defaults.put(SERVER_SSL_KEY_STORE, DEFAULT_SERVER_SSL_KEY_STORE);

--- a/server/src/test/java/com/adobe/testing/s3mock/ContextPathFileStoreControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/ContextPathFileStoreControllerTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.adobe.testing.s3mock.dto.Bucket;
+import com.adobe.testing.s3mock.dto.Buckets;
+import com.adobe.testing.s3mock.dto.ListAllMyBucketsResult;
+import com.adobe.testing.s3mock.dto.Owner;
+import com.adobe.testing.s3mock.store.FileStore;
+import com.adobe.testing.s3mock.store.KmsKeyStore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@AutoConfigureWebMvc
+@AutoConfigureMockMvc
+@SpringBootTest(classes = {S3MockConfiguration.class},
+    properties = {"http.mapping.contextPath=s3-mock"})
+class ContextPathFileStoreControllerTest {
+  private static final Owner TEST_OWNER = new Owner(123, "s3-mock-file-store");
+  private static final ObjectMapper MAPPER = new XmlMapper();
+
+  private static final String TEST_BUCKET_NAME = "testBucket";
+  private static final Bucket TEST_BUCKET =
+      new Bucket(Paths.get("/tmp/foo/1"), TEST_BUCKET_NAME, Instant.now().toString());
+
+  @MockBean
+  private KmsKeyStore kmsKeyStore; //Dependency of S3MockConfiguration.
+
+  @MockBean
+  private FileStore fileStore;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void testListBuckets_Ok() throws Exception {
+    List<Bucket> bucketList = new ArrayList<>();
+    bucketList.add(TEST_BUCKET);
+    bucketList.add(new Bucket(Paths.get("/tmp/foo/2"), "testBucket1", Instant.now().toString()));
+    when(fileStore.listBuckets()).thenReturn(bucketList);
+
+    ListAllMyBucketsResult expected = new ListAllMyBucketsResult();
+    Buckets buckets = new Buckets();
+    buckets.setBuckets(bucketList);
+    expected.setBuckets(buckets);
+    expected.setOwner(TEST_OWNER);
+
+    mockMvc.perform(
+            get("/s3-mock/")
+                .accept(MediaType.APPLICATION_XML)
+                .contentType(MediaType.APPLICATION_XML)
+        ).andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_XML))
+        .andExpect(MockMvcResultMatchers.content().xml(MAPPER.writeValueAsString(expected)));
+  }
+}
+
+


### PR DESCRIPTION
…on bean instead of the full application

## Description
Because of advanced concepts in our library (the library is used by other teams) like autoconfiguration, bootstrap configurations, etc, we are not able to use the S3 mock with the proposed way (as a Spring Boot application). Ideally, it would be to have the ability to inject the `FileStoreController` as a bean, but it needs small changes included in the PR).

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
