### PR TITLE
Tagging

### DIFF
--- a/integration-tests/src/test/java/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.java
+++ b/integration-tests/src/test/java/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.java
@@ -20,24 +20,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.Tag;
 
 public class TaggingResponsesV2IT extends S3TestBase {
-    private final String bucket = INITIAL_BUCKET_NAMES.iterator().next();
+  private final String bucket = INITIAL_BUCKET_NAMES.iterator().next();
 
-    @BeforeEach
-    public void setup() {
-        s3ClientV2.putObject(b -> b.bucket(bucket).key("foo").tagging("msv=foo"), RequestBody.fromString("foo"));
-    }
+  @BeforeEach
+  public void setup() {
+    s3ClientV2.putObject(
+        b -> b.bucket(bucket).key("foo").tagging("msv=foo"), RequestBody.fromString("foo"));
+  }
 
-    /**
-     * Verify that tagging can be obtained and returns expected content.
-     */
-    @Test
-    public void testGetObjectTagging() {
-        assertThat(s3ClientV2.getObjectTagging(b -> b.bucket(bucket).key("foo")).tagSet())
-            .contains(Tag.builder().key("msv").value("foo").build());
-    }
+  /**
+   * Verify that tagging can be obtained and returns expected content.
+   */
+  @Test
+  public void testGetObjectTagging() {
+    assertThat(s3ClientV2.getObjectTagging(b -> b.bucket(bucket).key("foo")).tagSet())
+        .contains(Tag.builder().key("msv").value("foo").build());
+  }
 }

--- a/integration-tests/src/test/java/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.java
+++ b/integration-tests/src/test/java/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.java
+++ b/integration-tests/src/test/java/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2017-2021 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.Tag;
+
+public class TaggingResponsesV2IT extends S3TestBase {
+    private final String bucket = INITIAL_BUCKET_NAMES.iterator().next();
+
+    @BeforeEach
+    public void setup() {
+        s3ClientV2.putObject(b -> b.bucket(bucket).key("foo").tagging("msv=foo"), RequestBody.fromString("foo"));
+    }
+
+    /**
+     * Verify that tagging can be obtained and returns expected content.
+     */
+    @Test
+    public void testGetObjectTagging() {
+        assertThat(s3ClientV2.getObjectTagging(b -> b.bucket(bucket).key("foo")).tagSet())
+            .contains(Tag.builder().key("msv").value("foo").build());
+    }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -119,7 +119,6 @@ import org.apache.commons.io.input.BoundedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -947,10 +947,14 @@ public class FileStoreController {
     copyTo(inputStream, byteArrayOutputStream);
 
     InputStream stream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
-    if (isV4ChunkedWithSigningEnabled(sha256Header)) {
-      stream = new AwsChunkedDecodingInputStream(stream);
+    try {
+      if (isV4ChunkedWithSigningEnabled(sha256Header)) {
+        stream = new AwsChunkedDecodingInputStream(stream);
+      }
+      verifyMd5(stream, contentMd5);
+    } finally {
+      IOUtils.closeQuietly(stream);
     }
-    verifyMd5(stream, contentMd5);
     return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -682,7 +682,8 @@ public class FileStoreController {
       params = {
           TAGGING
       },
-      method = RequestMethod.GET
+      method = RequestMethod.GET,
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<Tagging> getObjectTagging(@PathVariable final String bucketName,
       final HttpServletRequest request) {


### PR DESCRIPTION
## Description
Mark `#getObjectTagging()` as producing `application/xml`

## Related Issue
https://github.com/adobe/S3Mock/issues/405

## Tasks
- [X] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
