### PR TITLE
Allow customers to create ContextConfigurations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@
 * Version updates
   * TBD
 
+## 2.5.4
+* Features and fixes
+  * Rename local storage files, add file system structure documentation to README.md (fixes #220)
+  * `@Configuration` / `@ConfigurationProperties` classes now public to enable customers to use `@Import` / `@ContextConfiguration` on them. (fixes #751)
+
 ## 2.5.3
 * Features and fixes
   * Remove [Spring Component Index](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-scanning-index) from S3Mock (fixes #786)
     * Adding a Spring Component Index file is a breaking change for all clients of the s3mock.jar
     * If Spring finds even one Component Index file in the classpath, all other configuration in the application 
       is completely ignored by default.
-  * Add file system structure documentation to README.md (fixes #220)
 
 ## 2.5.2
 * Features and fixes

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
@@ -52,7 +52,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @Configuration
 @EnableConfigurationProperties(S3MockProperties.class)
-class S3MockConfiguration implements WebMvcConfigurer {
+public class S3MockConfiguration implements WebMvcConfigurer {
   private ServerConnector httpServerConnector;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockProperties.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockProperties.java
@@ -19,7 +19,7 @@ package com.adobe.testing.s3mock;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("com.adobe.testing.s3mock")
-class S3MockProperties {
+public class S3MockProperties {
 
   /**
    * Property name for passing the HTTPS port to use. Defaults to

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableConfigurationProperties(StoreProperties.class)
-class StoreConfiguration {
+public class StoreConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(StoreConfiguration.class);
   private static final DateTimeFormatter S3_OBJECT_DATE_FORMAT = DateTimeFormatter

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreProperties.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreProperties.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("com.adobe.testing.s3mock.domain") //TODO: wrong package.
-class StoreProperties {
+public class StoreProperties {
 
   /**
    * True if files should be retained when S3Mock exits gracefully.


### PR DESCRIPTION
## Description
If our "@Configuration" / "@ConfigurationProperties" classes are public,
customers can "@Import" them or use them in "@ContextConfiguration".

## Related Issue
Fixes #751

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
