### PR TITLE
434 fix property overrides

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -61,12 +61,15 @@ public class S3MockApplication {
   /**
    * Property name for passing a comma separated list of buckets that are to be created at startup.
    */
-  public static final String PROP_INITIAL_BUCKETS = "initialBuckets";
+  public static final String PROP_INITIAL_BUCKETS =
+      "com.adobe.testing.s3mock.domain.initialBuckets";
+  private static final String LEGACY_PROP_INITIAL_BUCKETS = "initialBuckets";
 
   /**
    * Property name for passing a root directory to use. If omitted a default temp-dir will be used.
    */
-  public static final String PROP_ROOT_DIRECTORY = "root";
+  public static final String PROP_ROOT_DIRECTORY = "com.adobe.testing.s3mock.domain.root";
+  private static final String LEGACY_PROP_ROOT_DIRECTORY = "root";
 
   /**
    * Property name for passing the HTTPS port to use. Defaults to {@value DEFAULT_HTTPS_PORT}. If
@@ -176,12 +179,66 @@ public class S3MockApplication {
 
     final ConfigurableApplicationContext ctx =
         new SpringApplicationBuilder(S3MockApplication.class)
-            .properties(defaults)
-            .properties(properties)
+            .properties(translateLegacyProperties(defaults))
+            .properties(translateLegacyProperties(properties))
             .bannerMode(bannerMode)
             .run(args);
 
     return ctx.getBean(S3MockApplication.class);
+  }
+
+  /**
+   * Hack to still support startup of S3Mock from Java, e.g. in a (J)Unit-Test using one of the
+   * Unit test integration modules.
+   * -----------
+   * TODO: Remove ASAP as this breaks Spring's Externalized Configuration
+   * https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config
+   * -----------
+   * S3Mock is using @Configuration / @ConfigurationProperties for each package.
+   * Before this was implemented, all properties were exposed without a package.
+   * Translation of these properties should be done in "application.properties" as is standard with
+   * Spring (Boot) applications. However, if S3Mock is used directly in a unit test from within a
+   * Spring application, S3Mock reads the "application.properties" of the tested application instead
+   * of its own "application.properties".
+   * This is equivalent to:
+   * com.adobe.testing.s3mock.httpPort=${http.port:}
+   * com.adobe.testing.s3mock.domain.initialBuckets=${initialBuckets:}
+   * com.adobe.testing.s3mock.domain.retainFilesOnExit=${retainFilesOnExit:}
+   * com.adobe.testing.s3mock.domain.root=${root:}
+   * com.adobe.testing.s3mock.domain.validKmsKeys=${validKmsKeys:}
+   */
+  private static Map<String, Object> translateLegacyProperties(Map<String, Object> properties) {
+    // make incoming map mutable
+    Map<String, Object> translated = new HashMap<>(properties);
+    translateLegacyProperty(translated, PROP_ROOT_DIRECTORY, LEGACY_PROP_ROOT_DIRECTORY);
+    translateLegacyProperty(translated, PROP_INITIAL_BUCKETS, LEGACY_PROP_INITIAL_BUCKETS);
+    translateLegacyProperty(translated,
+        "com.adobe.testing.s3mock.domain.retainFilesOnExit", "retainFilesOnExit");
+    translateLegacyProperty(translated,
+        "com.adobe.testing.s3mock.domain.validKmsKeys", "validKmsKeys");
+    translateLegacyProperty(translated,
+        "com.adobe.testing.s3mock.httpPort", "http.port");
+    return translated;
+  }
+
+  private static void translateLegacyProperty(Map<String, Object> properties, String propertyName,
+      String legacyPropertyName) {
+    if (!properties.containsKey(propertyName)) {
+      // start by looking at incoming properties
+      if (properties.containsKey(legacyPropertyName)) {
+        properties.put(propertyName, properties.get(legacyPropertyName));
+      }
+      // these may be overwritten by system properties
+      String legacySystemProperty = System.getProperty(legacyPropertyName);
+      if (legacySystemProperty != null) {
+        properties.put(propertyName, legacySystemProperty);
+      }
+      // highest precedence to environment variables.
+      String legacyEnvironmentProperty = System.getenv(legacyPropertyName);
+      if (legacyEnvironmentProperty != null) {
+        properties.put(propertyName, legacyEnvironmentProperty);
+      }
+    }
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/store/DomainProperties.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/DomainProperties.java
@@ -16,6 +16,7 @@
 
 package com.adobe.testing.s3mock.store;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -39,7 +40,7 @@ class DomainProperties {
   /**
    * Property name for passing a comma separated list of buckets that are to be created at startup.
    */
-  private List<String> initialBuckets;
+  private List<String> initialBuckets = new ArrayList<>();
 
   public List<String> getInitialBuckets() {
     return initialBuckets;

--- a/server/src/main/java/com/adobe/testing/s3mock/store/DomainProperties.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/DomainProperties.java
@@ -26,19 +26,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 class DomainProperties {
 
   /**
-   * Property.
+   * True if files should be retained when S3Mock exits gracefully.
+   * False to let S3Mock delete all files when S3Mock exits gracefully.
    */
   private boolean retainFilesOnExit;
 
   /**
-   * Property name for passing a root directory to use. If omitted a default temp-dir will be used.
+   * The root directory to use. If omitted a default temp-dir will be used.
    */
   private String root;
 
   private Set<String> validKmsKeys = new HashSet<>();
 
   /**
-   * Property name for passing a comma separated list of buckets that are to be created at startup.
+   * A comma separated list of buckets that are to be created at startup.
    */
   private List<String> initialBuckets = new ArrayList<>();
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -20,12 +20,5 @@
 logging.level.org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver=ERROR
 logging.level.org.eclipse.jetty.util.ssl.SslContextFactory.config=ERROR
 
-# map legacy properties
-com.adobe.testing.s3mock.httpPort=${http.port:9090}
-com.adobe.testing.s3mock.domain.initialBuckets=${initialBuckets:""}
-com.adobe.testing.s3mock.domain.retainFilesOnExit=${retainFilesOnExit:false}
-com.adobe.testing.s3mock.domain.root=${root:""}
-com.adobe.testing.s3mock.domain.validKmsKeys=${validKmsKeys:""}
-
 # deactivate JMX to save resources and startup time
 spring.jmx.enabled=false

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -40,12 +40,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/testsupport/testcontainers/src/main/java/com/adobe/testing/s3mock/testcontainers/S3MockContainer.java
+++ b/testsupport/testcontainers/src/main/java/com/adobe/testing/s3mock/testcontainers/S3MockContainer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -57,11 +57,15 @@ public class S3MockContainer extends GenericContainer<S3MockContainer> {
   }
 
   public S3MockContainer withValidKmsKeys(String kmsKeys) {
+    //TODO: this uses the legacy-style properties. Leave for now as test that property translation
+    // works in S3MockApplication.
     this.addEnv("validKmsKeys", kmsKeys);
     return self();
   }
 
   public S3MockContainer withInitialBuckets(String initialBuckets) {
+    //TODO: this uses the legacy-style properties. Leave for now as test that property translation
+    // works in S3MockApplication.
     this.addEnv("initialBuckets", initialBuckets);
     return self();
   }
@@ -74,6 +78,8 @@ public class S3MockContainer extends GenericContainer<S3MockContainer> {
    */
   public S3MockContainer withVolumeAsRoot(String root) {
     this.withFileSystemBind(root, "/s3mockroot", BindMode.READ_WRITE);
+    //TODO: this uses the legacy-style properties. Leave for now as test that property translation
+    // works in S3MockApplication.
     this.addEnv("root", "/s3mockroot");
     return self();
   }


### PR DESCRIPTION
## Description
Manually translate legacy to new property names.

When starting the S3Mock directly from Java with an 
"application.properties" in the  classpath, the S3Mock's bundled 
"application.properties" is not found anymore, so we can't do property 
translation there.

Implementing a poor man's property translation that directly interferes
with Spring's "Externalized Properties" precedence order here.
Need to deprecate direct usage and remove this ASAP.

"Fixes" #434

Probably breaks other integrations, we'll see...

## Related Issue
#434

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
