### PR TITLE
Adds missing x-amz-server-side-encryption and x-amz-server-side-encryption-aws-kms-key-id header

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -568,6 +568,7 @@ public class FileStoreController {
           .headers(headers -> headers.setAll(createUserMetadataHeaders(s3Object)))
           .headers(headers -> {
             if (s3Object.isEncrypted()) {
+              headers.set(X_AMZ_SERVER_SIDE_ENCRYPTION, s3Object.getKmsEncryption());
               headers.set(X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID, s3Object.getKmsKeyId());
             }
           })
@@ -678,6 +679,12 @@ public class FileStoreController {
         .header(HttpHeaders.CONTENT_ENCODING, s3Object.getContentEncoding())
         .header(HttpHeaders.ACCEPT_RANGES, RANGES_BYTES)
         .headers(headers -> headers.setAll(createUserMetadataHeaders(s3Object)))
+        .headers(headers -> {
+          if (s3Object.isEncrypted()) {
+            headers.set(X_AMZ_SERVER_SIDE_ENCRYPTION, s3Object.getKmsEncryption());
+            headers.set(X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID, s3Object.getKmsKeyId());
+          }
+        })
         .lastModified(s3Object.getLastModified())
         .contentLength(s3Object.getDataFile().length())
         .contentType(parseMediaType(s3Object.getContentType()))


### PR DESCRIPTION
## Description
Given PR adds missing `x-amz-server-side-encryption` and `x-amz-server-side-encryption-aws-kms-key-id` headers to the getObject and headObject responses.

**Problem statement:** Currently S3Mock doesn't return these headers in the getObject response (and partially returns in the headObject one). This leads to the exception to be thrown during the object integrity validation by AWS SDK while downloading encrypted object via getObject requests as `x-amz-server-side-encryption-aws-kms-key-id` header is used in the [SkipMd5CheckStrategy](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/SkipMd5CheckStrategy.java#L304-L310). 
Without this header object's etag value is compared to the InputStream digest and validation fails as etag of the encrypted object differs from the md5 checksum.

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
