### PR TITLE
Change Docker image entrypoint to exec form

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017-2021 Adobe.
+#  Copyright 2017-2022 Adobe.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,4 +82,4 @@ ENV root=/s3mockroot
 EXPOSE 9090 9191
 
 # run the app on startup
-ENTRYPOINT java -XX:+UseContainerSupport -Xmx128m --illegal-access=warn -Djava.security.egd=file:/dev/./urandom -jar s3mock.jar
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-Xmx128m", "--illegal-access=warn", "-Djava.security.egd=file:/dev/./urandom", "-jar", "s3mock.jar"]


### PR DESCRIPTION
## Description
Currently, the Docker image entrypoint is in the shell form. Changing it to the exec form allows to run the Docker image with additional arguments, like the server port, without having to redefine the whole command.

See https://docs.docker.com/engine/reference/builder/#entrypoint

## Tasks
- [ X ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ X ] I have written tests and verified that they fail without my change.
