### PR TITLE
Add module "jdk.crypto.ec" to fix SSL handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.x
+* Features and fixes
+  * Fix broken SSL handshake (fixes #706)
+* Refactorings
+  * Add sortpom-maven-plugin, run sortpom
+    * To run manually, execute `mvn com.github.ekryd.sortpom:sortpom-maven-plugin:sort`
+
 ## 2.4.13
 * Features and fixes
   *  Adds missing x-amz-server-side-encryption and x-amz-server-side-encryption-aws-kms-key-id header (fixes #639)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN unzip -q s3mock.jar -d "${TMP_DIR}"
 RUN jlink \
     --module-path $JAVA_HOME/jmods \
     --verbose \
-    --add-modules java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument \
+    --add-modules java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.crypto.ec \
     --compress 2 \
     --no-header-files \
     --no-man-pages \


### PR DESCRIPTION
## Description
While connections from Java and Python AWS SDKs work, "aws-cli" does not.


## Related Issue
Fixes #706

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
