### PR TITLE
Proper handling of KMS keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.x
 * Features and fixes
   * Fix broken SSL handshake (fixes #706)
+  * Fix KMS key handling (fixes #702)
 * Refactorings
   * Add sortpom-maven-plugin, run sortpom
     * To run manually, execute `mvn com.github.ekryd.sortpom:sortpom-maven-plugin:sort`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ The port `9090` is for HTTP, port `9191` is for HTTPS.
 The mock can be configured with the following environment parameters:
 
 - `validKmsKeys`: list of KMS Key-Refs that are to be treated as *valid*.
-  - The list must be comma separated keys like `keya, keyb`
+  - KMS keys must be configured as valid ARNs in the format of "`arn:aws:kms:region:acct-id:key/key-id`", for example "`arn:aws:kms:us-east-1:1234567890:key/valid-test-key-id`"
+  - The list must be comma separated keys like `arn-1, arn-2`
+  - When requesting with KMS encryption, the key ID is passed to the SDK / CLI, in the example above this would be "`valid-test-key-id`".
+  - *S3Mock does not implement KMS encryption*, if a key ID is passed in a request, S3Mock will just validate if a given Key was configured during startup and reject the request if the given Key was not configured.
 - `initialBuckets`: list of names for buckets that will be available initially.
   - The list must be comma separated names like `bucketa, bucketb`
 - `root`: the base directory to place the temporary files exposed by the mock.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -141,7 +141,7 @@
                     <time>30000</time>
                   </wait>
                   <env>
-                    <validKmsKeys>arn:aws:kms:us-east-1:1234567890:key/valid-test-key-ref</validKmsKeys>
+                    <validKmsKeys>arn:aws:kms:us-east-1:1234567890:key/valid-test-key-id</validKmsKeys>
                     <initialBuckets>bucket-a, bucket-b</initialBuckets>
                   </env>
                 </run>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesIT.kt
@@ -40,7 +40,7 @@ import java.util.UUID
 class ErrorResponsesIT : S3TestBase() {
   /**
    * Verifies that `NoSuchBucket` is returned in Error Response if `putObject`
-   * references a non existing Bucket.
+   * references a non-existing Bucket.
    */
   @Test
   fun putObjectOnNonExistingBucket() {
@@ -60,14 +60,13 @@ class ErrorResponsesIT : S3TestBase() {
 
   /**
    * Verifies that `NoSuchBucket` is returned in Error Response if `putObject`
-   * references a non existing Bucket.
+   * references a non-existing Bucket.
    */
   @Test
   fun putObjectEncryptedOnNonExistingBucket() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val putObjectRequest = PutObjectRequest(BUCKET_NAME, UPLOAD_FILE_NAME, uploadFile)
-    putObjectRequest.sseAwsKeyManagementParams =
-      SSEAwsKeyManagementParams(TEST_ENC_KEYREF)
+    putObjectRequest.sseAwsKeyManagementParams = SSEAwsKeyManagementParams(TEST_ENC_KEY_ID)
     assertThatThrownBy {
       s3Client!!.putObject(
         PutObjectRequest(
@@ -83,7 +82,7 @@ class ErrorResponsesIT : S3TestBase() {
 
   /**
    * Verifies that `NoSuchBucket` is returned in Error Response if `copyObject`
-   * references a non existing destination Bucket.
+   * references a non-existing destination Bucket.
    */
   @Test
   fun copyObjectToNonExistingDestinationBucket() {
@@ -102,7 +101,7 @@ class ErrorResponsesIT : S3TestBase() {
 
   /**
    * Verifies that `NoSuchBucket` is returned in Error Response if `copyObject`
-   * encrypted references a non existing destination Bucket.
+   * encrypted references a non-existing destination Bucket.
    */
   @Test
   fun copyObjectEncryptedToNonExistingDestinationBucket() {
@@ -115,7 +114,7 @@ class ErrorResponsesIT : S3TestBase() {
     val copyObjectRequest =
       CopyObjectRequest(BUCKET_NAME, sourceKey, destinationBucketName, destinationKey)
     copyObjectRequest.sseAwsKeyManagementParams =
-      SSEAwsKeyManagementParams(TEST_ENC_KEYREF)
+      SSEAwsKeyManagementParams(TEST_ENC_KEY_ID)
     assertThatThrownBy { s3Client!!.copyObject(copyObjectRequest) }
       .isInstanceOf(AmazonS3Exception::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
@@ -146,7 +145,7 @@ class ErrorResponsesIT : S3TestBase() {
 
   /**
    * Verifies that `NO_SUCH_KEY` is returned in Error Response if `getObject`
-   * on a non existing Object.
+   * on a non-existing Object.
    */
   @Test
   fun nonExistingObject() {
@@ -192,10 +191,10 @@ class ErrorResponsesIT : S3TestBase() {
   fun batchDeleteObjectsFromNonExistingBucket() {
     val uploadFile1 = File(UPLOAD_FILE_NAME)
     s3Client!!.createBucket(BUCKET_NAME)
-    s3Client!!.putObject(PutObjectRequest(BUCKET_NAME, "1_" + UPLOAD_FILE_NAME, uploadFile1))
+    s3Client!!.putObject(PutObjectRequest(BUCKET_NAME, "1_$UPLOAD_FILE_NAME", uploadFile1))
     val multiObjectDeleteRequest = DeleteObjectsRequest(UUID.randomUUID().toString())
     val keys: MutableList<KeyVersion> = ArrayList()
-    keys.add(KeyVersion("1_" + UPLOAD_FILE_NAME))
+    keys.add(KeyVersion("1_$UPLOAD_FILE_NAME"))
     multiObjectDeleteRequest.keys = keys
     assertThatThrownBy { s3Client!!.deleteObjects(multiObjectDeleteRequest) }
       .isInstanceOf(AmazonS3Exception::class.java)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.kt
@@ -24,7 +24,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 class ErrorResponsesV2IT : S3TestBase() {
   /**
    * Verifies that `NO_SUCH_KEY` is returned in Error Response if `getObject`
-   * on a non existing Object.
+   * on a non-existing Object.
    */
   @Test
   fun nonExistingObject() {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -92,7 +92,7 @@ abstract class S3TestBase {
   private val serviceEndpoint: String
     get() = "https://$host:$port"
 
-  fun createS3ClientV2(): S3Client {
+  private fun createS3ClientV2(): S3Client {
     return S3Client.builder()
       .region(Region.of("us-east-1"))
       .credentialsProvider(
@@ -232,11 +232,10 @@ abstract class S3TestBase {
 
   companion object {
     val INITIAL_BUCKET_NAMES: Collection<String> = Arrays.asList("bucket-a", "bucket-b")
-    const val TEST_ENC_KEYREF = "arn:aws:kms:us-east-1:1234567890:key/valid-test-key-ref"
+    const val TEST_ENC_KEY_ID = "valid-test-key-id"
     const val BUCKET_NAME = "mydemotestbucket"
     const val UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt"
-    const val TEST_WRONG_KEYREF =
-      "arn:aws:kms:us-east-1:1234567890:keyWRONGWRONGWRONG/2d70f7f6-b484-4309-91d5-7813b7dd46ce"
+    const val TEST_WRONG_KEY_ID = "key-ID-WRONGWRONGWRONG"
     const val _1MB = 1024 * 1024
     const val _2MB = 2L * _1MB
     const val _5MB = 5L * _1MB

--- a/server/src/test/java/com/adobe/testing/s3mock/store/KmsKeyStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/KmsKeyStoreTest.java
@@ -34,9 +34,10 @@ class KmsKeyStoreTest {
 
   @Test
   void testValidateKeyRef() {
-    String keyRef = "testKeyRef";
+    String keyId = "valid-test-key-id";
+    String keyRef = "arn:aws:kms:us-east-1:1234567890:key/" + keyId;
     kmsKeyStore.registerKMSKeyRef(keyRef);
-    assertThat(kmsKeyStore.validateKeyRef(keyRef)).isTrue();
+    assertThat(kmsKeyStore.validateKeyId(keyId)).isTrue();
   }
 
 }


### PR DESCRIPTION
## Description
This never worked according to AWS spec / docs.
Configuring the KMS keys must be done in ARN format, requests with SDK
or CLI are done with the KMS-key-ID only.

## Related Issue
Fixes #702

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
