### PR TITLE
Add support for LegalHold APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## 2.x
 * Features and fixes
-  * TBD
+  * Add support for LegalHold APIs (fixes #157)
+    * Implement GetObjectLegalHold / PutObjectLegalHold
+    * Implement GetObjectLockConfiguration / PutObjectLockConfiguration
+    * In S3, object locking can only be activated for versioned buckets, versions are currently not supported by S3Mock.
+      S3 enforces LegalHold only for versions, so S3Mock currently can't enforce the legal hold.
 * Refactorings
-  * TBD
+  * Added support for IntegrationTests to use a dedicated bucket per test method
+    * Refactored some ITs to this pattern.
 * Version updates
   * TBD
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2.kt
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest
+import software.amazon.awssdk.services.s3.model.ObjectLockLegalHold
+import software.amazon.awssdk.services.s3.model.ObjectLockLegalHoldStatus
+import software.amazon.awssdk.services.s3.model.PutObjectLegalHoldRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.io.File
+
+class LegalHoldV2 : S3TestBase() {
+
+  @Test
+  fun testGetLegalHoldDefault() {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val sourceKey = UPLOAD_FILE_NAME
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(S3TestBase.BUCKET_NAME).build())
+    s3ClientV2!!.putObject(
+      PutObjectRequest.builder().bucket(S3TestBase.BUCKET_NAME).key(sourceKey).build(),
+      RequestBody.fromFile(uploadFile)
+    )
+    val objectLegalHold = s3ClientV2!!.getObjectLegalHold(
+      GetObjectLegalHoldRequest
+        .builder()
+        .bucket(BUCKET_NAME)
+        .key(sourceKey)
+        .build()
+    )
+    assertThat(objectLegalHold.legalHold().status()).isEqualTo(ObjectLockLegalHoldStatus.OFF)
+  }
+
+  @Test
+  fun testPutAndGetLegalHold() {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val sourceKey = UPLOAD_FILE_NAME
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(S3TestBase.BUCKET_NAME).build())
+    s3ClientV2!!.putObject(
+      PutObjectRequest.builder().bucket(S3TestBase.BUCKET_NAME).key(sourceKey).build(),
+      RequestBody.fromFile(uploadFile)
+    )
+
+    s3ClientV2!!.putObjectLegalHold(PutObjectLegalHoldRequest
+      .builder()
+      .bucket(BUCKET_NAME)
+      .key(sourceKey)
+      .legalHold(ObjectLockLegalHold.builder().status(ObjectLockLegalHoldStatus.ON).build())
+      .build())
+
+    val objectLegalHold = s3ClientV2!!.getObjectLegalHold(
+      GetObjectLegalHoldRequest
+        .builder()
+        .bucket(BUCKET_NAME)
+        .key(sourceKey)
+        .build()
+    )
+    assertThat(objectLegalHold.legalHold().status()).isEqualTo(ObjectLockLegalHoldStatus.ON)
+  }
+
+  companion object {
+    const val BUCKET_NAME = "legal-hold-v2"
+  }
+}

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
@@ -30,7 +30,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
 import java.io.File
 
