### PR TITLE
Amazon SDK v2 does not work for ListMultiPartUploads

### DIFF
--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AmazonClientUploadV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AmazonClientUploadV1IT.kt
@@ -66,9 +66,10 @@ import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
 /**
- * Test the application using the AmazonS3 client.
+ * Test the application using the AmazonS3 SDK V1.
+ * TODO: split up tests by type
  */
-internal class AmazonClientUploadIT : S3TestBase() {
+internal class AmazonClientUploadV1IT : S3TestBase() {
   /**
    * Verify that buckets can be created and listed.
    */
@@ -827,7 +828,7 @@ internal class AmazonClientUploadIT : S3TestBase() {
   /**
    * Tests if the list objects can be retrieved.
    *
-   * For more detailed tests of the List Objects API see [ListObjectIT].
+   * For more detailed tests of the List Objects API see [ListObjectV1IT].
    */
   @Test
   fun shouldGetObjectListing() {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV1IT.kt
@@ -35,9 +35,10 @@ import java.io.File
 import java.util.UUID
 
 /**
+ * Test the application using the AmazonS3 SDK V1.
  * Verifies S3 Mocks Error Responses.
  */
-class ErrorResponsesIT : S3TestBase() {
+class ErrorResponsesV1IT : S3TestBase() {
   /**
    * Verifies that `NoSuchBucket` is returned in Error Response if `putObject`
    * references a non-existing Bucket.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
@@ -27,7 +27,10 @@ import org.slf4j.LoggerFactory
 import java.util.Arrays
 import java.util.stream.Collectors
 
-class ListObjectIT : S3TestBase() {
+/**
+ * Test the application using the AmazonS3 SDK V1.
+ */
+class ListObjectV1IT : S3TestBase() {
   class Param constructor(
     val prefix: String?,
     val delimiter: String?,
@@ -160,7 +163,7 @@ class ListObjectIT : S3TestBase() {
   }
 
   companion object {
-    private val LOGGER = LoggerFactory.getLogger(ListObjectIT::class.java)
+    private val LOGGER = LoggerFactory.getLogger(ListObjectV1IT::class.java)
     private const val BUCKET_NAME = "list-objects-test"
     private val ALL_OBJECTS = arrayOf(
       "3330/0", "33309/0", "a",

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV1IT.kt
@@ -42,7 +42,10 @@ import java.util.Date
 import java.util.Random
 import java.util.UUID
 
-class MultiPartUploadIT : S3TestBase() {
+/**
+ * Test the application using the AmazonS3 SDK V1.
+ */
+class MultiPartUploadV1IT : S3TestBase() {
   /**
    * Tests if user metadata can be passed by multipart upload.
    */

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV2IT.kt
@@ -1,0 +1,857 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.adobe.testing.s3mock.its
+
+import com.adobe.testing.s3mock.util.StringEncoding
+import org.apache.commons.codec.digest.DigestUtils
+import org.apache.commons.lang3.ArrayUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.InstanceOfAssertFactories
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails
+import software.amazon.awssdk.awscore.exception.AwsServiceException
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload
+import software.amazon.awssdk.services.s3.model.CompletedPart
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest
+import software.amazon.awssdk.services.s3.model.ListPartsRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest
+import software.amazon.awssdk.services.s3.model.UploadPartRequest
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.time.Instant
+import java.util.Date
+import java.util.Random
+import java.util.UUID
+
+class MultiPartUploadV2IT : S3TestBase() {
+  /**
+   * Tests if user metadata can be passed by multipart upload.
+   */
+  @Test
+  fun shouldPassUserMetadataWithMultipartUploads() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val objectMetadata = HashMap<String, String>()
+    objectMetadata["key"] = "value"
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME)
+          .metadata(objectMetadata).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    val uploadPartResult = s3ClientV2!!.uploadPart(
+      UploadPartRequest
+        .builder()
+        .bucket(initiateMultipartUploadResult.bucket())
+        .key(initiateMultipartUploadResult.key())
+        .uploadId(uploadId)
+        .partNumber(1)
+        .contentLength(uploadFile.length()).build(),
+      //.lastPart(true)
+      RequestBody.fromFile(uploadFile),
+    )
+
+    s3ClientV2!!.completeMultipartUpload(
+      CompleteMultipartUploadRequest
+        .builder()
+        .bucket(initiateMultipartUploadResult.bucket())
+        .key(initiateMultipartUploadResult.key())
+        .uploadId(initiateMultipartUploadResult.uploadId())
+        .multipartUpload(
+          CompletedMultipartUpload
+            .builder()
+            .parts(
+              CompletedPart
+                .builder()
+                .eTag(uploadPartResult.eTag())
+                .partNumber(1)
+                .build()
+            )
+            .build()
+        )
+        .build()
+    )
+    val getObjectResponse = s3ClientV2!!.getObject(
+      GetObjectRequest
+        .builder()
+        .bucket(initiateMultipartUploadResult.bucket())
+        .key(initiateMultipartUploadResult.key())
+        .build()
+    )
+    assertThat(getObjectResponse.response().metadata())
+      .`as`("User metadata should be identical!")
+      .isEqualTo(objectMetadata)
+  }
+
+  /**
+   * Tests if a multipart upload with the last part being smaller than 5MB works.
+   */
+  @Test
+  fun shouldAllowMultipartUploads() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val objectMetadata = HashMap<String, String>()
+    objectMetadata["key"] = "value"
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME)
+          .metadata(objectMetadata).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    // upload part 1, >5MB
+    val randomBytes = createRandomBytes()
+    val partETag = uploadPart(UPLOAD_FILE_NAME, uploadId, 1, randomBytes)
+    // upload part 2, <5MB
+    val uploadPartResult = s3ClientV2!!.uploadPart(
+      UploadPartRequest
+        .builder()
+        .bucket(initiateMultipartUploadResult.bucket())
+        .key(initiateMultipartUploadResult.key())
+        .uploadId(uploadId)
+        .partNumber(2)
+        .contentLength(uploadFile.length()).build(),
+      //.lastPart(true)
+      RequestBody.fromFile(uploadFile),
+    )
+
+    val completeMultipartUpload = s3ClientV2!!.completeMultipartUpload(
+      CompleteMultipartUploadRequest
+        .builder()
+        .bucket(initiateMultipartUploadResult.bucket())
+        .key(initiateMultipartUploadResult.key())
+        .uploadId(initiateMultipartUploadResult.uploadId())
+        .multipartUpload(
+          CompletedMultipartUpload
+            .builder()
+            .parts(
+              CompletedPart
+                .builder()
+                .eTag(partETag)
+                .partNumber(1)
+                .build(),
+              CompletedPart
+                .builder()
+                .eTag(uploadPartResult.eTag())
+                .partNumber(2)
+                .build()
+            )
+            .build()
+        )
+        .build()
+    )
+
+    // Verify only 1st and 3rd counts
+    val getObjectResponse = s3ClientV2!!.getObject(
+      GetObjectRequest
+        .builder()
+        .bucket(BUCKET_NAME)
+        .key(UPLOAD_FILE_NAME)
+        .build()
+    )
+
+    val uploadFileBytes = readStreamIntoByteArray(uploadFile.inputStream())
+    val allMd5s = ArrayUtils.addAll(
+      DigestUtils.md5(randomBytes),
+      *DigestUtils.md5(uploadFileBytes)
+    )
+
+    // verify special etag
+    assertThat(completeMultipartUpload.eTag()).`as`("Special etag doesn't match.")
+      .isEqualTo("\"" + DigestUtils.md5Hex(allMd5s) + "-2" + "\"")
+
+    // verify content size
+    assertThat(getObjectResponse.response().contentLength())
+      .`as`("Content length doesn't match")
+      .isEqualTo(randomBytes.size.toLong() + uploadFileBytes.size.toLong())
+
+    // verify contents
+    assertThat(readStreamIntoByteArray(getObjectResponse.buffered())).`as`(
+      "Object contents doesn't match"
+    ).isEqualTo(concatByteArrays(randomBytes, uploadFileBytes))
+  }
+
+  @Test
+  @Throws(IOException::class)
+  fun shouldInitiateMultipartAndRetrieveParts() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val objectMetadata = HashMap<String, String>()
+    objectMetadata["key"] = "value"
+    val hash = DigestUtils.md5Hex(FileInputStream(uploadFile))
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME)
+          .metadata(objectMetadata).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    val key = initiateMultipartUploadResult.key()
+
+    val uploadPartResult = s3ClientV2!!.uploadPart(
+      UploadPartRequest
+        .builder()
+        .bucket(initiateMultipartUploadResult.bucket())
+        .key(key)
+        .uploadId(uploadId)
+        .partNumber(1)
+        .contentLength(uploadFile.length()).build(),
+      //.lastPart(true)
+      RequestBody.fromFile(uploadFile),
+    )
+
+    val listPartsRequest = ListPartsRequest
+      .builder()
+      .bucket(BUCKET_NAME)
+      .key(key)
+      .uploadId(uploadId)
+      .build()
+    val partListing = s3ClientV2!!.listParts(listPartsRequest)
+    assertThat(partListing.parts()).`as`("Part listing should be 1").hasSize(1)
+    val partSummary = partListing.parts()[0]
+    assertThat(partSummary.eTag()).`as`("Etag should match").isEqualTo("\"" + hash + "\"")
+    assertThat(partSummary.partNumber()).`as`("Part number should match").isEqualTo(1)
+    assertThat(partSummary.lastModified()).`as`("LastModified should be valid date")
+      .isExactlyInstanceOf(Instant::class.java)
+  }
+
+  /**
+   * Tests if not yet completed / aborted multipart uploads are listed.
+   */
+  @Test
+  fun shouldListMultipartUploads() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    assertThat(
+      s3ClientV2!!.listMultipartUploads(
+        ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+      )
+        .uploads()
+    ).isEmpty()
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+
+    val listing = s3ClientV2!!.listMultipartUploads(
+      ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+    )
+    assertThat(listing.uploads()).isNotEmpty
+    assertThat(listing.bucket()).isEqualTo(BUCKET_NAME)
+    assertThat(listing.uploads()).hasSize(1)
+    val upload = listing.uploads()[0]
+    assertThat(upload.uploadId()).isEqualTo(uploadId)
+    assertThat(upload.key()).isEqualTo(UPLOAD_FILE_NAME)
+  }
+
+  /**
+   * Tests if empty parts list of not yet completed multipart upload is returned.
+   */
+  @Test
+  fun shouldListEmptyPartListForMultipartUpload() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    assertThat(
+      s3ClientV2!!.listMultipartUploads(
+        ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+      ).uploads()
+    ).isEmpty()
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    val listing = s3ClientV2!!
+      .listParts(
+        ListPartsRequest
+          .builder()
+          .bucket(BUCKET_NAME)
+          .key(UPLOAD_FILE_NAME)
+          .uploadId(uploadId)
+          .build()
+      )
+    assertThat(listing.parts()).isEmpty()
+    assertThat(listing.bucket()).isEqualTo(BUCKET_NAME)
+    assertThat(listing.uploadId()).isEqualTo(uploadId)
+    assertThat(StringEncoding.decode(listing.key())).isEqualTo(UPLOAD_FILE_NAME)
+  }
+
+  /**
+   * Tests that an exception is thrown when listing parts if the upload id is unknown.
+   */
+  @Test
+  fun shouldThrowOnListMultipartUploadsWithUnknownId() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    assertThatThrownBy {
+      s3ClientV2!!.listParts(
+        ListPartsRequest.builder().bucket(BUCKET_NAME).key("NON_EXISTENT_KEY").uploadId(
+          "NON_EXISTENT_UPLOAD_ID"
+        ).build()
+      )
+    }
+      .isInstanceOf(AwsServiceException::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 404")
+  }
+
+  /**
+   * Tests if not yet completed / aborted multipart uploads are listed with prefix filtering.
+   */
+  @Test
+  fun shouldListMultipartUploadsWithPrefix() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key("key1").build()
+      )
+    s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key("key2").build()
+      )
+    val listMultipartUploadsRequest =
+      ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).prefix("key2").build()
+    val listing = s3ClientV2!!.listMultipartUploads(listMultipartUploadsRequest)
+    assertThat(listing.uploads()).hasSize(1)
+    assertThat(listing.uploads()[0].key()).isEqualTo("key2")
+  }
+
+  /**
+   * Tests if multipart uploads are stored and can be retrieved by bucket.
+   */
+  @Test
+  fun shouldListMultipartUploadsWithBucket() {
+    // create multipart upload 1
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key("key1").build()
+      )
+    // create multipart upload 2
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME_2).build())
+    s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME_2).key("key2").build()
+      )
+
+    // assert multipart upload 1
+    val listMultipartUploadsRequest1 =
+      ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+    val listing = s3ClientV2!!.listMultipartUploads(listMultipartUploadsRequest1)
+    assertThat(listing.uploads()).hasSize(1)
+    assertThat(listing.uploads()[0].key()).isEqualTo("key1")
+
+    // assert multipart upload 2
+    val listMultipartUploadsRequest2 =
+      ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME_2).build()
+    val listing2 = s3ClientV2!!.listMultipartUploads(listMultipartUploadsRequest2)
+    assertThat(listing2.uploads()).hasSize(1)
+    assertThat(listing2.uploads()[0].key()).isEqualTo("key2")
+  }
+
+  @Test
+  fun testListMultipartsXXX() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    s3ClientV2!!.listMultipartUploads(
+      ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+    )
+  }
+
+  /**
+   * Tests if a multipart upload can be aborted.
+   */
+  @Test
+  fun shouldAbortMultipartUpload() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    assertThat(
+      s3ClientV2!!.listMultipartUploads(
+        ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+      ).hasUploads()
+    ).isFalse
+
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    val randomBytes = createRandomBytes()
+    val partETag = uploadPart(UPLOAD_FILE_NAME, uploadId, 1, randomBytes)
+    assertThat(
+      s3ClientV2!!.listMultipartUploads(
+        ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+      ).hasUploads()
+    ).isTrue
+
+    val partsBeforeComplete =
+      s3ClientV2!!.listParts(
+        ListPartsRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME).uploadId(uploadId)
+          .build()
+      ).parts()
+    assertThat(partsBeforeComplete).hasSize(1)
+    assertThat(partsBeforeComplete[0].eTag()).isEqualTo(partETag)
+    s3ClientV2!!.abortMultipartUpload(
+      AbortMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME)
+        .uploadId(uploadId).build()
+    )
+    assertThat(
+      s3ClientV2!!.listMultipartUploads(
+        ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+      ).hasUploads()
+    ).isFalse
+
+    // List parts, make sure we find no parts
+    assertThatThrownBy {
+      s3ClientV2!!.listParts(
+        ListPartsRequest.builder().bucket(BUCKET_NAME).key(UPLOAD_FILE_NAME).uploadId(
+          uploadId
+        ).build()
+      )
+    }
+      .isInstanceOf(AwsServiceException::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 404")
+      .asInstanceOf(InstanceOfAssertFactories.type(AwsServiceException::class.java))
+      .extracting(AwsServiceException::awsErrorDetails)
+      .extracting(AwsErrorDetails::errorCode)
+      .isEqualTo("NoSuchUpload")
+  }
+
+  /**
+   * Tests if the parts specified in CompleteUploadRequest are adhered
+   * irrespective of the number of parts uploaded before.
+   */
+  @Test
+  @Throws(IOException::class)
+  fun shouldAdherePartsInCompleteMultipartUploadRequest() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val key = UUID.randomUUID().toString()
+    assertThat(
+      s3ClientV2!!.listMultipartUploads(
+        ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+      )
+        .uploads()
+    ).isEmpty()
+
+    // Initiate upload
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(key).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+
+    // Upload 3 parts
+    val randomBytes1 = createRandomBytes()
+    val partETag1 = uploadPart(key, uploadId, 1, randomBytes1)
+    val randomBytes2 = createRandomBytes()
+    val partETag2 = uploadPart(key, uploadId, 2, randomBytes2)
+    val randomBytes3 = createRandomBytes()
+    val partETag3 = uploadPart(key, uploadId, 3, randomBytes3)
+
+    // Adding to parts list only 1st and 3rd part
+    val parts: MutableList<String> = ArrayList()
+    parts.add(partETag1)
+    parts.add(partETag3)
+
+    // Try to complete with these parts
+    val result = s3ClientV2!!.completeMultipartUpload(
+      CompleteMultipartUploadRequest.builder()
+        .bucket(BUCKET_NAME)
+        .key(key)
+        .uploadId(uploadId)
+        .multipartUpload(
+          CompletedMultipartUpload
+            .builder()
+            .parts(
+              CompletedPart
+                .builder()
+                .eTag(partETag1)
+                .partNumber(1)
+                .build(),
+              CompletedPart
+                .builder()
+                .eTag(partETag3)
+                .partNumber(3)
+                .build()
+            )
+            .build()
+        )
+        .build()
+    )
+
+    // Verify only 1st and 3rd counts
+    val getObjectResponse = s3ClientV2!!.getObject(
+      GetObjectRequest
+        .builder()
+        .bucket(BUCKET_NAME)
+        .key(key)
+        .build()
+    )
+
+    val allMd5s = ArrayUtils.addAll(
+      DigestUtils.md5(randomBytes1),
+      *DigestUtils.md5(randomBytes3)
+    )
+
+    // verify special etag
+    assertThat(result.eTag()).`as`("Special etag doesn't match.")
+      .isEqualTo("\"" + DigestUtils.md5Hex(allMd5s) + "-2" + "\"")
+
+    // verify content size
+    assertThat(getObjectResponse.response().contentLength())
+      .`as`("Content length doesn't match")
+      .isEqualTo(randomBytes1.size.toLong() + randomBytes3.size)
+
+    // verify contents
+    assertThat(readStreamIntoByteArray(getObjectResponse.buffered())).`as`(
+      "Object contents doesn't match"
+    )
+      .isEqualTo(concatByteArrays(randomBytes1, randomBytes3))
+  }
+
+  /**
+   * Tests that uploaded parts can be listed regardless if the MultipartUpload was completed or
+   * aborted.
+   */
+  @Test
+  fun shouldListPartsOnCompleteOrAbort() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val key = UUID.randomUUID().toString()
+    assertThat(
+      s3ClientV2!!.listMultipartUploads(
+        ListMultipartUploadsRequest.builder().bucket(BUCKET_NAME).build()
+      )
+        .uploads()
+    ).isEmpty()
+
+    // Initiate upload
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME).key(key).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+
+    // Upload part
+    val randomBytes = createRandomBytes()
+    val partETag = uploadPart(key, uploadId, 1, randomBytes)
+
+    // List parts, make sure we find part 1
+    val partsBeforeComplete = s3ClientV2!!.listParts(
+      ListPartsRequest
+        .builder()
+        .bucket(BUCKET_NAME)
+        .key(key)
+        .uploadId(uploadId)
+        .build()
+    )
+      .parts()
+    assertThat(partsBeforeComplete).hasSize(1)
+    assertThat(partsBeforeComplete[0].eTag()).isEqualTo(partETag)
+
+    // Complete
+    val result = s3ClientV2!!.completeMultipartUpload(
+      CompleteMultipartUploadRequest
+        .builder()
+        .bucket(BUCKET_NAME)
+        .key(key)
+        .uploadId(uploadId)
+        .multipartUpload(
+          CompletedMultipartUpload
+            .builder()
+            .parts(
+              CompletedPart
+                .builder()
+                .eTag(partETag)
+                .partNumber(1)
+                .build()
+            )
+            .build()
+        )
+        .build()
+    )
+
+    // List parts, make sure we find no parts
+    assertThatThrownBy {
+      s3ClientV2!!.listParts(
+        ListPartsRequest
+          .builder()
+          .bucket(BUCKET_NAME)
+          .key(key)
+          .uploadId(uploadId)
+          .build()
+      )
+    }
+      .isInstanceOf(AwsServiceException::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 404")
+      .asInstanceOf(InstanceOfAssertFactories.type(AwsServiceException::class.java))
+      .extracting(AwsServiceException::awsErrorDetails)
+      .extracting(AwsErrorDetails::errorCode)
+      .isEqualTo("NoSuchUpload")
+  }
+
+  /**
+   * Upload two objects, copy as parts without length, complete multipart.
+   */
+  @Test
+  @Throws(IOException::class)
+  fun shouldCopyPartsAndComplete() {
+    //Initiate upload in BUCKET_NAME_2
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME_2).build())
+    val multipartUploadKey = UUID.randomUUID().toString()
+
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(BUCKET_NAME_2).key(multipartUploadKey).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    val parts: MutableList<CompletedPart> = ArrayList()
+
+    //bucket for test data
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+
+    //create two objects, initiate copy part with full object length
+    val sourceKeys = arrayOf(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+    val allRandomBytes: MutableList<ByteArray> = ArrayList()
+    for (i in sourceKeys.indices) {
+      val key = sourceKeys[i]
+      val partNumber = i + 1
+      val randomBytes = createRandomBytes()
+      val metadata1 = HashMap<String, String>()
+      metadata1["contentLength"] = randomBytes.size.toString()
+      val putObjectResult =  //ignore result
+        s3ClientV2!!.putObject(
+          PutObjectRequest
+            .builder()
+            .bucket(BUCKET_NAME)
+            .key(key)
+            .metadata(metadata1)
+            .build(),
+          RequestBody.fromInputStream(ByteArrayInputStream(randomBytes), randomBytes.size.toLong())
+        )
+
+      val result = s3ClientV2!!.uploadPartCopy(
+        UploadPartCopyRequest.builder()
+          .partNumber(partNumber)
+          .uploadId(uploadId)
+          .destinationBucket(BUCKET_NAME_2)
+          .destinationKey(multipartUploadKey)
+          .sourceKey(key)
+          .sourceBucket(BUCKET_NAME).build()
+      )
+      val etag = result.copyPartResult().eTag()
+      parts.add(CompletedPart.builder().eTag(etag).partNumber(partNumber).build())
+      allRandomBytes.add(randomBytes)
+    }
+    assertThat(allRandomBytes).hasSize(2)
+
+    // Complete with parts
+    val result = s3ClientV2!!.completeMultipartUpload(
+      CompleteMultipartUploadRequest
+        .builder()
+        .bucket(BUCKET_NAME_2)
+        .key(multipartUploadKey)
+        .uploadId(uploadId)
+        .multipartUpload(
+          CompletedMultipartUpload
+            .builder()
+            .parts(parts)
+            .build()
+        )
+        .build()
+    )
+
+    // Verify parts
+    val getObjectResponse = s3ClientV2!!.getObject(
+      GetObjectRequest
+        .builder()
+        .bucket(BUCKET_NAME_2)
+        .key(multipartUploadKey)
+        .build()
+    )
+    val allMd5s = ArrayUtils.addAll(
+      DigestUtils.md5(allRandomBytes[0]),
+      *DigestUtils.md5(allRandomBytes[1])
+    )
+
+    // verify etag
+    assertThat(result.eTag())
+      .`as`("etag doesn't match.")
+      .isEqualTo("\"" + DigestUtils.md5Hex(allMd5s) + "-2" + "\"")
+
+    // verify content size
+    assertThat(getObjectResponse.response().contentLength())
+      .`as`("Content length doesn't match")
+      .isEqualTo(allRandomBytes[0].size.toLong() + allRandomBytes[1].size)
+
+    // verify contents
+    assertThat(readStreamIntoByteArray(getObjectResponse.buffered()))
+      .`as`("Object contents doesn't match")
+      .isEqualTo(concatByteArrays(allRandomBytes[0], allRandomBytes[1]))
+  }
+
+  /**
+   * Puts an Object; Copies part of that object to a new bucket;
+   * Requests parts for the uploadId; compares etag of upload response and parts list.
+   */
+  @Test
+  fun shouldCopyObjectPart() {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val sourceKey = UPLOAD_FILE_NAME
+    val destinationBucketName = "destinationbucket"
+    val destinationKey = "copyOf/$sourceKey"
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(destinationBucketName).build())
+    val putObjectResult =
+      s3ClientV2!!.putObject(
+        PutObjectRequest.builder().bucket(BUCKET_NAME).key(sourceKey).build(),
+        RequestBody.fromFile(uploadFile)
+      )
+    val objectMetadata = HashMap<String, String>()
+    objectMetadata["key"] = "value"
+
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(destinationBucketName).key(destinationKey)
+          .metadata(objectMetadata).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+
+    val result = s3ClientV2!!.uploadPartCopy(
+      UploadPartCopyRequest.builder()
+        .uploadId(uploadId)
+        .destinationBucket(destinationBucketName)
+        .destinationKey(destinationKey)
+        .sourceKey(sourceKey)
+        .sourceBucket(BUCKET_NAME)
+        .partNumber(1)
+        .copySourceRange("bytes=0-" + uploadFile.length())
+        .build()
+    )
+    val etag = result.copyPartResult().eTag()
+
+    val partListing = s3ClientV2!!.listParts(
+      ListPartsRequest
+        .builder()
+        .bucket(initiateMultipartUploadResult.bucket())
+        .key(initiateMultipartUploadResult.key())
+        .uploadId(initiateMultipartUploadResult.uploadId())
+        .build()
+    )
+    assertThat(partListing.parts()).hasSize(1)
+    assertThat(partListing.parts()[0].eTag()).isEqualTo(etag)
+  }
+
+  /**
+   * Tries to copy part of an non-existing object to a new bucket.
+   */
+  @Test
+  fun shouldThrowNoSuchKeyOnCopyObjectPartForNonExistingKey() {
+    val sourceKey = "NON_EXISTENT_KEY"
+    val destinationBucketName = "destinationbucket"
+    val destinationKey = "copyOf/$sourceKey"
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(destinationBucketName).build())
+    val objectMetadata = HashMap<String, String>()
+    objectMetadata["key"] = "value"
+    val initiateMultipartUploadResult = s3ClientV2!!
+      .createMultipartUpload(
+        CreateMultipartUploadRequest.builder().bucket(destinationBucketName).key(destinationKey)
+          .metadata(objectMetadata).build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    assertThatThrownBy {
+      s3ClientV2!!.uploadPartCopy(
+        UploadPartCopyRequest.builder()
+          .uploadId(uploadId)
+          .destinationBucket(destinationBucketName)
+          .destinationKey(destinationKey)
+          .sourceKey(sourceKey)
+          .sourceBucket(BUCKET_NAME)
+          .partNumber(1)
+          .copySourceRange("bytes=0-5")
+          .build()
+      )
+    }
+      .isInstanceOf(AwsServiceException::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 404")
+      .asInstanceOf(InstanceOfAssertFactories.type(AwsServiceException::class.java))
+      .extracting(AwsServiceException::awsErrorDetails)
+      .extracting(AwsErrorDetails::errorCode)
+      .isEqualTo("NoSuchKey")
+  }
+
+  private fun uploadPart(
+    key: String,
+    uploadId: String,
+    partNumber: Int,
+    randomBytes: ByteArray
+  ): String {
+    return s3ClientV2!!
+      .uploadPart(
+        UploadPartRequest.builder()
+          .bucket(BUCKET_NAME)
+          .key(key)
+          .uploadId(uploadId)
+          .partNumber(partNumber)
+          .contentLength(randomBytes.size.toLong()).build(),
+        RequestBody.fromInputStream(ByteArrayInputStream(randomBytes), randomBytes.size.toLong())
+      )
+      .eTag()
+  }
+
+  /**
+   * Creates 5+MB of random bytes to upload as a valid part
+   * (all parts but the last must be at least 5MB in size)
+   */
+  private fun createRandomBytes(): ByteArray {
+    val size = 5 * 1024 * 1024 + random.nextInt(1024 * 1024)
+    val bytes = ByteArray(size)
+    random.nextBytes(bytes)
+    return bytes
+  }
+
+  @Throws(IOException::class)
+  private fun readStreamIntoByteArray(inputStream: InputStream): ByteArray {
+    inputStream.use { `in` ->
+      val baos = ByteArrayOutputStream(BUFFER_SIZE)
+      val buffer = ByteArray(BUFFER_SIZE)
+      var bytesRead = -1
+      while (`in`.read(buffer).also { bytesRead = it } != -1) {
+        baos.write(buffer, 0, bytesRead)
+      }
+      baos.flush()
+      return baos.toByteArray()
+    }
+  }
+
+  private fun concatByteArrays(arr1: ByteArray, arr2: ByteArray): ByteArray {
+    val result = ByteArray(arr1.size + arr2.size)
+    System.arraycopy(arr1, 0, result, 0, arr1.size)
+    System.arraycopy(arr2, 0, result, arr1.size, arr2.size)
+    return result
+  }
+
+  companion object {
+    private val random = Random()
+    private const val BUFFER_SIZE = 128 * 1024
+    private const val BUCKET_NAME_2 = "testbucket2"
+  }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -82,6 +82,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-devtools</artifactId>
+      <optional>true</optional>
+    </dependency>
     <!-- Use Jetty instead -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
@@ -31,7 +31,9 @@ public class AwsHttpParameters {
   public static final String PART_NUMBER = "partNumber";
   public static final String START_AFTER = "start-after";
   public static final String TAGGING = "tagging";
+  public static final String NOT_TAGGING = NOT + TAGGING;
   public static final String UPLOADS = "uploads";
+  public static final String NOT_UPLOADS = NOT + UPLOADS;
 
   public static final String UPLOAD_ID = "uploadId";
   public static final String NOT_UPLOAD_ID = NOT + UPLOAD_ID;


### PR DESCRIPTION
## Description
AWS SDK v1 apparently used the wrong path for ListMultiPartUploads requests (it was the only one adding a `/` to the end of the path), and they fixed that in v2?
Anyway, just adding the URI pattern did not work, had to debug other failing calls and tests because the S3 API often uses the same path and HTTP method for different calls, just adding or omitting parameters.

Most of our integration tests are using the V1 SDK only, so this problem did not surface until now.

## Related Issue
#734 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
