### PR TITLE
Proper handling of "x-amz-tagging" header in PutObjectRequest.

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
@@ -131,10 +131,15 @@ class S3MockConfiguration implements WebMvcConfigurer {
     return new S3MockExceptionHandler();
   }
 
+  @Bean
+  TaggingHeaderConverter taggingHeaderConverter() {
+    return new TaggingHeaderConverter();
+  }
+
   /**
    * {@link ResponseEntityExceptionHandler} dealing with {@link S3Exception}s; Serializes them to
-   * response output as suitable ErrorResponses. See https://docs.aws.amazon
-   * .com/AmazonS3/latest/API/ErrorResponses.html.
+   * response output as suitable ErrorResponses. See
+   * https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html.
    */
   @ControllerAdvice
   static class S3MockExceptionHandler extends ResponseEntityExceptionHandler {

--- a/server/src/main/java/com/adobe/testing/s3mock/TaggingHeaderConverter.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/TaggingHeaderConverter.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock;
+
+import com.adobe.testing.s3mock.dto.Tag;
+import com.adobe.testing.s3mock.util.AwsHttpHeaders;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * Converts values of the {@link AwsHttpHeaders#X_AMZ_TAGGING}
+ * which is sent by the Amazon client like this:
+ * x-amz-tagging: tag1=value1&tag2=value2
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+ */
+class TaggingHeaderConverter implements Converter<String, List<Tag>> {
+
+  private static final Pattern TAGGING_PATTERN = Pattern.compile(".*=.*(&.*=.*)?");
+
+  @Override
+  public List<Tag> convert(String source) {
+    List<Tag> tags = null;
+    Matcher matcher = TAGGING_PATTERN.matcher(source);
+    if (matcher.matches()) {
+      tags = new ArrayList<>();
+      String[] split = source.split("&");
+      for (String tag : split) {
+        tags.add(new Tag(tag));
+      }
+    }
+    return tags;
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/TaggingHeaderConverterTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/TaggingHeaderConverterTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.adobe.testing.s3mock.dto.Tag;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TaggingHeaderConverterTest {
+
+  @Test
+  void testSingleTagConversion() {
+    TaggingHeaderConverter iut = new TaggingHeaderConverter();
+    String singleTag = "tag1=value1";
+    List<Tag> actual = iut.convert(singleTag);
+    assertThat(actual).isNotEmpty();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(new Tag(singleTag));
+  }
+
+  @Test
+  void testMultipleTagConversion() {
+    TaggingHeaderConverter iut = new TaggingHeaderConverter();
+    String tag1 = "tag1=value1";
+    String tag2 = "tag2=value2";
+    List<Tag> actual = iut.convert(tag1 + "&" + tag2);
+    assertThat(actual).isNotEmpty();
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual.get(0)).isEqualTo(new Tag(tag1));
+    assertThat(actual.get(1)).isEqualTo(new Tag(tag2));
+  }
+
+}


### PR DESCRIPTION
## Description
The default String -> List converters do not seem to work for the "&" delimiter.

## Related Issue
Fixes #673

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
