### PR TITLE
Revert "Revert build to docker-maven-plugin with buildx"

### DIFF
--- a/docker/build-docker-image.sh
+++ b/docker/build-docker-image.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+#  Copyright 2017-2022 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+BUILDER_NAME=$1
+VERSIONED_TAG_NAME=$2
+LATEST_TAG_NAME=$3
+
+# build --load to make the Docker container available in the local architecture for local
+# integration tests.
+docker buildx build --load --tag "${VERSIONED_TAG_NAME}" --tag "${LATEST_TAG_NAME}" --builder "${BUILDER_NAME}" .

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -56,12 +56,6 @@
                     <tag>${project.version}</tag>
                     <tag>latest</tag>
                   </tags>
-                  <buildx>
-                    <platforms>
-                      <platform>linux/amd64</platform>
-                      <platform>linux/arm64</platform>
-                    </platforms>
-                  </buildx>
                 </build>
               </image>
             </images>
@@ -116,17 +110,69 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>docker-maven-plugin</artifactId>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
             <executions>
+              <execution>
+                <id>start-buildkit</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>sh</executable>
+                  <arguments>
+                    <argument>start-buildkit.sh</argument>
+                    <argument>${docker-builder.image.name}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
               <execution>
                 <id>build-docker-image</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>build</goal>
+                  <goal>exec</goal>
                 </goals>
+                <configuration>
+                  <executable>sh</executable>
+                  <arguments>
+                    <argument>build-docker-image.sh</argument>
+                    <argument>${docker-builder.image.name}</argument>
+                    <!-- Versioned tag name -->
+                    <argument>${docker.image.name}:${project.version}</argument>
+                    <!-- Latest tag name -->
+                    <argument>${docker.image.name}:latest</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>stop-buildkit</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>sh</executable>
+                  <arguments>
+                    <argument>stop-buildkit.sh</argument>
+                    <argument>${docker-builder.image.name}</argument>
+                  </arguments>
+                </configuration>
               </execution>
             </executions>
+            <configuration>
+              <includeProjectDependencies>true</includeProjectDependencies>
+              <includePluginDependencies>false</includePluginDependencies>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.adobe.testing</groupId>
+                <artifactId>s3mock</artifactId>
+                <classifier>exec</classifier>
+                <version>${project.version}</version>
+                <type>jar</type>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -139,17 +185,71 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>docker-maven-plugin</artifactId>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
             <executions>
+              <!-- Declare start/stop here again as we can't be sure if the regular stop goal was
+               executed before the "push-docker-image" goal. -->
               <execution>
-                <id>tag-docker-image-commit-id</id>
+                <id>release-start-buildkit</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>sh</executable>
+                  <arguments>
+                    <argument>start-buildkit.sh</argument>
+                    <argument>${docker-builder.image.name}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>build-and-push-docker-image</id>
                 <phase>install</phase>
                 <goals>
-                  <goal>push</goal>
+                  <goal>exec</goal>
                 </goals>
+                <configuration>
+                  <executable>sh</executable>
+                  <arguments>
+                    <argument>push-docker-image.sh</argument>
+                    <argument>${docker-builder.image.name}</argument>
+                    <!-- Versioned tag name -->
+                    <argument>${docker.image.name}:${project.version}</argument>
+                    <!-- Latest tag name -->
+                    <argument>${docker.image.name}:latest</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>release-stop-buildkit</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>sh</executable>
+                  <arguments>
+                    <argument>stop-buildkit.sh</argument>
+                    <argument>${docker-builder.image.name}</argument>
+                  </arguments>
+                </configuration>
               </execution>
             </executions>
+            <configuration>
+              <includeProjectDependencies>true</includeProjectDependencies>
+              <includePluginDependencies>false</includePluginDependencies>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.adobe.testing</groupId>
+                <artifactId>s3mock</artifactId>
+                <classifier>exec</classifier>
+                <version>${project.version}</version>
+                <type>jar</type>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/docker/push-docker-image.sh
+++ b/docker/push-docker-image.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+#  Copyright 2017-2022 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+BUILDER_NAME=$1
+VERSIONED_TAG_NAME=$2
+LATEST_TAG_NAME=$3
+
+# Docker buildx does not support a combination of "--load" and "--platform", unfortunately.
+
+# build --load to make the Docker container available in the local architecture for local
+# integration tests.
+docker buildx build --load --tag "${VERSIONED_TAG_NAME}" --tag "${LATEST_TAG_NAME}" --builder "${BUILDER_NAME}" .
+
+# build --platform / --push to build all platforms we want and push the Docker containers to
+# Docker Hub.
+docker buildx build --platform linux/amd64,linux/arm64 --push --tag "${VERSIONED_TAG_NAME}" --tag "${LATEST_TAG_NAME}" --builder "${BUILDER_NAME}" .

--- a/docker/start-buildkit.sh
+++ b/docker/start-buildkit.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+#  Copyright 2017-2022 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+BUILDER_NAME=$1
+
+# Start builder in case it's not already running
+if [ "$(docker buildx ls | grep ${BUILDER_NAME} | wc -l)" -eq 0 ]; then \
+  docker buildx create --driver docker-container --name "${BUILDER_NAME}" ; \
+  docker buildx inspect --bootstrap --builder "${BUILDER_NAME}" ; \
+fi

--- a/docker/stop-buildkit.sh
+++ b/docker/stop-buildkit.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+#  Copyright 2017-2022 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+BUILDER_NAME=$1
+
+# Stop builder in case it's running
+if [ "$(docker buildx ls | grep ${BUILDER_NAME} | wc -l)" -gt 0 ]; then \
+  docker buildx rm "${BUILDER_NAME}" ; \
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <checkstyle.version>10.3</checkstyle.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-io.version>2.11.0</commons-io.version>
-    <docker-maven-plugin.version>0.40.1</docker-maven-plugin.version>
+    <docker-maven-plugin.version>0.40.0</docker-maven-plugin.version>
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <junit.version>4.13.2</junit.version>
     <kotlin.version>1.7.0</kotlin.version>


### PR DESCRIPTION
Reverts adobe/S3Mock#617

docker-maven-plugin's `docker:push` target is still broken, this is only invoked during a release...
https://github.com/adobe/S3Mock/runs/6901658834?check_suite_focus=true