### PR TITLE
Correctly detect and use existing root folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 * Version updates
   * TBD
 
+## 2.5.2
+* Features and fixes
+  * Correctly detect and use existing root folder (fixes #786)
+
 ## 2.5.1
 * Features and fixes
-  * Use @SpringBootApplication to configure S3Mock (fixes #782)
+  * Use `@SpringBootApplication` to configure S3Mock (fixes #782)
 
 ## 2.5.0
 * Features and fixes

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
@@ -77,13 +77,16 @@ class StoreConfiguration {
     if (!properties.isRetainFilesOnExit()) {
       root.deleteOnExit();
     }
-    if (!root.mkdir()) {
+    if (root.exists()) {
+      LOG.info("Using existing folder \"{}\" as root folder. Will retain files on exit: {}",
+          root.getAbsolutePath(), properties.isRetainFilesOnExit());
+    } else if (!root.mkdir()) {
       throw new IllegalStateException("Root folder could not be created. Path: "
           + root.getAbsolutePath());
+    } else {
+      LOG.info("Successfully created \"{}\" as root folder. Will retain files on exit: {}",
+          root.getAbsolutePath(), properties.isRetainFilesOnExit());
     }
-
-    LOG.info("Using \"{}\" as root folder. Will retain files on exit: {}",
-        root.getAbsolutePath(), properties.isRetainFilesOnExit());
 
     return root;
   }


### PR DESCRIPTION
## Description
Forgot that this is a feature - mount the root folder into Docker, so
that we can look at the created files while the S3Mock is running, or,
if `retainFilesOnExit` is set to true, even after S3Mock shuts down.

I'll have to think about how to integration test this later.

## Related Issue
Fixes #786

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
