### PR TITLE
ETags in requests and responses must comply to RFC-2616

### DIFF
--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResult.java
@@ -18,6 +18,7 @@ package com.adobe.testing.s3mock.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
@@ -38,6 +39,7 @@ public class CompleteMultipartUploadResult {
 
   @JsonProperty("ETag")
   @JsonSerialize(using = EtagSerializer.class)
+  @JsonDeserialize(using = EtagDeserializer.class)
   private final String etag;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CopyObjectResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CopyObjectResult.java
@@ -18,6 +18,7 @@ package com.adobe.testing.s3mock.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
@@ -31,6 +32,7 @@ public class CopyObjectResult {
 
   @JsonProperty("ETag")
   @JsonSerialize(using = EtagSerializer.class)
+  @JsonDeserialize(using = EtagDeserializer.class)
   private String etag;
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/CopyPartResult.java
@@ -19,6 +19,7 @@ package com.adobe.testing.s3mock.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Date;
 
@@ -34,6 +35,7 @@ public class CopyPartResult {
 
   @JsonProperty("ETag")
   @JsonSerialize(using = EtagSerializer.class)
+  @JsonDeserialize(using = EtagDeserializer.class)
   private final String etag;
 
   public CopyPartResult(final Date lastModified, final String etag) {

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/S3Object.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/S3Object.java
@@ -19,6 +19,8 @@ package com.adobe.testing.s3mock.dto;
 import com.adobe.testing.s3mock.store.S3ObjectMetadata;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Class representing an Object on S3.
@@ -34,6 +36,8 @@ public class S3Object {
   private String lastModified;
 
   @JsonProperty("ETag")
+  @JsonSerialize(using = EtagSerializer.class)
+  @JsonDeserialize(using = EtagDeserializer.class)
   private String etag;
 
   @JsonProperty("Size")

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultTest_testSerialization.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2021 Adobe.
+     Copyright 2017-2022 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
   <Contents>
     <Key>key0</Key>
     <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
     <Size>434234</Size>
     <StorageClass>STANDARD</StorageClass>
     <Owner>
@@ -38,7 +38,7 @@
   <Contents>
     <Key>key1</Key>
     <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
     <Size>434234</Size>
     <StorageClass>STANDARD</StorageClass>
     <Owner>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultV2Test_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/ListBucketResultV2Test_testSerialization.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2021 Adobe.
+     Copyright 2017-2022 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
   <Contents>
     <Key>key0</Key>
     <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
     <Size>434234</Size>
     <StorageClass>STANDARD</StorageClass>
     <Owner>
@@ -35,7 +35,7 @@
   <Contents>
     <Key>key1</Key>
     <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-    <ETag>fba9dede5f27731c9771645a39863328</ETag>
+    <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
     <Size>434234</Size>
     <StorageClass>STANDARD</StorageClass>
     <Owner>


### PR DESCRIPTION
## Description
Whenever S3Mock uses Serialization / Deserialization with Jackson, we must use our custom EtagSerializer / EtagDeserializer that wraps and unwraps the etag for the DTO.

## Related Issue
Fixes #801

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
