### PR TITLE
ListParts throw exception when there is no upload

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
@@ -1037,6 +1037,11 @@ public class FileStore {
   public List<Part> getMultipartUploadParts(final String bucketName,
       final String fileName,
       final String uploadId) {
+    final MultipartUploadInfo uploadInfo = uploadIdToInfo.get(uploadId);
+    if (uploadInfo == null) {
+      throw new IllegalArgumentException("Unknown upload " + uploadId);
+    }
+
     final File partsDirectory = retrieveFile(bucketName, fileName, uploadId);
     final String[] partNames = listAndSortPartsInFromDirectory(partsDirectory);
 

--- a/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
@@ -616,19 +616,6 @@ class FileStoreTest {
     assertThat(e.getMessage()).isEqualTo("Unknown upload 12345");
   }
 
-@Test
-  void missingUploadPreparation() {
-    Range range = new Range(0, 0);
-    IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () ->
-        fileStore.copyPart(
-            TEST_BUCKET_NAME, UUID.randomUUID().toString(), range, "1",
-            TEST_BUCKET_NAME, UUID.randomUUID().toString(), UUID.randomUUID().toString())
-    );
-
-    assertThat(e.getMessage()).isEqualTo("Missed preparing Multipart Request");
-  }
-
-
   private Part prepareExpectedPart(final int partNumber, final String content) {
     Part part = new Part();
     part.setETag(String.format("%s", DigestUtils.md5Hex(content)));

--- a/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
@@ -613,7 +613,7 @@ class FileStoreTest {
         ffileStore.getMultipartUploadParts(TEST_BUCKET_NAME, fileName, uploadId)
     );
 
-    assertThat(e.getMessage()).isEqualTo("Unknown upload 12345");
+    assertThat(e.getMessage()).isEqualTo("Unknown upload UNKNOWN");
   }
 
   private Part prepareExpectedPart(final int partNumber, final String content) {

--- a/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/FileStoreTest.java
@@ -604,6 +604,31 @@ class FileStoreTest {
     fileStore.abortMultipartUpload(TEST_BUCKET_NAME, fileName, uploadId);
   }
 
+  @Test
+  void missingUploadFromGetMultipartUploadParts() throws IOException {
+    final String fileName = "PartFile";
+    final String uploadId = "UNKNOWN";
+
+    IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () ->
+        ffileStore.getMultipartUploadParts(TEST_BUCKET_NAME, fileName, uploadId)
+    );
+
+    assertThat(e.getMessage()).isEqualTo("Unknown upload 12345");
+  }
+
+@Test
+  void missingUploadPreparation() {
+    Range range = new Range(0, 0);
+    IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () ->
+        fileStore.copyPart(
+            TEST_BUCKET_NAME, UUID.randomUUID().toString(), range, "1",
+            TEST_BUCKET_NAME, UUID.randomUUID().toString(), UUID.randomUUID().toString())
+    );
+
+    assertThat(e.getMessage()).isEqualTo("Missed preparing Multipart Request");
+  }
+
+
   private Part prepareExpectedPart(final int partNumber, final String content) {
     Part part = new Part();
     part.setETag(String.format("%s", DigestUtils.md5Hex(content)));


### PR DESCRIPTION
## Description
`ListParts` API should return error when there is no upload.
Below is AWS S3 req, response example.
```
// aws-cli
aws s3api list-parts --bucket test-bucket --key 'multipart/01' --upload-id dfRtDYU0WWCCcH43C3WFbkRONycyCpTJJvxu2i5GYkZljF.Yxwh6XG7WfS2vC4to6HiV6Yjlx.cph0gtNBtJ8P3URCSbB7rjxI5iEwVDmgaXZOGgkk5nVTW16HOQ5l0R --debug

// REQUEST
2022-03-10 21:35:48,788 - MainThread - botocore.auth - DEBUG - CanonicalRequest:
GET
/multipart/01
uploadId=dfRtDYU0WWCCcH43C3WFbkRONycyCpTJJvxu2i5GYkZljF.Yxwh6XG7WfS2vC4to6HiV6Yjlx.cph0gtNBtJ8P3URCSbB7rjxI5iEwVDmgaXZOGgkk5nVTW16HOQ5l0R
host:test-bucket.s3.ap-northeast-2.amazonaws.com

// RESPONSE
<?xml version="1.0" encoding="UTF-8"?>\n
<Error>
	<Code>NoSuchUpload</Code>
	<Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>
	<UploadId>dfRtDYU0WWCCcH43C3WFbkRONycyCpTJJvxu2i5GYkZljF.Yxwh6XG7WfS2vC4to6HiV6Yjlx.cph0gtNBtJ8P3URCSbB7rjxI5iEwVDmgaXZOGgkk5nVTW16HOQ5l0R</UploadId>
	<RequestId>HV7DERPTA08P6HQ7</RequestId>
	<HostId>kw6Xde37mVyxKeg6R4QRmoW9ICFH1VbLtRA4keQ1T6bxUbCYVMz07QJY2taJScf1GKglAIy0xNc=</HostId>
</Error>
```

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
