### PR TITLE
Let S3Mock only accept "valid" bucket names / debug info

### DIFF
--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketTestsV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketTestsV2IT.kt
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException
+
+/**
+ * Test the application using the AmazonS3 SDK V2.
+ */
+class BucketTestsV2IT : S3TestBase() {
+
+  @Test
+  fun createAndDeleteBucket() {
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+
+    val bucketCreated = s3ClientV2!!.waiter()
+      .waitUntilBucketExists(HeadBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val bucketCreatedResponse = bucketCreated.matched().response()!!.get()
+    assertThat(bucketCreatedResponse).isNotNull
+    s3ClientV2!!.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val bucketDeleted = s3ClientV2!!.waiter()
+      .waitUntilBucketNotExists(HeadBucketRequest.builder().bucket(BUCKET_NAME).build())
+    val bucketDeletedResponse = bucketDeleted.matched().exception()!!.get()
+    assertThat(bucketDeletedResponse).isNotNull
+    assertThat(bucketDeletedResponse).isInstanceOf(NoSuchBucketException::class.java)
+  }
+
+  companion object {
+    const val BUCKET_NAME = "bucket-tests-v2-bucket"
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/FileStoreController.java
@@ -194,7 +194,7 @@ public class FileStoreController {
   }
 
   //================================================================================================
-  // /{bucketName:.+}
+  // /{bucketName:[a-z0-9.-]+}
   //================================================================================================
 
   /**
@@ -207,10 +207,17 @@ public class FileStoreController {
    * @return 200 OK if creation was successful.
    */
   @RequestMapping(
-      value = "/{bucketName}",
+      value = {
+          "/{bucketName:[a-z0-9.-]+}",
+          "/{bucketName:.+}"
+      },
       method = RequestMethod.PUT
   )
   public ResponseEntity<String> createBucket(@PathVariable final String bucketName) {
+    if (!bucketName.matches("[a-z0-9.-]+")) {
+      throw new S3Exception(BAD_REQUEST.value(), "InvalidBucketName",
+          "The specified bucket is not valid.");
+    }
     try {
       fileStore.createBucket(bucketName);
       return ResponseEntity.ok().build();
@@ -229,7 +236,7 @@ public class FileStoreController {
    * @return 200 if it exists; 404 if not found.
    */
   @RequestMapping(
-      value = "/{bucketName}",
+      value = "/{bucketName:[a-z0-9.-]+}",
       method = RequestMethod.HEAD
   )
   public ResponseEntity<Void> headBucket(@PathVariable final String bucketName) {
@@ -249,7 +256,7 @@ public class FileStoreController {
    * @return 204 if Bucket was deleted; 404 if not found
    */
   @RequestMapping(
-      value = "/{bucketName}",
+      value = "/{bucketName:[a-z0-9.-]+}",
       method = RequestMethod.DELETE
   )
   public ResponseEntity<String> deleteBucket(@PathVariable final String bucketName) {
@@ -290,7 +297,7 @@ public class FileStoreController {
       params = {
           NOT_UPLOADS
       },
-      value = "/{bucketName}",
+      value = "/{bucketName:[a-z0-9.-]+}",
       method = RequestMethod.GET,
       produces = {
           APPLICATION_XML_VALUE
@@ -365,7 +372,7 @@ public class FileStoreController {
    *
    * @return {@link ListBucketResultV2} a list of objects in Bucket
    */
-  @RequestMapping(value = "/{bucketName}",
+  @RequestMapping(value = "/{bucketName:[a-z0-9.-]+}",
       params = {
           LIST_TYPE_V2
       },
@@ -457,9 +464,9 @@ public class FileStoreController {
   @RequestMapping(
       value = {
           //AWS SDK V2 pattern
-          "/{bucketName}",
+          "/{bucketName:[a-z0-9.-]+}",
           //AWS SDK V1 pattern
-          "/{bucketName}/"
+          "/{bucketName:[a-z0-9.-]+}/"
       },
       params = {
           UPLOADS
@@ -511,7 +518,7 @@ public class FileStoreController {
    * @return The {@link BatchDeleteResponse}
    */
   @RequestMapping(
-      value = "/{bucketName}",
+      value = "/{bucketName:[a-z0-9.-]+}",
       params = {
           DELETE
       },
@@ -551,7 +558,7 @@ public class FileStoreController {
   }
 
   //================================================================================================
-  // /{bucketName}/**
+  // /{bucketName:[a-z0-9.-]+}/**
   //================================================================================================
 
   /**
@@ -563,7 +570,7 @@ public class FileStoreController {
    * @return 200 with object metadata headers, 404 if not found.
    */
   @RequestMapping(
-      value = "/{bucketName}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       method = RequestMethod.HEAD
   )
   public ResponseEntity<String> headObject(@PathVariable final String bucketName,
@@ -602,7 +609,7 @@ public class FileStoreController {
    * @return ResponseEntity with Status Code 204 if object was successfully deleted.
    */
   @RequestMapping(
-      value = "/{bucketName}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       method = RequestMethod.DELETE
   )
   public ResponseEntity<String> deleteObject(@PathVariable final String bucketName,
@@ -629,7 +636,7 @@ public class FileStoreController {
    * @param uploadId id of the upload. Has to match all other part's uploads.
    */
   @RequestMapping(
-      value = "/{bucketName}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           UPLOAD_ID
       },
@@ -659,7 +666,7 @@ public class FileStoreController {
    * @throws IOException If an input or output exception occurs
    */
   @RequestMapping(
-      value = "/{bucketName}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           NOT_UPLOADS,
           NOT_UPLOAD_ID,
@@ -715,7 +722,7 @@ public class FileStoreController {
    * @param bucketName The Bucket's name
    */
   @RequestMapping(
-      value = "/{bucketName:.+}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           TAGGING
       },
@@ -752,7 +759,7 @@ public class FileStoreController {
    * @return the {@link ListPartsResult}
    */
   @RequestMapping(
-      value = "/{bucketName:.+}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           UPLOAD_ID
       },
@@ -781,7 +788,7 @@ public class FileStoreController {
    * @param body Tagging object
    */
   @RequestMapping(
-      value = "/{bucketName:.+}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           TAGGING
       },
@@ -827,7 +834,7 @@ public class FileStoreController {
    * @throws IOException in case of an error.
    */
   @RequestMapping(
-      value = "/{bucketName:.+}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           UPLOAD_ID,
           PART_NUMBER
@@ -880,7 +887,7 @@ public class FileStoreController {
    * @throws IOException in case of an error.
    */
   @RequestMapping(
-      value = "/{bucketName}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       headers = {
           X_AMZ_COPY_SOURCE,
       },
@@ -942,7 +949,7 @@ public class FileStoreController {
       headers = {
           NOT_X_AMZ_COPY_SOURCE
       },
-      value = "/{bucketName:.+}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       method = RequestMethod.PUT
   )
   public ResponseEntity<String> putObject(@PathVariable final String bucketName,
@@ -1045,7 +1052,7 @@ public class FileStoreController {
    * @throws IOException If an input or output exception occurs
    */
   @RequestMapping(
-      value = "/{bucketName}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       headers = {
           X_AMZ_COPY_SOURCE
       },
@@ -1106,7 +1113,7 @@ public class FileStoreController {
    * @return the {@link InitiateMultipartUploadResult}.
    */
   @RequestMapping(
-      value = "/{bucketName:.+}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           UPLOADS
       },
@@ -1148,7 +1155,7 @@ public class FileStoreController {
    * @return {@link CompleteMultipartUploadResult}
    */
   @RequestMapping(
-      value = "/{bucketName:.+}/**",
+      value = "/{bucketName:[a-z0-9.-]+}/**",
       params = {
           UPLOAD_ID
       },

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
@@ -28,18 +28,21 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 import org.springframework.boot.web.servlet.filter.OrderedFormContentFilter;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -85,6 +88,19 @@ class S3MockConfiguration implements WebMvcConfigurer {
         .defaultContentType(MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_XML);
     configurer.favorPathExtension(false);
     configurer.mediaType("xml", MediaType.TEXT_XML);
+  }
+
+  @Bean
+  @Profile("debug")
+  public CommonsRequestLoggingFilter logFilter() {
+    CommonsRequestLoggingFilter filter
+        = new CommonsRequestLoggingFilter();
+    filter.setIncludeQueryString(true);
+    filter.setIncludePayload(true);
+    filter.setMaxPayloadLength(10000);
+    filter.setIncludeHeaders(true);
+    filter.setAfterMessagePrefix("REQUEST DATA : ");
+    return filter;
   }
 
   /**

--- a/server/src/main/resources/application-debug.properties
+++ b/server/src/main/resources/application-debug.properties
@@ -1,0 +1,25 @@
+#
+#  Copyright 2017-2022 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Enable debug logging for requests to better debug S3Mock
+logging.level.org.springframework.web=DEBUG
+spring.mvc.log-request-details=true
+
+# Enable JMX  when debugging
+spring.jmx.enabled=true
+
+# Enable all actuator endpoints when debugging
+management.endpoints.web.exposure.include=*

--- a/server/src/test/java/com/adobe/testing/s3mock/FileStoreControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/FileStoreControllerTest.java
@@ -90,7 +90,7 @@ class FileStoreControllerTest {
           "d:1", "d:1:1",
           "eor.txt", "foo/eor.txt"};
 
-  private static final String TEST_BUCKET_NAME = "testBucket";
+  private static final String TEST_BUCKET_NAME = "test-bucket";
   private static final Bucket TEST_BUCKET =
       new Bucket(Paths.get("/tmp/foo/1"), TEST_BUCKET_NAME, Instant.now().toString());
   private static final String UPLOAD_FILE_NAME = "src/test/resources/sampleFile.txt";
@@ -108,7 +108,7 @@ class FileStoreControllerTest {
   void testListBuckets_Ok() throws Exception {
     List<Bucket> bucketList = new ArrayList<>();
     bucketList.add(TEST_BUCKET);
-    bucketList.add(new Bucket(Paths.get("/tmp/foo/2"), "testBucket1", Instant.now().toString()));
+    bucketList.add(new Bucket(Paths.get("/tmp/foo/2"), "test-bucket1", Instant.now().toString()));
     when(fileStore.listBuckets()).thenReturn(bucketList);
     ListAllMyBucketsResult expected = new ListAllMyBucketsResult(TEST_OWNER, bucketList);
 
@@ -142,7 +142,7 @@ class FileStoreControllerTest {
     when(fileStore.doesBucketExist(TEST_BUCKET_NAME)).thenReturn(true);
 
     mockMvc.perform(
-        head("/testBucket")
+        head("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isOk());
@@ -153,7 +153,7 @@ class FileStoreControllerTest {
     when(fileStore.doesBucketExist(TEST_BUCKET_NAME)).thenReturn(false);
 
     mockMvc.perform(
-        head("/testBucket")
+        head("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isNotFound());
@@ -162,7 +162,7 @@ class FileStoreControllerTest {
   @Test
   void testCreateBucket_Ok() throws Exception {
     mockMvc.perform(
-        put("/testBucket")
+        put("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isOk());
@@ -174,7 +174,7 @@ class FileStoreControllerTest {
         .thenThrow(new RuntimeException("THIS IS EXPECTED"));
 
     mockMvc.perform(
-        put("/testBucket")
+        put("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isInternalServerError());
@@ -189,7 +189,7 @@ class FileStoreControllerTest {
     when(fileStore.deleteBucket(TEST_BUCKET_NAME)).thenReturn(true);
 
     mockMvc.perform(
-        delete("/testBucket")
+        delete("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isNoContent());
@@ -204,7 +204,7 @@ class FileStoreControllerTest {
     when(fileStore.deleteBucket(TEST_BUCKET_NAME)).thenReturn(false);
 
     mockMvc.perform(
-        delete("/testBucket")
+        delete("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isNotFound());
@@ -218,7 +218,7 @@ class FileStoreControllerTest {
         .thenReturn(Collections.singletonList(new com.adobe.testing.s3mock.store.S3Object()));
 
     mockMvc.perform(
-        delete("/testBucket")
+        delete("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isConflict());
@@ -232,7 +232,7 @@ class FileStoreControllerTest {
         .thenThrow(new IOException("THIS IS EXPECTED"));
 
     mockMvc.perform(
-        delete("/testBucket")
+        delete("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isInternalServerError());
@@ -243,14 +243,14 @@ class FileStoreControllerTest {
     givenBucket();
 
     mockMvc.perform(
-        get("/testBucket")
+        get("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
             .queryParam(MAX_KEYS, "-1")
     ).andExpect(MockMvcResultMatchers.status().isBadRequest());
 
     mockMvc.perform(
-        get("/testBucket")
+        get("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
             .queryParam(ENCODING_TYPE, "not_valid")
@@ -265,7 +265,7 @@ class FileStoreControllerTest {
         .thenThrow(new IOException("THIS IS EXPECTED"));
 
     mockMvc.perform(
-        get("/testBucket")
+        get("/test-bucket")
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.APPLICATION_XML)
     ).andExpect(MockMvcResultMatchers.status().isInternalServerError());
@@ -285,7 +285,7 @@ class FileStoreControllerTest {
         .thenReturn(Collections.singletonList(s3Object(key, "etag")));
 
     mockMvc.perform(
-            get("/testBucket")
+            get("/test-bucket")
                 .accept(MediaType.APPLICATION_XML)
                 .contentType(MediaType.APPLICATION_XML)
         ).andExpect(MockMvcResultMatchers.status().isOk())
@@ -307,7 +307,7 @@ class FileStoreControllerTest {
         .thenReturn(s3Object(key, digest));
 
     mockMvc.perform(
-            put("/testBucket/" + key)
+            put("/test-bucket/" + key)
                 .accept(MediaType.APPLICATION_XML)
                 .contentType(MediaType.TEXT_PLAIN_VALUE)
                 .content(FileUtils.readFileToByteArray(testFile))
@@ -330,7 +330,7 @@ class FileStoreControllerTest {
         .thenReturn(s3Object(key, hexDigest));
 
     mockMvc.perform(
-            put("/testBucket/" + key)
+            put("/test-bucket/" + key)
                 .accept(MediaType.APPLICATION_XML)
                 .contentType(MediaType.TEXT_PLAIN_VALUE)
                 .header(CONTENT_MD5, base64Digest)
@@ -354,7 +354,7 @@ class FileStoreControllerTest {
         .thenReturn(s3Object(key, hexDigest));
 
     mockMvc.perform(
-        put("/testBucket/" + key)
+        put("/test-bucket/" + key)
             .accept(MediaType.APPLICATION_XML)
             .contentType(MediaType.TEXT_PLAIN_VALUE)
             .content(FileUtils.readFileToByteArray(testFile))
@@ -385,7 +385,7 @@ class FileStoreControllerTest {
         + " Each part must be at least 5 MB in size, except the last part.");
 
     mockMvc.perform(
-            post("/testBucket/" + key)
+            post("/test-bucket/" + key)
                 .accept(MediaType.APPLICATION_XML)
                 .content(MAPPER.writeValueAsString(uploadRequest))
                 .param("uploadId", uploadId)
@@ -417,7 +417,7 @@ class FileStoreControllerTest {
 
     String key = "sampleFile.txt";
     mockMvc.perform(
-            post("/testBucket/" + key)
+            post("/test-bucket/" + key)
                 .accept(MediaType.APPLICATION_XML)
                 .content(MAPPER.writeValueAsString(uploadRequest))
                 .param("uploadId", uploadId)
@@ -453,7 +453,7 @@ class FileStoreControllerTest {
             + "entity tag.");
 
     mockMvc.perform(
-            post("/testBucket/" + key)
+            post("/test-bucket/" + key)
                 .accept(MediaType.APPLICATION_XML)
                 .content(MAPPER.writeValueAsString(uploadRequest))
                 .param("uploadId", uploadId)
@@ -489,7 +489,7 @@ class FileStoreControllerTest {
         + "specified in order by part number.");
 
     mockMvc.perform(
-            post("/testBucket/" + key)
+            post("/test-bucket/" + key)
                 .accept(MediaType.APPLICATION_XML)
                 .content(MAPPER.writeValueAsString(uploadRequest))
                 .param("uploadId", uploadId)
@@ -509,7 +509,7 @@ class FileStoreControllerTest {
     when(fileStore.getS3Object(any(), any())).thenReturn(expectedS3Object);
 
     mockMvc.perform(
-        get("/testBucket/" + key)
+        get("/test-bucket/" + key)
     ).andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(MockMvcResultMatchers.header().string(X_AMZ_SERVER_SIDE_ENCRYPTION, encryption))
         .andExpect(MockMvcResultMatchers.header().string(
@@ -528,7 +528,7 @@ class FileStoreControllerTest {
     when(fileStore.getS3Object(any(), any())).thenReturn(expectedS3Object);
 
     mockMvc.perform(
-        head("/testBucket/" + key)
+        head("/test-bucket/" + key)
     ).andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(MockMvcResultMatchers.header().string(X_AMZ_SERVER_SIDE_ENCRYPTION, encryption))
         .andExpect(MockMvcResultMatchers.header().string(
@@ -542,7 +542,7 @@ class FileStoreControllerTest {
     givenBucket();
 
     mockMvc.perform(
-        head("/testBucket/" + key)
+        head("/test-bucket/" + key)
     ).andExpect(MockMvcResultMatchers.status().isNotFound());
   }
 


### PR DESCRIPTION
## Description
Using simplified bucket name validation.
When creating a bucket, check against simplified Regex whether the
bucket name is valid or not - only necessary for plain HTTP requests,
AWS SDKs (for Java) will validate the name before sending the request.
When calling other APIs, accept only valid bucket names in the path.

Also:
Log all request details when running in "debug" profile

## Related Issue
N/A

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