-class LegalHoldV2 : S3TestBase() {
+class LegalHoldV2IT : S3TestBase() {
 
   @Test
   fun testGetLegalHoldNoBucketLockConfiguration(testInfo: TestInfo) {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/TaggingResponsesV2IT.kt
@@ -17,28 +17,31 @@ package com.adobe.testing.s3mock.its
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.Tag
 import software.amazon.awssdk.services.s3.model.Tagging
 
 class TaggingResponsesV2IT : S3TestBase() {
-  private val bucket = INITIAL_BUCKET_NAMES.iterator().next()
 
   /**
    * Verify that tagging can be obtained and returns expected content.
    */
   @Test
-  fun testObjectTaggingWithPutObjectRequest() {
+  fun testObjectTaggingWithPutObjectRequest(testInfo: TestInfo) {
+    val bucketName = bucketName(testInfo)
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
     s3ClientV2!!.putObject(
-      { b: PutObjectRequest.Builder -> b.bucket(bucket).key("foo").tagging("msv=foo") },
+      { b: PutObjectRequest.Builder -> b.bucket(bucketName).key("foo").tagging("msv=foo") },
       RequestBody.fromString("foo")
     )
 
     assertThat(s3ClientV2!!.getObjectTagging { b: GetObjectTaggingRequest.Builder ->
       b.bucket(
-        bucket
+        bucketName
       ).key("foo")
     }
       .tagSet())
@@ -49,20 +52,22 @@ class TaggingResponsesV2IT : S3TestBase() {
    * Verify that tagging with multiple tags can be obtained and returns expected content.
    */
   @Test
-  fun testObjectTaggingWithPutObjectRequest_multipleTags() {
+  fun testObjectTaggingWithPutObjectRequest_multipleTags(testInfo: TestInfo) {
+    val bucketName = bucketName(testInfo)
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
     val tag1 = Tag.builder().key("tag1").value("foo").build()
     val tag2 = Tag.builder().key("tag2").value("bar").build()
 
     s3ClientV2!!.putObject(
       { b: PutObjectRequest.Builder ->
-        b.bucket(bucket).key("multipleFoo")
+        b.bucket(bucketName).key("multipleFoo")
         .tagging(Tagging.builder().tagSet(tag1, tag2).build())
       }, RequestBody.fromString("multipleFoo")
     )
 
     assertThat(s3ClientV2!!.getObjectTagging { b: GetObjectTaggingRequest.Builder ->
       b.bucket(
-        bucket
+        bucketName
       ).key("multipleFoo")
     }
       .tagSet())

--- a/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
@@ -21,17 +21,22 @@ import static com.adobe.testing.s3mock.util.AwsHttpParameters.CONTINUATION_TOKEN
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.ENCODING_TYPE;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.LIST_TYPE_V2;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.MAX_KEYS;
+import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_LIST_TYPE;
+import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_OBJECT_LOCK;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_UPLOADS;
+import static com.adobe.testing.s3mock.util.AwsHttpParameters.OBJECT_LOCK;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.START_AFTER;
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 import com.adobe.testing.s3mock.dto.ListAllMyBucketsResult;
 import com.adobe.testing.s3mock.dto.ListBucketResult;
 import com.adobe.testing.s3mock.dto.ListBucketResultV2;
+import com.adobe.testing.s3mock.dto.ObjectLockConfiguration;
 import com.adobe.testing.s3mock.service.BucketService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -89,11 +94,14 @@ public class BucketController {
           "/{bucketName:[a-z0-9.-]+}",
           "/{bucketName:.+}"
       },
+      params = {
+          NOT_OBJECT_LOCK
+      },
       method = RequestMethod.PUT
   )
   public ResponseEntity<Void> createBucket(@PathVariable final String bucketName,
       @RequestHeader(value = X_AMZ_BUCKET_OBJECT_LOCK_ENABLED,
-          required = false) Boolean objectLockEnabled) {
+          required = false, defaultValue = "false") boolean objectLockEnabled) {
     bucketService.verifyBucketNameIsAllowed(bucketName);
     bucketService.verifyBucketDoesNotExist(bucketName);
     bucketService.createBucket(bucketName, objectLockEnabled);
@@ -137,6 +145,56 @@ public class BucketController {
   }
 
   /**
+   * Get ObjectLockConfiguration of a bucket.
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLockConfiguration.html">API Reference</a>
+   *
+   * @param bucketName name of the Bucket.
+   *
+   * @return 200, ObjectLockConfiguration
+   */
+  @RequestMapping(
+      value = "/{bucketName:[a-z0-9.-]+}",
+      params = {
+          OBJECT_LOCK,
+          NOT_LIST_TYPE
+      },
+      method = RequestMethod.GET,
+      produces = {
+          APPLICATION_XML_VALUE
+      }
+  )
+  public ResponseEntity<ObjectLockConfiguration> getObjectLockConfiguration(
+      @PathVariable String bucketName) {
+    bucketService.verifyBucketExists(bucketName);
+    ObjectLockConfiguration configuration = bucketService.getObjectLockConfiguration(bucketName);
+    return ResponseEntity.ok(configuration);
+  }
+
+  /**
+   * Put ObjectLockConfiguration of a bucket.
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLockConfiguration.html">API Reference</a>
+   *
+   * @param bucketName name of the Bucket.
+   *
+   * @return 200, ObjectLockConfiguration
+   */
+  @RequestMapping(
+      value = "/{bucketName:[a-z0-9.-]+}",
+      params = {
+          OBJECT_LOCK
+      },
+      method = RequestMethod.PUT,
+      consumes = APPLICATION_XML_VALUE
+  )
+  public ResponseEntity<Void> putObjectLockConfiguration(
+      @PathVariable String bucketName,
+      @RequestBody ObjectLockConfiguration configuration) {
+    bucketService.verifyBucketExists(bucketName);
+    bucketService.setObjectLockConfiguration(bucketName, configuration);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
    * Retrieve list of objects of a bucket.
    * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">API Reference</a>
    *
@@ -149,7 +207,9 @@ public class BucketController {
    */
   @RequestMapping(
       params = {
-          NOT_UPLOADS
+          NOT_UPLOADS,
+          NOT_OBJECT_LOCK,
+          NOT_LIST_TYPE
       },
       value = "/{bucketName:[a-z0-9.-]+}",
       method = RequestMethod.GET,

--- a/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
@@ -16,6 +16,7 @@
 
 package com.adobe.testing.s3mock;
 
+import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_BUCKET_OBJECT_LOCK_ENABLED;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.CONTINUATION_TOKEN;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.ENCODING_TYPE;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.LIST_TYPE_V2;
@@ -31,6 +32,7 @@ import com.adobe.testing.s3mock.service.BucketService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -89,10 +91,12 @@ public class BucketController {
       },
       method = RequestMethod.PUT
   )
-  public ResponseEntity<Void> createBucket(@PathVariable final String bucketName) {
+  public ResponseEntity<Void> createBucket(@PathVariable final String bucketName,
+      @RequestHeader(value = X_AMZ_BUCKET_OBJECT_LOCK_ENABLED,
+          required = false) Boolean objectLockEnabled) {
     bucketService.verifyBucketNameIsAllowed(bucketName);
     bucketService.verifyBucketDoesNotExist(bucketName);
-    bucketService.createBucket(bucketName);
+    bucketService.createBucket(bucketName, objectLockEnabled);
     return ResponseEntity.ok().build();
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -29,6 +29,7 @@ import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENC
 import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_TAGGING;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.DELETE;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.LEGAL_HOLD;
+import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_LEGAL_HOLD;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_TAGGING;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_UPLOADS;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_UPLOAD_ID;
@@ -198,7 +199,8 @@ public class ObjectController {
       params = {
           NOT_UPLOADS,
           NOT_UPLOAD_ID,
-          NOT_TAGGING
+          NOT_TAGGING,
+          NOT_LEGAL_HOLD
       },
       method = RequestMethod.GET,
       produces = {
@@ -310,7 +312,9 @@ public class ObjectController {
   public ResponseEntity<LegalHold> getLegalHold(@PathVariable String bucketName,
       @PathVariable ObjectKey key) {
     bucketService.verifyBucketExists(bucketName);
-    S3ObjectMetadata s3ObjectMetadata = objectService.verifyObjectExists(bucketName, key.getKey());
+    bucketService.verifyBucketOjectLockEnabled(bucketName);
+    S3ObjectMetadata s3ObjectMetadata =
+        objectService.verifyObjectLockConfiguration(bucketName, key.getKey());
 
     return ResponseEntity
         .ok()
@@ -335,6 +339,7 @@ public class ObjectController {
       @PathVariable ObjectKey key,
       @RequestBody LegalHold body) {
     bucketService.verifyBucketExists(bucketName);
+    bucketService.verifyBucketOjectLockEnabled(bucketName);
 
     objectService.verifyObjectExists(bucketName, key.getKey());
     objectService.setLegalHold(bucketName, key.getKey(), body);

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -362,7 +362,8 @@ public class ObjectController {
   @RequestMapping(
       params = {
           NOT_UPLOAD_ID,
-          NOT_TAGGING
+          NOT_TAGGING,
+          NOT_LEGAL_HOLD
       },
       headers = {
           NOT_X_AMZ_COPY_SOURCE

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -28,6 +28,7 @@ import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENC
 import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID;
 import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_TAGGING;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.DELETE;
+import static com.adobe.testing.s3mock.util.AwsHttpParameters.LEGAL_HOLD;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_TAGGING;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_UPLOADS;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_UPLOAD_ID;
@@ -51,6 +52,7 @@ import com.adobe.testing.s3mock.dto.CopyObjectResult;
 import com.adobe.testing.s3mock.dto.CopySource;
 import com.adobe.testing.s3mock.dto.Delete;
 import com.adobe.testing.s3mock.dto.DeleteResult;
+import com.adobe.testing.s3mock.dto.LegalHold;
 import com.adobe.testing.s3mock.dto.ObjectKey;
 import com.adobe.testing.s3mock.dto.Range;
 import com.adobe.testing.s3mock.dto.Tag;
@@ -287,6 +289,57 @@ public class ObjectController {
         .ok()
         .eTag("\"" + s3ObjectMetadata.getEtag() + "\"")
         .lastModified(s3ObjectMetadata.getLastModified())
+        .build();
+  }
+
+  /**
+   * Returns the legal hold for an object.
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLegalHold.html">API Reference</a>
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html">API Reference</a>
+   *
+   * @param bucketName The Bucket's name
+   */
+  @RequestMapping(
+      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      params = {
+          LEGAL_HOLD
+      },
+      method = RequestMethod.GET,
+      produces = APPLICATION_XML_VALUE
+  )
+  public ResponseEntity<LegalHold> getLegalHold(@PathVariable String bucketName,
+      @PathVariable ObjectKey key) {
+    bucketService.verifyBucketExists(bucketName);
+    S3ObjectMetadata s3ObjectMetadata = objectService.verifyObjectExists(bucketName, key.getKey());
+
+    return ResponseEntity
+        .ok()
+        .body(s3ObjectMetadata.getLegalHold());
+  }
+
+  /**
+   * Sets legal hold for an object.
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html">API Reference</a>
+   *
+   * @param bucketName The Bucket's name
+   * @param body Tagging object
+   */
+  @RequestMapping(
+      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      params = {
+          LEGAL_HOLD
+      },
+      method = RequestMethod.PUT
+  )
+  public ResponseEntity<String> putLegalHold(@PathVariable String bucketName,
+      @PathVariable ObjectKey key,
+      @RequestBody LegalHold body) {
+    bucketService.verifyBucketExists(bucketName);
+
+    objectService.verifyObjectExists(bucketName, key.getKey());
+    objectService.setLegalHold(bucketName, key.getKey(), body);
+    return ResponseEntity
+        .ok()
         .build();
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/S3Exception.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3Exception.java
@@ -69,6 +69,12 @@ public class S3Exception extends RuntimeException {
           "The requested bucket name is not available. "
               + "The bucket namespace is shared by all users of the system. "
               + "Please select a different name and try again.");
+  public static final S3Exception INVALID_REQUEST_BUCKET_OBJECT_LOCK =
+      new S3Exception(BAD_REQUEST.value(), "InvalidRequest",
+          "Bucket is missing Object Lock Configuration");
+  public static final S3Exception NOT_FOUND_OBJECT_LOCK =
+      new S3Exception(NOT_FOUND.value(), "NotFound",
+          "The specified object does not have a ObjectLock configuration");
   public static final S3Exception INVALID_REQUEST_MAXKEYS =
       new S3Exception(BAD_REQUEST.value(), "InvalidRequest",
           "maxKeys should be non-negative");

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/DefaultRetention.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/DefaultRetention.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DefaultRetention.html">API Reference</a>.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class DefaultRetention {
+
+  @JsonProperty("Days")
+  private Integer days;
+
+  @JsonProperty("Years")
+  private Integer years;
+
+  @JsonProperty("Mode")
+  private Mode mode;
+
+  public DefaultRetention() {
+  }
+
+  public DefaultRetention(Integer days, Integer years, Mode mode) {
+    //TODO: setting days & years not allowed!
+    this.days = days;
+    this.years = years;
+    this.mode = mode;
+  }
+
+  public Integer getDays() {
+    return days;
+  }
+
+  public void setDays(Integer days) {
+    this.days = days;
+  }
+
+  public Integer getYears() {
+    return years;
+  }
+
+  public void setYears(Integer years) {
+    this.years = years;
+  }
+
+  public Mode getMode() {
+    return mode;
+  }
+
+  public void setMode(Mode mode) {
+    this.mode = mode;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DefaultRetention retention = (DefaultRetention) o;
+    return Objects.equals(days, retention.days) && Objects.equals(years,
+        retention.years) && mode == retention.mode;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(days, years, mode);
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/LegalHold.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/LegalHold.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html#API_PutObjectLegalHold_RequestSyntax">API Reference</a>.
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html">API Reference</a>.
+ */
+@JsonRootName("LegalHold")
+public class LegalHold {
+
+  @JsonProperty("Status")
+  private Status status;
+
+  public LegalHold() {
+
+  }
+
+  public LegalHold(Status status) {
+    this.status = status;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public void setStatus(Status status) {
+    this.status = status;
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Mode.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Mode.java
@@ -20,16 +20,17 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html#API_PutObjectLegalHold_RequestSyntax">API Reference</a>.
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DefaultRetention.html">API Reference</a>.
  */
-public enum Status {
-  ON("ON"),
-  OFF("OFF");
+public enum Mode {
+
+  GOVERNANCE("GOVERNANCE"),
+  COMPLIANCE("COMPLIANCE");
 
   private final String value;
 
   @JsonCreator
-  Status(String value) {
+  Mode(String value) {
     this.value = value;
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectLockConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectLockConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import java.util.Objects;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ObjectLockConfiguration.html">API Reference</a>.
+ */
+@JsonRootName("ObjectLockConfiguration")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ObjectLockConfiguration {
+
+  @JsonProperty("ObjectLockEnabled")
+  private ObjectLockEnabled objectLockEnabled;
+
+  @JsonProperty("Rule")
+  private ObjectLockRule objectLockRule;
+
+  public ObjectLockConfiguration() {
+  }
+
+  public ObjectLockConfiguration(ObjectLockEnabled objectLockEnabled,
+      ObjectLockRule objectLockRule) {
+    this.objectLockEnabled = objectLockEnabled;
+    this.objectLockRule = objectLockRule;
+  }
+
+  public ObjectLockEnabled getObjectLockEnabled() {
+    return objectLockEnabled;
+  }
+
+  public void setObjectLockEnabled(ObjectLockEnabled objectLockEnabled) {
+    this.objectLockEnabled = objectLockEnabled;
+  }
+
+  public ObjectLockRule getObjectLockRule() {
+    return objectLockRule;
+  }
+
+  public void setObjectLockRule(ObjectLockRule objectLockRule) {
+    this.objectLockRule = objectLockRule;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ObjectLockConfiguration that = (ObjectLockConfiguration) o;
+    return objectLockEnabled == that.objectLockEnabled && Objects.equals(objectLockRule,
+        that.objectLockRule);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(objectLockEnabled, objectLockRule);
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectLockEnabled.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectLockEnabled.java
@@ -20,16 +20,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html#API_PutObjectLegalHold_RequestSyntax">API Reference</a>.
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ObjectLockConfiguration.html">API Reference</a>.
  */
-public enum Status {
-  ON("ON"),
-  OFF("OFF");
+public enum ObjectLockEnabled {
+  ENABLED("Enabled");
 
   private final String value;
 
   @JsonCreator
-  Status(String value) {
+  ObjectLockEnabled(String value) {
     this.value = value;
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectLockRule.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectLockRule.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ObjectLockRule.html">API Reference</a>.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ObjectLockRule {
+
+  @JsonProperty("DefaultRetention")
+  private  DefaultRetention defaultRetention;
+
+  public ObjectLockRule() {
+  }
+
+  public ObjectLockRule(DefaultRetention defaultRetention) {
+    this.defaultRetention = defaultRetention;
+  }
+
+  public DefaultRetention getDefaultRetention() {
+    return defaultRetention;
+  }
+
+  public void setDefaultRetention(DefaultRetention defaultRetention) {
+    this.defaultRetention = defaultRetention;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ObjectLockRule that = (ObjectLockRule) o;
+    return Objects.equals(defaultRetention, that.defaultRetention);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(defaultRetention);
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Status.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Status.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html#API_PutObjectLegalHold_RequestSyntax">API Reference</a>.
+ */
+public enum Status {
+  ON("ON"),
+  OFF("OFF");
+
+  private final String value;
+
+  @JsonCreator
+  Status(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/StorageClass.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/StorageClass.java
@@ -17,6 +17,7 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html">API Reference</a>.
@@ -41,6 +42,7 @@ public enum StorageClass {
   }
 
   @Override
+  @JsonValue
   public String toString() {
     return value;
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/service/BucketService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/BucketService.java
@@ -19,6 +19,7 @@ package com.adobe.testing.s3mock.service;
 import static com.adobe.testing.s3mock.S3Exception.BUCKET_ALREADY_EXISTS;
 import static com.adobe.testing.s3mock.S3Exception.BUCKET_NOT_EMPTY;
 import static com.adobe.testing.s3mock.S3Exception.INVALID_BUCKET_NAME;
+import static com.adobe.testing.s3mock.S3Exception.INVALID_REQUEST_BUCKET_OBJECT_LOCK;
 import static com.adobe.testing.s3mock.S3Exception.INVALID_REQUEST_ENCODINGTYPE;
 import static com.adobe.testing.s3mock.S3Exception.INVALID_REQUEST_MAXKEYS;
 import static com.adobe.testing.s3mock.S3Exception.NO_SUCH_BUCKET;
@@ -92,8 +93,8 @@ public class BucketService {
    *
    * @return the Bucket
    */
-  public Bucket createBucket(String bucketName) {
-    return Bucket.from(bucketStore.createBucket(bucketName));
+  public Bucket createBucket(String bucketName, Boolean objectLockEnabled) {
+    return Bucket.from(bucketStore.createBucket(bucketName, objectLockEnabled));
   }
 
   public boolean deleteBucket(String bucketName) {
@@ -221,6 +222,12 @@ public class BucketService {
   public void verifyBucketExists(String bucketName) {
     if (!bucketStore.doesBucketExist(bucketName)) {
       throw NO_SUCH_BUCKET;
+    }
+  }
+
+  public void verifyBucketOjectLockEnabled(String bucketName) {
+    if (!bucketStore.isObjectLockEnabled(bucketName)) {
+      throw INVALID_REQUEST_BUCKET_OBJECT_LOCK;
     }
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/service/BucketService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/BucketService.java
@@ -32,6 +32,7 @@ import com.adobe.testing.s3mock.dto.Bucket;
 import com.adobe.testing.s3mock.dto.ListAllMyBucketsResult;
 import com.adobe.testing.s3mock.dto.ListBucketResult;
 import com.adobe.testing.s3mock.dto.ListBucketResultV2;
+import com.adobe.testing.s3mock.dto.ObjectLockConfiguration;
 import com.adobe.testing.s3mock.dto.S3Object;
 import com.adobe.testing.s3mock.store.BucketMetadata;
 import com.adobe.testing.s3mock.store.BucketStore;
@@ -93,12 +94,22 @@ public class BucketService {
    *
    * @return the Bucket
    */
-  public Bucket createBucket(String bucketName, Boolean objectLockEnabled) {
+  public Bucket createBucket(String bucketName, boolean objectLockEnabled) {
     return Bucket.from(bucketStore.createBucket(bucketName, objectLockEnabled));
   }
 
   public boolean deleteBucket(String bucketName) {
     return bucketStore.deleteBucket(bucketName);
+  }
+
+  public void setObjectLockConfiguration(String bucketName, ObjectLockConfiguration configuration) {
+    BucketMetadata bucketMetadata = bucketStore.getBucketMetadata(bucketName);
+    bucketMetadata.setObjectLockConfiguration(configuration);
+  }
+
+  public ObjectLockConfiguration getObjectLockConfiguration(String bucketName) {
+    BucketMetadata bucketMetadata = bucketStore.getBucketMetadata(bucketName);
+    return bucketMetadata.getObjectLockConfiguration();
   }
 
   /**
@@ -165,8 +176,7 @@ public class BucketService {
 
     if (Objects.equals("url", encodingType)) {
       contents = apply(contents, (object) -> {
-        String key = object.getKey();
-        object.setKey(urlEncodeIgnoreSlashes(key));
+        object.setKey(urlEncodeIgnoreSlashes(object.getKey()));
         return object;
       });
       returnPrefix = urlEncodeIgnoreSlashes(prefix);

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -17,6 +17,7 @@
 package com.adobe.testing.s3mock.service;
 
 import static com.adobe.testing.s3mock.S3Exception.BAD_REQUEST_MD5;
+import static com.adobe.testing.s3mock.S3Exception.NOT_FOUND_OBJECT_LOCK;
 import static com.adobe.testing.s3mock.S3Exception.NOT_MODIFIED;
 import static com.adobe.testing.s3mock.S3Exception.NO_SUCH_KEY;
 import static com.adobe.testing.s3mock.S3Exception.PRECONDITION_FAILED;
@@ -290,6 +291,15 @@ public class ObjectService {
     S3ObjectMetadata s3ObjectMetadata = objectStore.getS3ObjectMetadata(bucketMetadata, uuid);
     if (s3ObjectMetadata == null) {
       throw NO_SUCH_KEY;
+    }
+    return s3ObjectMetadata;
+  }
+
+
+  public S3ObjectMetadata verifyObjectLockConfiguration(String bucketName, String key) {
+    S3ObjectMetadata s3ObjectMetadata = verifyObjectExists(bucketName, key);
+    if (s3ObjectMetadata.getLegalHold() == null) {
+      throw NOT_FOUND_OBJECT_LOCK;
     }
     return s3ObjectMetadata;
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -26,6 +26,7 @@ import com.adobe.testing.s3mock.dto.CopyObjectResult;
 import com.adobe.testing.s3mock.dto.Delete;
 import com.adobe.testing.s3mock.dto.DeleteResult;
 import com.adobe.testing.s3mock.dto.DeletedS3Object;
+import com.adobe.testing.s3mock.dto.LegalHold;
 import com.adobe.testing.s3mock.dto.S3ObjectIdentifier;
 import com.adobe.testing.s3mock.dto.Tag;
 import com.adobe.testing.s3mock.store.BucketMetadata;
@@ -213,6 +214,19 @@ public class ObjectService {
     BucketMetadata bucketMetadata = bucketStore.getBucketMetadata(bucketName);
     UUID uuid = bucketMetadata.getID(key);
     objectStore.storeObjectTags(bucketMetadata, uuid, tags);
+  }
+
+  /**
+   * Sets LegalHold for a given object.
+   *
+   * @param bucketName Bucket the object is stored in.
+   * @param key object key to store tags for.
+   * @param legalHold the legal hold.
+   */
+  public void setLegalHold(String bucketName, String key, LegalHold legalHold) {
+    BucketMetadata bucketMetadata = bucketStore.getBucketMetadata(bucketName);
+    UUID uuid = bucketMetadata.getID(key);
+    objectStore.storeLegalHold(bucketMetadata, uuid, legalHold);
   }
 
   public InputStream verifyMd5(InputStream inputStream, String contentMd5,

--- a/server/src/main/java/com/adobe/testing/s3mock/store/BucketMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/BucketMetadata.java
@@ -18,6 +18,7 @@ package com.adobe.testing.s3mock.store;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.adobe.testing.s3mock.dto.ObjectLockConfiguration;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,18 +33,18 @@ public class BucketMetadata {
 
   private String creationDate;
 
-  private Boolean objectLockEnabled;
-
+  private ObjectLockConfiguration objectLockConfiguration;
   private Path path;
 
   private Map<String, UUID> objects = new HashMap<>();
 
-  public Boolean getObjectLockEnabled() {
-    return objectLockEnabled;
+  public ObjectLockConfiguration getObjectLockConfiguration() {
+    return objectLockConfiguration;
   }
 
-  public void setObjectLockEnabled(Boolean objectLockEnabled) {
-    this.objectLockEnabled = objectLockEnabled;
+  public void setObjectLockConfiguration(
+      ObjectLockConfiguration objectLockConfiguration) {
+    this.objectLockConfiguration = objectLockConfiguration;
   }
 
   public String getName() {

--- a/server/src/main/java/com/adobe/testing/s3mock/store/BucketMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/BucketMetadata.java
@@ -32,9 +32,19 @@ public class BucketMetadata {
 
   private String creationDate;
 
+  private Boolean objectLockEnabled;
+
   private Path path;
 
   private Map<String, UUID> objects = new HashMap<>();
+
+  public Boolean getObjectLockEnabled() {
+    return objectLockEnabled;
+  }
+
+  public void setObjectLockEnabled(Boolean objectLockEnabled) {
+    this.objectLockEnabled = objectLockEnabled;
+  }
 
   public String getName() {
     return name;

--- a/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
@@ -16,6 +16,8 @@
 
 package com.adobe.testing.s3mock.store;
 
+import com.adobe.testing.s3mock.dto.ObjectLockConfiguration;
+import com.adobe.testing.s3mock.dto.ObjectLockEnabled;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
@@ -59,7 +61,7 @@ public class BucketStore {
     this.retainFilesOnExit = retainFilesOnExit;
     this.s3ObjectDateFormat = s3ObjectDateFormat;
     this.objectMapper = objectMapper;
-    initialBuckets.forEach(bucketName -> this.createBucket(bucketName, null));
+    initialBuckets.forEach(bucketName -> this.createBucket(bucketName, false));
   }
 
   /**
@@ -176,7 +178,7 @@ public class BucketStore {
    * @throws IllegalStateException if the bucket cannot be created or the bucket already exists but
    *        is not a directory.
    */
-  public BucketMetadata createBucket(String bucketName, Boolean objectLockEnabled) {
+  public BucketMetadata createBucket(String bucketName, boolean objectLockEnabled) {
     BucketMetadata bucketMetadata = getBucketMetadata(bucketName);
     if (bucketMetadata != null) {
       throw new IllegalStateException("Bucket already exists.");
@@ -189,7 +191,11 @@ public class BucketStore {
       newBucketMetadata.setName(bucketName);
       newBucketMetadata.setCreationDate(s3ObjectDateFormat.format(LocalDateTime.now()));
       newBucketMetadata.setPath(bucketFolder.toPath());
-      newBucketMetadata.setObjectLockEnabled(objectLockEnabled);
+      if (objectLockEnabled) {
+        newBucketMetadata.setObjectLockConfiguration(
+            new ObjectLockConfiguration(ObjectLockEnabled.ENABLED, null)
+        );
+      }
       writeToDisk(newBucketMetadata);
       return newBucketMetadata;
     }
@@ -209,8 +215,12 @@ public class BucketStore {
   }
 
   public Boolean isObjectLockEnabled(String bucketName) {
-    Boolean objectLockEnabled = getBucketMetadata(bucketName).getObjectLockEnabled();
-    return objectLockEnabled != null ? objectLockEnabled : false;
+    ObjectLockConfiguration objectLockConfiguration =
+        getBucketMetadata(bucketName).getObjectLockConfiguration();
+    if (objectLockConfiguration != null) {
+      return ObjectLockEnabled.ENABLED == objectLockConfiguration.getObjectLockEnabled();
+    }
+    return false;
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
@@ -59,7 +59,7 @@ public class BucketStore {
     this.retainFilesOnExit = retainFilesOnExit;
     this.s3ObjectDateFormat = s3ObjectDateFormat;
     this.objectMapper = objectMapper;
-    initialBuckets.forEach(this::createBucket);
+    initialBuckets.forEach(bucketName -> this.createBucket(bucketName, null));
   }
 
   /**
@@ -176,7 +176,7 @@ public class BucketStore {
    * @throws IllegalStateException if the bucket cannot be created or the bucket already exists but
    *        is not a directory.
    */
-  public BucketMetadata createBucket(String bucketName) {
+  public BucketMetadata createBucket(String bucketName, Boolean objectLockEnabled) {
     BucketMetadata bucketMetadata = getBucketMetadata(bucketName);
     if (bucketMetadata != null) {
       throw new IllegalStateException("Bucket already exists.");
@@ -189,6 +189,7 @@ public class BucketStore {
       newBucketMetadata.setName(bucketName);
       newBucketMetadata.setCreationDate(s3ObjectDateFormat.format(LocalDateTime.now()));
       newBucketMetadata.setPath(bucketFolder.toPath());
+      newBucketMetadata.setObjectLockEnabled(objectLockEnabled);
       writeToDisk(newBucketMetadata);
       return newBucketMetadata;
     }
@@ -205,6 +206,11 @@ public class BucketStore {
    */
   public Boolean doesBucketExist(String bucketName) {
     return getBucketMetadata(bucketName) != null;
+  }
+
+  public Boolean isObjectLockEnabled(String bucketName) {
+    Boolean objectLockEnabled = getBucketMetadata(bucketName).getObjectLockEnabled();
+    return objectLockEnabled != null ? objectLockEnabled : false;
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
@@ -21,6 +21,7 @@ import static java.nio.file.Files.newOutputStream;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.adobe.testing.s3mock.dto.CopyObjectResult;
+import com.adobe.testing.s3mock.dto.LegalHold;
 import com.adobe.testing.s3mock.dto.Tag;
 import com.adobe.testing.s3mock.util.AwsChunkedDecodingInputStream;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -129,7 +130,7 @@ public class ObjectStore {
   }
 
   /**
-   * Sets tags for a given object.
+   * Store tags for a given object.
    *
    * @param bucket Bucket the object is stored in.
    * @param id object ID to store tags for.
@@ -139,6 +140,21 @@ public class ObjectStore {
     synchronized (lockStore.get(id)) {
       S3ObjectMetadata s3ObjectMetadata = getS3ObjectMetadata(bucket, id);
       s3ObjectMetadata.setTags(tags);
+      writeMetafile(bucket, s3ObjectMetadata);
+    }
+  }
+
+  /**
+   * Store legal hold for a given object.
+   *
+   * @param bucket Bucket the object is stored in.
+   * @param id object ID to store tags for.
+   * @param legalHold the legal hold.
+   */
+  public void storeLegalHold(BucketMetadata bucket, UUID id, LegalHold legalHold) {
+    synchronized (lockStore.get(id)) {
+      S3ObjectMetadata s3ObjectMetadata = getS3ObjectMetadata(bucket, id);
+      s3ObjectMetadata.setLegalHold(legalHold);
       writeMetafile(bucket, s3ObjectMetadata);
     }
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
@@ -17,7 +17,6 @@
 package com.adobe.testing.s3mock.store;
 
 import com.adobe.testing.s3mock.dto.LegalHold;
-import com.adobe.testing.s3mock.dto.Status;
 import com.adobe.testing.s3mock.dto.Tag;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -63,10 +62,7 @@ public class S3ObjectMetadata {
 
   private List<Tag> tags;
 
-  /**
-   * Legal hold is OFF by default.
-   */
-  private LegalHold legalHold = new LegalHold(Status.OFF);
+  private LegalHold legalHold;
 
   public LegalHold getLegalHold() {
     return legalHold;

--- a/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
@@ -16,6 +16,8 @@
 
 package com.adobe.testing.s3mock.store;
 
+import com.adobe.testing.s3mock.dto.LegalHold;
+import com.adobe.testing.s3mock.dto.Status;
 import com.adobe.testing.s3mock.dto.Tag;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -60,6 +62,19 @@ public class S3ObjectMetadata {
   private Map<String, String> userMetadata;
 
   private List<Tag> tags;
+
+  /**
+   * Legal hold is OFF by default.
+   */
+  private LegalHold legalHold = new LegalHold(Status.OFF);
+
+  public LegalHold getLegalHold() {
+    return legalHold;
+  }
+
+  public void setLegalHold(LegalHold legalHold) {
+    this.legalHold = legalHold;
+  }
 
   public String getKey() {
     return key;

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
@@ -45,6 +45,8 @@ public final class AwsHttpHeaders {
 
   public static final String X_AMZ_DELETE_MARKER = "x-amz-delete-marker";
 
+  public static final String X_AMZ_BUCKET_OBJECT_LOCK_ENABLED = "x-amz-bucket-object-lock-enabled";
+
   private AwsHttpHeaders() {
     // empty private constructor
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
@@ -27,6 +27,7 @@ public class AwsHttpParameters {
   public static final String DELETE = "delete";
   public static final String ENCODING_TYPE = "encoding-type";
   public static final String LIST_TYPE_V2 = "list-type=2";
+  public static final String NOT_LIST_TYPE = "!list-type";
   public static final String MAX_KEYS = "max-keys";
   public static final String PART_NUMBER = "partNumber";
   public static final String START_AFTER = "start-after";
@@ -40,6 +41,8 @@ public class AwsHttpParameters {
 
   public static final String LEGAL_HOLD = "legal-hold";
   public static final String NOT_LEGAL_HOLD = NOT + LEGAL_HOLD;
+  public static final String OBJECT_LOCK = "object-lock";
+  public static final String NOT_OBJECT_LOCK = NOT + OBJECT_LOCK;
 
   private AwsHttpParameters() {
     // empty private constructor

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
@@ -38,6 +38,9 @@ public class AwsHttpParameters {
   public static final String UPLOAD_ID = "uploadId";
   public static final String NOT_UPLOAD_ID = NOT + UPLOAD_ID;
 
+  public static final String LEGAL_HOLD = "legal-hold";
+  public static final String NOT_LEGAL_HOLD = NOT + LEGAL_HOLD;
+
   private AwsHttpParameters() {
     // empty private constructor
   }

--- a/server/src/test/java/com/adobe/testing/s3mock/BucketControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/BucketControllerTest.java
@@ -146,7 +146,7 @@ class BucketControllerTest {
 
   @Test
   void testCreateBucket_InternalServerError() throws Exception {
-    when(bucketService.createBucket(TEST_BUCKET_NAME))
+    when(bucketService.createBucket(TEST_BUCKET_NAME, null))
         .thenThrow(new IllegalStateException("THIS IS EXPECTED"));
 
     mockMvc.perform(

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/LegalHoldTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/LegalHoldTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import static com.adobe.testing.s3mock.dto.DtoTestUtil.deserialize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+class LegalHoldTest {
+
+  @Test
+  void testDeserialization(TestInfo testInfo) throws IOException {
+    LegalHold iut = deserialize(LegalHold.class, testInfo);
+    assertThat(iut.getStatus()).isEqualTo(Status.ON);
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ObjectLockConfigurationTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ObjectLockConfigurationTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import static com.adobe.testing.s3mock.dto.DtoTestUtil.deserialize;
+import static com.adobe.testing.s3mock.dto.DtoTestUtil.serializeAndAssert;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+class ObjectLockConfigurationTest {
+
+  @Test
+  void testSerialization(TestInfo testInfo) throws IOException {
+    DefaultRetention retention = new DefaultRetention(1, null, Mode.COMPLIANCE);
+    ObjectLockRule rule = new ObjectLockRule(retention);
+    ObjectLockConfiguration iut = new ObjectLockConfiguration(ObjectLockEnabled.ENABLED, rule);
+
+    serializeAndAssert(iut, testInfo);
+  }
+
+
+  @Test
+  void testDeserialization(TestInfo testInfo) throws IOException {
+    ObjectLockConfiguration iut = deserialize(ObjectLockConfiguration.class, testInfo);
+    assertThat(iut.getObjectLockEnabled()).isNull();
+    assertThat(iut.getObjectLockRule().getDefaultRetention().getYears()).isEqualTo(1);
+    assertThat(iut.getObjectLockRule().getDefaultRetention().getMode()).isEqualTo(Mode.COMPLIANCE);
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/store/BucketStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/BucketStoreTest.java
@@ -44,7 +44,7 @@ class BucketStoreTest {
    */
   @Test
   void shouldCreateBucket() {
-    final BucketMetadata bucket = bucketStore.createBucket(TEST_BUCKET_NAME);
+    final BucketMetadata bucket = bucketStore.createBucket(TEST_BUCKET_NAME, null);
     assertThat(bucket.getName()).as("Bucket should have been created.").endsWith(TEST_BUCKET_NAME);
     assertThat(bucket.getPath()).exists();
   }
@@ -55,7 +55,7 @@ class BucketStoreTest {
    */
   @Test
   void bucketShouldExist() {
-    bucketStore.createBucket(TEST_BUCKET_NAME);
+    bucketStore.createBucket(TEST_BUCKET_NAME, null);
 
     final Boolean doesBucketExist = bucketStore.doesBucketExist(TEST_BUCKET_NAME);
 
@@ -84,9 +84,9 @@ class BucketStoreTest {
     final String bucketName2 = "myNüwNämeZwöei";
     final String bucketName3 = "myNüwNämeDrü";
 
-    bucketStore.createBucket(bucketName1);
-    bucketStore.createBucket(bucketName2);
-    bucketStore.createBucket(bucketName3);
+    bucketStore.createBucket(bucketName1, null);
+    bucketStore.createBucket(bucketName2, null);
+    bucketStore.createBucket(bucketName3, null);
 
     final List<BucketMetadata> buckets = bucketStore.listBuckets();
 
@@ -99,7 +99,7 @@ class BucketStoreTest {
    */
   @Test
   void shouldGetBucketByName() {
-    bucketStore.createBucket(TEST_BUCKET_NAME);
+    bucketStore.createBucket(TEST_BUCKET_NAME, null);
     BucketMetadata bucket = bucketStore.getBucketMetadata(TEST_BUCKET_NAME);
 
     assertThat(bucket).as("Bucket should not be null").isNotNull();
@@ -113,7 +113,7 @@ class BucketStoreTest {
    */
   @Test
   void shouldDeleteBucket() {
-    bucketStore.createBucket(TEST_BUCKET_NAME);
+    bucketStore.createBucket(TEST_BUCKET_NAME, null);
     boolean bucketDeleted = bucketStore.deleteBucket(TEST_BUCKET_NAME);
     BucketMetadata bucket = bucketStore.getBucketMetadata(TEST_BUCKET_NAME);
 

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/LegalHoldTest_testDeserialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/LegalHoldTest_testDeserialization.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2022 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<LegalHold xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Status>ON</Status>
+</LegalHold>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ObjectLockConfigurationTest_testDeserialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ObjectLockConfigurationTest_testDeserialization.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2022 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<ObjectLockConfiguration>
+  <Rule>
+    <DefaultRetention>
+      <Mode>COMPLIANCE</Mode>
+      <Years>1</Years>
+    </DefaultRetention>
+  </Rule>
+</ObjectLockConfiguration>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ObjectLockConfigurationTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ObjectLockConfigurationTest_testSerialization.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2022 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<ObjectLockConfiguration>
+  <ObjectLockEnabled>Enabled</ObjectLockEnabled>
+  <Rule>
+    <DefaultRetention>
+      <Days>1</Days>
+      <Mode>COMPLIANCE</Mode>
+    </DefaultRetention>
+  </Rule>
+</ObjectLockConfiguration>


### PR DESCRIPTION
## Description
* Implement GetObjectLegalHold / PutObjectLegalHold
* Implement GetObjectLockConfiguration / PutObjectLockConfiguration
* In S3, object locking can only be activated for versioned buckets, versions are currently not supported by S3Mock.
  S3 enforces LegalHold only for versions, so S3Mock currently can't enforce the legal hold.
* Added support for IntegrationTests to use a dedicated bucket per test method
    * Refactored some ITs to this pattern.

## Related Issue
Fixes #157

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
