### PR TITLE
Add multi-part upload checks, S3 has a minimum size allowed of 5MB

### DIFF
--- a/integration-tests/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesIT.java
+++ b/integration-tests/src/test/java/com/adobe/testing/s3mock/its/ErrorResponsesIT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -244,7 +244,7 @@ public class ErrorResponsesIT extends S3TestBase {
 
     s3Client.createBucket(BUCKET_NAME);
 
-    final TransferManager transferManager = createDefaultTransferManager();
+    final TransferManager transferManager = createTransferManager();
     assertThatThrownBy(() -> {
       final Upload upload = transferManager.upload(
           new PutObjectRequest(UUID.randomUUID().toString(), UPLOAD_FILE_NAME, uploadFile));
@@ -370,7 +370,7 @@ public class ErrorResponsesIT extends S3TestBase {
 
     s3Client.createBucket(BUCKET_NAME);
 
-    final TransferManager transferManager = createDefaultTransferManager();
+    final TransferManager transferManager = createTransferManager();
     final Upload upload =
         transferManager.upload(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
     upload.waitForUploadResult();
@@ -395,7 +395,7 @@ public class ErrorResponsesIT extends S3TestBase {
 
     s3Client.createBucket(BUCKET_NAME);
 
-    final TransferManager transferManager = createDefaultTransferManager();
+    final TransferManager transferManager = createTransferManager();
     final Upload upload =
         transferManager.upload(new PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile));
     upload.waitForUploadResult();
@@ -414,7 +414,8 @@ public class ErrorResponsesIT extends S3TestBase {
    */
   @Test
   public void multipartCopyToNonExistingBucket() throws InterruptedException {
-    final int contentLen = 3 * _1MB;
+    //content larger than default part threshold of 5MiB
+    final int contentLen = 7 * _1MB;
 
     final ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentLength(contentLen);
@@ -423,7 +424,7 @@ public class ErrorResponsesIT extends S3TestBase {
 
     final Bucket sourceBucket = s3Client.createBucket(UUID.randomUUID().toString());
 
-    final TransferManager transferManager = createTransferManager(_2MB, _1MB, _2MB, _1MB);
+    final TransferManager transferManager = createTransferManager();
 
     final InputStream sourceInputStream = randomInputStream(contentLen);
     final Upload upload = transferManager
@@ -446,7 +447,8 @@ public class ErrorResponsesIT extends S3TestBase {
    */
   @Test
   public void multipartCopyNonExistingObject() throws InterruptedException {
-    final int contentLen = 3 * _1MB;
+    //content larger than default part threshold of 5MiB
+    final int contentLen = 7 * _1MB;
 
     final ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentLength(contentLen);
@@ -456,7 +458,7 @@ public class ErrorResponsesIT extends S3TestBase {
     final Bucket sourceBucket = s3Client.createBucket(UUID.randomUUID().toString());
     final Bucket targetBucket = s3Client.createBucket(UUID.randomUUID().toString());
 
-    final TransferManager transferManager = createTransferManager(_2MB, _1MB, _2MB, _1MB);
+    final TransferManager transferManager = createTransferManager();
 
     final InputStream sourceInputStream = randomInputStream(contentLen);
     final Upload upload = transferManager

--- a/integration-tests/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
+++ b/integration-tests/src/test/java/com/adobe/testing/s3mock/its/S3TestBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -74,6 +74,8 @@ abstract class S3TestBase {
       "arn:aws:kms:us-east-1:1234567890:keyWRONGWRONGWRONG/2d70f7f6-b484-4309-91d5-7813b7dd46ce";
   static final int _1MB = 1024 * 1024;
   static final long _2MB = 2L * _1MB;
+  static final long _5MB = 5L * _1MB;
+  static final long _6MB = 6L * _1MB;
   private static final long _6BYTE = 6L;
 
   private static final int THREAD_COUNT = 50;
@@ -209,14 +211,7 @@ abstract class S3TestBase {
     }
   }
 
-  TransferManager createDefaultTransferManager() {
-    return createTransferManager(_6BYTE, _6BYTE, _6BYTE, _6BYTE);
-  }
-
-  TransferManager createTransferManager(final long multipartUploadThreshold,
-      final long multipartUploadPartSize,
-      final long multipartCopyThreshold,
-      final long multipartCopyPartSize) {
+  TransferManager createTransferManager() {
     final ThreadFactory threadFactory = new ThreadFactory() {
       private int threadCount = 1;
 
@@ -232,10 +227,6 @@ abstract class S3TestBase {
     return TransferManagerBuilder.standard()
         .withS3Client(s3Client)
         .withExecutorFactory(() -> Executors.newFixedThreadPool(THREAD_COUNT, threadFactory))
-        .withMultipartUploadThreshold(multipartUploadThreshold)
-        .withMinimumUploadPartSize(multipartUploadPartSize)
-        .withMultipartCopyPartSize(multipartCopyPartSize)
-        .withMultipartCopyThreshold(multipartCopyThreshold)
         .build();
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -160,6 +160,8 @@ class FileStoreController {
 
   private static final MediaType FALLBACK_MEDIA_TYPE = new MediaType("binary", "octet-stream");
 
+  private static final Long MINIMUM_PART_SIZE = 5L * 1024L * 1024L;
+
   private final Map<String, String> fileStorePagingStateCache = new ConcurrentHashMap<>();
   private final FileStore fileStore;
 
@@ -298,11 +300,11 @@ class FileStoreController {
           required = false) final Integer maxKeys) {
     verifyBucketExistence(bucketName);
     if (maxKeys < 0) {
-      throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
+      throw new S3Exception(BAD_REQUEST.value(), "InvalidRequest",
           "maxKeys should be non-negative");
     }
     if (isNotEmpty(encodingType) && !"url".equals(encodingType)) {
-      throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
+      throw new S3Exception(BAD_REQUEST.value(), "InvalidRequest",
           "encodingtype can only be none or 'url'");
     }
 
@@ -376,7 +378,7 @@ class FileStoreController {
           defaultValue = "1000", required = false) final Integer maxKeys,
       @RequestParam(name = CONTINUATION_TOKEN, required = false) final String continuationToken) {
     if (isNotEmpty(encodingtype) && !"url".equals(encodingtype)) {
-      throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
+      throw new S3Exception(BAD_REQUEST.value(), "InvalidRequest",
           "encodingtype can only be none or 'url'");
     }
 
@@ -1320,11 +1322,11 @@ class FileStoreController {
     try {
       partNumber = Integer.parseInt(partNumberString);
     } catch (final NumberFormatException nfe) {
-      throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
+      throw new S3Exception(BAD_REQUEST.value(), "InvalidRequest",
           "Part number must be an integer between 1 and 10000, inclusive");
     }
     if (partNumber < 1 || partNumber > 10000) {
-      throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidRequest",
+      throw new S3Exception(BAD_REQUEST.value(), "InvalidRequest",
           "Part number must be an integer between 1 and 10000, inclusive");
     }
   }
@@ -1338,9 +1340,24 @@ class FileStoreController {
   }
 
   private void validateMultipartParts(final String bucketName, final String filename,
-      final String uploadId, final List<Part> requestedParts) {
+      final String uploadId, final List<Part> requestedParts) throws S3Exception {
     final List<Part> uploadedParts =
         fileStore.getMultipartUploadParts(bucketName, filename, uploadId);
+    if (uploadedParts.size() == 0) {
+      throw new S3Exception(NOT_FOUND.value(), "NoSuchUpload",
+          "The specified multipart upload does not exist. The upload ID might be invalid, or the "
+              + "multipart upload might have been aborted or completed.");
+    }
+
+    for (int i = 0; i < uploadedParts.size() - 1; i++) {
+      Part part = uploadedParts.get(i);
+      if (part.getSize() < MINIMUM_PART_SIZE) {
+        throw new S3Exception(BAD_REQUEST.value(), "EntityTooSmall",
+            "Your proposed upload is smaller than the minimum allowed object size. "
+                + "Each part must be at least 5 MB in size, except the last part.");
+      }
+    }
+
     final Map<Integer, String> uploadedPartsMap =
         uploadedParts.stream().collect(Collectors.toMap(Part::getPartNumber, Part::getETag));
 
@@ -1349,13 +1366,13 @@ class FileStoreController {
       if (!uploadedPartsMap.containsKey(part.getPartNumber())
           || !uploadedPartsMap.get(part.getPartNumber())
           .equals(part.getETag().replaceAll("^\"|\"$", ""))) {
-        throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidPart",
+        throw new S3Exception(BAD_REQUEST.value(), "InvalidPart",
             "One or more of the specified parts could not be found. The part might not have been "
                 + "uploaded, or the specified entity tag might not have matched the part's entity"
                 + " tag.");
       }
       if (part.getPartNumber() < prevPartNumber) {
-        throw new S3Exception(HttpStatus.BAD_REQUEST.value(), "InvalidPartOrder",
+        throw new S3Exception(BAD_REQUEST.value(), "InvalidPartOrder",
             "The list of parts was not in ascending order. The parts list must be specified in "
                 + "order by part number.");
       }


### PR DESCRIPTION
## Description
AWS allows multipart uploads only if all parts (but the last) are at
least 5MB in size. All tests were using payloads that are too small,
mis-configured TransferManager instances cutting the payloads in parts
that are below 5MB in size.


## Related Issue
#392 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
