### PR TITLE
Allow listing a MultiPartUpload with no parts.

### DIFF
--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadIT.kt
@@ -15,6 +15,7 @@
  */
 package com.adobe.testing.s3mock.its
 
+import com.adobe.testing.s3mock.util.StringEncoding
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest
@@ -203,6 +204,26 @@ class MultiPartUploadIT : S3TestBase() {
     val upload = listing.multipartUploads[0]
     assertThat(upload.uploadId).isEqualTo(uploadId)
     assertThat(upload.key).isEqualTo(UPLOAD_FILE_NAME)
+  }
+
+  /**
+   * Tests if empty parts list of not yet completed multipart upload is returned.
+   */
+  @Test
+  fun shouldListEmptyPartListForMultipartUpload() {
+    s3Client!!.createBucket(BUCKET_NAME)
+    assertThat(
+      s3Client!!.listMultipartUploads(ListMultipartUploadsRequest(BUCKET_NAME))
+        .multipartUploads
+    ).isEmpty()
+    val initiateMultipartUploadResult = s3Client!!
+      .initiateMultipartUpload(InitiateMultipartUploadRequest(BUCKET_NAME, UPLOAD_FILE_NAME))
+    val uploadId = initiateMultipartUploadResult.uploadId
+    val listing = s3Client!!.listParts(ListPartsRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadId))
+    assertThat(listing.parts).isEmpty()
+    assertThat(listing.bucketName).isEqualTo(BUCKET_NAME)
+    assertThat(listing.uploadId).isEqualTo(uploadId)
+    assertThat(StringEncoding.decode(listing.key)).isEqualTo(UPLOAD_FILE_NAME)
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/FileStore.java
@@ -882,6 +882,18 @@ public class FileStore {
   }
 
   /**
+   * Returns the not-yet multipart upload, if it exists, throws IllegalArgumentException otherwise.
+   */
+  public MultipartUpload getMultipartUpload(String uploadId) {
+    return uploadIdToInfo.values()
+        .stream()
+        .filter(info -> uploadId.equals(info.upload.getUploadId()))
+        .map(info -> info.upload)
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("No MultipartUpload found with uploadId"));
+  }
+
+  /**
    * Aborts the upload.
    *
    * @param bucketName to which was uploaded
@@ -1249,10 +1261,13 @@ public class FileStore {
 
   private void verifyMultipartUploadPreparation(final String destinationBucket,
       final String destinationFilename, final String uploadId) {
+    MultipartUploadInfo multipartUploadInfo = uploadIdToInfo.get(uploadId);
     final Path partsFolder =
         Paths.get(rootFolder.getAbsolutePath(), destinationBucket, destinationFilename, uploadId);
 
-    if (!partsFolder.toFile().exists() || !partsFolder.toFile().isDirectory()) {
+    if (multipartUploadInfo == null
+        || !partsFolder.toFile().exists()
+        || !partsFolder.toFile().isDirectory()) {
       throw new IllegalStateException("Missed preparing Multipart Request");
     }
   }

--- a/server/src/test/java/com/adobe/testing/s3mock/FileStoreControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/FileStoreControllerTest.java
@@ -396,15 +396,14 @@ class FileStoreControllerTest {
   @Test
   void testCompleteMultipart_BadRequest_uploadIdNotFound() throws Exception {
     givenBucket();
-    String key = "sampleFile.txt";
     String uploadId = "testUploadId";
 
     List<Part> parts = new ArrayList<>();
     parts.add(createPart(0, 5L));
     parts.add(createPart(1, 5L));
 
-    when(fileStore.getMultipartUploadParts(eq(TEST_BUCKET_NAME), eq(key), eq(uploadId)))
-        .thenReturn(Collections.emptyList());
+    when(fileStore.getMultipartUpload(eq(uploadId)))
+        .thenThrow(IllegalArgumentException.class);
 
     CompleteMultipartUploadRequest uploadRequest = new CompleteMultipartUploadRequest();
     for (Part part : parts) {
@@ -416,6 +415,7 @@ class FileStoreControllerTest {
         "The specified multipart upload does not exist. The upload ID might be "
             + "invalid, or the multipart upload might have been aborted or completed.");
 
+    String key = "sampleFile.txt";
     mockMvc.perform(
             post("/testBucket/" + key)
                 .accept(MediaType.APPLICATION_XML)


### PR DESCRIPTION
## Description
Allow listing a MultiPartUpload with no parts.
This was introduced with #397

## Related Issue
Fixes #694

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
