### PR TITLE
Remove Spring Component Indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 * Version updates
   * TBD
 
+## 2.5.3
+* Features and fixes
+  * Remove [Spring Component Index](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-scanning-index) from S3Mock (fixes #786)
+    * Adding a Spring Component Index file is a breaking change for all clients of the s3mock.jar
+    * If Spring finds even one Component Index file in the classpath, all other configuration in the application 
+      is completely ignored by default.
+
 ## 2.5.2
 * Features and fixes
   * Correctly detect and use existing root folder (fixes #786)

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -79,11 +79,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context-indexer</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>


### PR DESCRIPTION
## Description
Adding a Spring Component Index file is a breaking change for all
clients of the s3mock.jar
Did not notice this when I added the index in 2.5.0

## Related Issue
Fixes #782 #751

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
