### PR TITLE
Allow "copy" of key to same key.

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
@@ -700,6 +700,13 @@ public class FileStore {
     if (sourceObject == null) {
       return null;
     }
+    if (sourceObjectName.equals(destinationObjectName)
+        && sourceBucketName.equals(destinationBucketName)) {
+      // source and destination is the same, pretend we copied - S3 does the same.
+      // this does not change the modificationDate. Also, this would need to increment the
+      // version if/when we support versioning.
+      return new CopyObjectResult(sourceObject.getModificationDate(), sourceObject.getEtag());
+    }
     Map<String, String> copyUserMetadata = sourceObject.getUserMetadata();
     if (userMetadata != null && !userMetadata.isEmpty()) {
       copyUserMetadata = userMetadata;


### PR DESCRIPTION
## Description
This implementation just fakes the copy process - there currently is no
way to change particular metadata of an existing key in the FileStore.


## Related Issue
Fixes #468

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
