### PR TITLE
Add Get- / Put- ObjectAcl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 ### Planned changes
 
 * Features and fixes
-  * Support for ACL APIs
   * Support for BucketLifecycleConfiguration APIs
   * Support for GetObjectAttributes API
   * Support for Presigned URIs
@@ -73,6 +72,16 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
   * TBD
 * Version updates
   * TBD
+
+## 2.7.0
+2.x will support JDK8 LTS until LTS support is cancelled, with Docker and JUnit integrations as-is.
+
+* Features and fixes
+  * Add support for ACL APIs (fixes #213 / #290)
+    * Implement GetObjectACL / PutObjectACL
+    * Return / accept String instead of a POJO. We need to use JAX-B annotations instead of Jackson annotations
+      because AWS decided to use xsi:type annotations in the XML representation, which are not supported
+      by Jackson. It doesn't seem to be possible to use bot JAX-B and Jackson for (de-)serialization in parallel.
 
 ## 2.6.3
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
     * Return / accept String instead of a POJO. We need to use JAX-B annotations instead of Jackson annotations
       because AWS decided to use xsi:type annotations in the XML representation, which are not supported
       by Jackson. It doesn't seem to be possible to use bot JAX-B and Jackson for (de-)serialization in parallel.
+* Version updates
+  * Bump aws-java-sdk-s3 from 1.12.298 to 1.12.309
+  * Bump aws-v2.version from 2.17.269 to 2.17.281
+  * Bump spring-boot.version from 2.7.3 to 2.7.4
+  * Bump maven-jar-plugin from 3.2.2 to 3.3.0
 
 ## 2.6.3
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The following [actions are supported by Amazon S3](https://docs.aws.amazon.com/A
 | [GetBucketVersioning](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html)                                                 | :x:                |
 | [GetBucketWebsite](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketWebsite.html)                                                       | :x:                |
 | [GetObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html)                                                                     | :white_check_mark: |
-| [GetObjectAcl](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html)                                                               | :x:                |
+| [GetObjectAcl](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html)                                                               | :white_check_mark: |
 | [GetObjectAttributes](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAttributes.html)                                                 | :x:                |
 | [GetObjectLegalHold](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLegalHold.html)                                                   | :white_check_mark: |
 | [GetObjectLockConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLockConfiguration.html)                                   | :white_check_mark: |
@@ -136,7 +136,7 @@ The following [actions are supported by Amazon S3](https://docs.aws.amazon.com/A
 | [PutBucketVersioning](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html)                                                 | :x:                |
 | [PutBucketWebsite](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html)                                                       | :x:                |
 | [PutObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)                                                                     | :white_check_mark: |
-| [PutObjectAcl](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html)                                                               | :x:                |
+| [PutObjectAcl](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html)                                                               | :white_check_mark: |
 | [PutObjectLegalHold](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html)                                                   | :white_check_mark: |
 | [PutObjectLockConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLockConfiguration.html)                                   | :white_check_mark: |
 | [PutObjectRetention](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html)                                                   | :white_check_mark: |

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-build-config</artifactId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-docker</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-integration-tests</artifactId>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
@@ -1,0 +1,138 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its
+
+import com.adobe.testing.s3mock.dto.Owner.DEFAULT_OWNER
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.AccessControlPolicy
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.GetObjectAclRequest
+import software.amazon.awssdk.services.s3.model.Grant
+import software.amazon.awssdk.services.s3.model.Grantee
+import software.amazon.awssdk.services.s3.model.Owner
+import software.amazon.awssdk.services.s3.model.Permission.FULL_CONTROL
+import software.amazon.awssdk.services.s3.model.PutObjectAclRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.Type.CANONICAL_USER
+import java.io.File
+
+internal class AclIT : S3TestBase() {
+
+  @Test
+  fun testGetAcl_noAcl(testInfo: TestInfo) {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val sourceKey = UPLOAD_FILE_NAME
+    val bucketName = bucketName(testInfo)
+    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2!!.putObject(
+      PutObjectRequest.builder().bucket(bucketName).key(sourceKey).build(),
+      RequestBody.fromFile(uploadFile)
+    )
+
+    val acl = s3ClientV2!!.getObjectAcl(
+      GetObjectAclRequest
+        .builder()
+        .bucket(bucketName)
+        .key(sourceKey)
+        .build()
+    )
+
+    val owner = acl.owner()
+    assertThat(owner.id()).isEqualTo(DEFAULT_OWNER.id)
+    assertThat(owner.displayName()).isEqualTo(DEFAULT_OWNER.displayName)
+    val grants = acl.grants()
+    assertThat(grants).hasSize(1)
+    val grant = grants[0]
+    assertThat(grant.permission()).isEqualTo(FULL_CONTROL)
+    val grantee = grant.grantee()
+    assertThat(grantee).isNotNull
+    assertThat(grantee.id()).isEqualTo(DEFAULT_OWNER.id)
+    assertThat(grantee.displayName()).isEqualTo(DEFAULT_OWNER.displayName)
+    assertThat(grantee.type()).isEqualTo(CANONICAL_USER)
+  }
+
+
+  @Test
+  fun testPutAndGetAcl(testInfo: TestInfo) {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val key = UPLOAD_FILE_NAME
+    val bucketName = bucketName(testInfo)
+    s3ClientV2!!.createBucket(
+      CreateBucketRequest
+        .builder()
+        .bucket(bucketName)
+        .objectLockEnabledForBucket(true)
+        .build()
+    )
+    s3ClientV2!!.putObject(
+      PutObjectRequest.builder().bucket(bucketName).key(key).build(),
+      RequestBody.fromFile(uploadFile)
+    )
+
+    val userId = "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2ab"
+    val userName = "John Doe"
+    val granteeId = "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2ef"
+    val granteeName = "Jane Doe"
+    val granteeEmail = "jane@doe.com"
+    s3ClientV2!!.putObjectAcl(
+      PutObjectAclRequest
+        .builder()
+        .bucket(bucketName)
+        .key(key)
+        .accessControlPolicy(
+          AccessControlPolicy
+            .builder()
+            .owner(Owner.builder().id(userId).displayName(userName).build())
+            .grants(
+              Grant.builder()
+                .permission(FULL_CONTROL)
+                .grantee(
+                  Grantee.builder().id(granteeId).displayName(granteeName)
+                    .type(CANONICAL_USER).build()
+                ).build()
+            ).build()
+        )
+        .build()
+    )
+
+    val acl = s3ClientV2!!.getObjectAcl(
+      GetObjectAclRequest
+        .builder()
+        .bucket(bucketName)
+        .key(key)
+        .build()
+    )
+    val owner = acl.owner()
+    assertThat(owner).isNotNull
+    assertThat(owner.id()).isEqualTo(userId)
+    assertThat(owner.displayName()).isEqualTo(userName)
+
+    assertThat(acl.grants()).hasSize(1)
+
+    val grant = acl.grants()[0]
+    assertThat(grant.permission()).isEqualTo(FULL_CONTROL)
+
+    val grantee = grant.grantee()
+    assertThat(grantee).isNotNull
+    assertThat(grantee.id()).isEqualTo(granteeId)
+    assertThat(grantee.displayName()).isEqualTo(granteeName)
+    assertThat(grantee.type()).isEqualTo(CANONICAL_USER)
+  }
+}

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketTestsV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketTestsV1IT.kt
@@ -50,7 +50,8 @@ internal class BucketTestsV1IT : S3TestBase() {
     assertThat(createdBucket.creationDate).isAfterOrEqualTo(creationDate)
     val bucketOwner = createdBucket.owner
     assertThat(bucketOwner.displayName).isEqualTo("s3-mock-file-store")
-    assertThat(bucketOwner.id).isEqualTo("123")
+    assertThat(bucketOwner.id)
+      .isEqualTo("79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be")
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>2.6.4-SNAPSHOT</version>
+  <version>2.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -35,7 +35,6 @@
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
@@ -74,7 +73,7 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <scope>test</scope>
+<!--      <scope>test</scope>-->
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -361,7 +361,8 @@ public class ObjectController {
       params = {
           TAGGING
       },
-      method = RequestMethod.PUT
+      method = RequestMethod.PUT,
+      consumes = APPLICATION_XML_VALUE
   )
   public ResponseEntity<String> putObjectTagging(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
@@ -416,7 +417,8 @@ public class ObjectController {
       params = {
           LEGAL_HOLD
       },
-      method = RequestMethod.PUT
+      method = RequestMethod.PUT,
+      consumes = APPLICATION_XML_VALUE
   )
   public ResponseEntity<String> putLegalHold(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
@@ -470,9 +472,10 @@ public class ObjectController {
       params = {
           RETENTION
       },
-      method = RequestMethod.PUT
+      method = RequestMethod.PUT,
+      consumes = APPLICATION_XML_VALUE
   )
-  public ResponseEntity<String> putObjectRetention(@PathVariable String bucketName,
+  public ResponseEntity<Void> putObjectRetention(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
       @RequestBody Retention body) {
     bucketService.verifyBucketExists(bucketName);
@@ -511,7 +514,7 @@ public class ObjectController {
       value = "/{bucketName:[a-z0-9.-]+}/{*key}",
       method = RequestMethod.PUT
   )
-  public ResponseEntity<String> putObject(@PathVariable String bucketName,
+  public ResponseEntity<Void> putObject(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
       @RequestHeader(value = X_AMZ_SERVER_SIDE_ENCRYPTION, required = false) String encryption,
       @RequestHeader(

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -29,8 +29,10 @@ import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_METADATA_DIRECT
 import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENCRYPTION;
 import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID;
 import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_TAGGING;
+import static com.adobe.testing.s3mock.util.AwsHttpParameters.ACL;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.DELETE;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.LEGAL_HOLD;
+import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_ACL;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_LEGAL_HOLD;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_RETENTION;
 import static com.adobe.testing.s3mock.util.AwsHttpParameters.NOT_TAGGING;
@@ -53,12 +55,14 @@ import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
 import static org.springframework.http.HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
+import com.adobe.testing.s3mock.dto.AccessControlPolicy;
 import com.adobe.testing.s3mock.dto.CopyObjectResult;
 import com.adobe.testing.s3mock.dto.CopySource;
 import com.adobe.testing.s3mock.dto.Delete;
 import com.adobe.testing.s3mock.dto.DeleteResult;
 import com.adobe.testing.s3mock.dto.LegalHold;
 import com.adobe.testing.s3mock.dto.ObjectKey;
+import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Range;
 import com.adobe.testing.s3mock.dto.Retention;
 import com.adobe.testing.s3mock.dto.Tag;
@@ -67,12 +71,15 @@ import com.adobe.testing.s3mock.service.BucketService;
 import com.adobe.testing.s3mock.service.ObjectService;
 import com.adobe.testing.s3mock.store.S3ObjectMetadata;
 import com.adobe.testing.s3mock.util.AwsHttpHeaders.MetadataDirective;
+import com.adobe.testing.s3mock.util.XmlUtil;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.xml.bind.JAXBException;
+import javax.xml.stream.XMLStreamException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.springframework.http.HttpHeaders;
@@ -210,7 +217,8 @@ public class ObjectController {
           NOT_UPLOAD_ID,
           NOT_TAGGING,
           NOT_LEGAL_HOLD,
-          NOT_RETENTION
+          NOT_RETENTION,
+          NOT_ACL
       },
       method = RequestMethod.GET,
       produces = {
@@ -245,6 +253,70 @@ public class ObjectController {
         .contentType(parseMediaType(s3ObjectMetadata.getContentType()))
         .headers(headers -> headers.setAll(createOverrideHeaders(queryParams)))
         .body(outputStream -> Files.copy(s3ObjectMetadata.getDataPath(), outputStream));
+  }
+
+  /**
+   * Adds an ACL to an object.
+   * This method accepts a String instead of the POJO. We need to use JAX-B annotations
+   * instead of Jackson annotations because AWS decided to use xsi:type annotations in the XML
+   * representation, which are not supported by Jackson.
+   * It doesn't seem to be possible to use bot JAX-B and Jackson for (de-)serialization in parallel.
+   * :-(
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html">API Reference</a>
+   *
+   * @param bucketName the Bucket in which to store the file in.
+   *
+   * @return {@link ResponseEntity} with Status Code and empty ETag.
+   */
+  @RequestMapping(
+      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      params = {
+          ACL,
+      },
+      method = RequestMethod.PUT,
+      consumes = APPLICATION_XML_VALUE
+  )
+  public ResponseEntity<Void> putObjectAcl(@PathVariable final String bucketName,
+      @PathVariable ObjectKey key,
+      @RequestBody String body) throws XMLStreamException, JAXBException {
+    bucketService.verifyBucketExists(bucketName);
+    objectService.verifyObjectExists(bucketName, key.getKey());
+    AccessControlPolicy policy = XmlUtil.deserializeJaxb(body);
+    objectService.setAcl(bucketName, key.getKey(), policy);
+    return ResponseEntity
+        .ok()
+        .build();
+  }
+
+  /**
+   * Gets ACL of an object.
+   * This method returns a String instead of the POJO. We need to use JAX-B annotations
+   * instead of Jackson annotations because AWS decided to use xsi:type annotations in the XML
+   * representation, which are not supported by Jackson.
+   * It doesn't seem to be possible to use bot JAX-B and Jackson for (de-)serialization in parallel.
+   * :-(
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">API Reference</a>
+   *
+   * @param bucketName the Bucket in which to store the file in.
+   *
+   * @return {@link ResponseEntity} with Status Code and empty ETag.
+   */
+  @RequestMapping(
+      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      params = {
+          ACL,
+      },
+      method = RequestMethod.GET,
+      produces = {
+          APPLICATION_XML_VALUE
+      }
+  )
+  public ResponseEntity<String> getObjectAcl(@PathVariable final String bucketName,
+      @PathVariable ObjectKey key) throws JAXBException {
+    bucketService.verifyBucketExists(bucketName);
+    objectService.verifyObjectExists(bucketName, key.getKey());
+    AccessControlPolicy acl = objectService.getAcl(bucketName, key.getKey());
+    return ResponseEntity.ok(XmlUtil.serializeJaxb(acl));
   }
 
   /**
@@ -430,7 +502,8 @@ public class ObjectController {
           NOT_UPLOAD_ID,
           NOT_TAGGING,
           NOT_LEGAL_HOLD,
-          NOT_RETENTION
+          NOT_RETENTION,
+          NOT_ACL
       },
       headers = {
           NOT_X_AMZ_COPY_SOURCE
@@ -454,6 +527,8 @@ public class ObjectController {
     bucketService.verifyBucketExists(bucketName);
 
     InputStream stream = objectService.verifyMd5(inputStream, contentMd5, sha256Header);
+    //TODO: need to extract owner from headers
+    Owner owner = Owner.DEFAULT_OWNER;
     Map<String, String> userMetadata = getUserMetadata(headers);
     S3ObjectMetadata s3ObjectMetadata =
         objectService.putS3Object(bucketName,
@@ -465,7 +540,8 @@ public class ObjectController {
             userMetadata,
             encryption,
             kmsKeyId,
-            tags);
+            tags,
+            owner);
 
     return ResponseEntity
         .ok()
@@ -493,7 +569,11 @@ public class ObjectController {
           X_AMZ_COPY_SOURCE
       },
       params = {
-          NOT_UPLOAD_ID
+          NOT_UPLOAD_ID,
+          NOT_TAGGING,
+          NOT_LEGAL_HOLD,
+          NOT_RETENTION,
+          NOT_ACL
       },
       method = RequestMethod.PUT,
       produces = {

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/AccessControlPolicy.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/AccessControlPolicy.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import java.util.List;
+import java.util.Objects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AccessControlPolicy.html">API Reference</a>.
+ * This POJO uses JAX-B annotations instead of Jackson annotations because AWS decided to use
+ * xsi:type annotations in the XML representation, which are not supported by Jackson.
+ */
+@XmlRootElement(name = "AccessControlPolicy")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AccessControlPolicy {
+  @XmlElement(name = "Owner")
+  private Owner owner;
+
+  @XmlElement(name = "Grant")
+  @XmlElementWrapper(name = "AccessControlList")
+  private List<Grant> accessControlList;
+
+  public AccessControlPolicy() {
+    // Jackson needs the default constructor for deserialization.
+  }
+
+  public AccessControlPolicy(Owner owner, List<Grant> accessControlList) {
+    this.owner = owner;
+    this.accessControlList = accessControlList;
+  }
+
+  public Owner getOwner() {
+    return owner;
+  }
+
+  public void setOwner(Owner owner) {
+    this.owner = owner;
+  }
+
+  public List<Grant> getAccessControlList() {
+    return accessControlList;
+  }
+
+  public void setAccessControlList(List<Grant> accessControlList) {
+    this.accessControlList = accessControlList;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AccessControlPolicy policy = (AccessControlPolicy) o;
+    return Objects.equals(owner, policy.owner) && Objects.equals(
+        accessControlList, policy.accessControlList);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(owner, accessControlList);
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Grant.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Grant.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_Grant.html">API Reference</a>.
+ */
+@XmlRootElement(name = "Grant")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Grant {
+
+  @XmlElement(name = "Grantee")
+  private Grantee grantee;
+
+  @XmlElement(name = "Permission")
+  private Permission permission;
+
+  public Grant() {
+    // Jackson needs the default constructor for deserialization.
+  }
+
+  public Grant(Grantee grantee, Permission permission) {
+    this.grantee = grantee;
+    this.permission = permission;
+  }
+
+  public Grantee getGrantee() {
+    return grantee;
+  }
+
+  public void setGrantee(Grantee grantee) {
+    this.grantee = grantee;
+  }
+
+  public Permission getPermission() {
+    return permission;
+  }
+
+  public void setPermission(Permission permission) {
+    this.permission = permission;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Grant grant = (Grant) o;
+    return Objects.equals(grantee, grant.grantee) && permission == grant.permission;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(grantee, permission);
+  }
+
+  public enum Permission {
+    FULL_CONTROL("FULL_CONTROL"),
+    WRITE("WRITE"),
+    WRITE_ACP("WRITE_ACP"),
+    READ("READ"),
+    READ_ACP("READ_ACP");
+
+    private final String value;
+
+    @JsonCreator
+    Permission(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Grantee.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Grantee.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import java.net.URI;
+import java.util.Objects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_Grantee.html">API Reference</a>.
+ */
+@XmlRootElement(name = "Grantee")
+@XmlAccessorType(XmlAccessType.FIELD)
+public abstract class Grantee extends Owner {
+
+  @XmlElement(name = "EmailAddress")
+  private String emailAddress;
+  @XmlElement(name = "URI")
+  private URI uri;
+
+  public Grantee() {
+    // Jackson needs the default constructor for deserialization.
+  }
+
+  public Grantee(String id, String displayName, String emailAddress, URI uri) {
+    super(id, displayName);
+    this.emailAddress = emailAddress;
+    this.uri = uri;
+  }
+
+  public static Grantee from(Owner owner) {
+    return new CanonicalUser(owner.getId(), owner.getDisplayName(), null, null);
+  }
+
+  public String getEmailAddress() {
+    return emailAddress;
+  }
+
+  public void setEmailAddress(String emailAddress) {
+    this.emailAddress = emailAddress;
+  }
+
+  public URI getUri() {
+    return uri;
+  }
+
+  public void setUri(URI uri) {
+    this.uri = uri;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    Grantee grantee = (Grantee) o;
+    return Objects.equals(emailAddress, grantee.emailAddress) && Objects.equals(
+        uri, grantee.uri);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), emailAddress, uri);
+  }
+
+  @XmlType(name = "CanonicalUser")
+  public static class CanonicalUser extends Grantee {
+    public CanonicalUser() {
+    }
+
+    public CanonicalUser(String id, String displayName, String emailAddress, URI uri) {
+      super(id, displayName, emailAddress, uri);
+    }
+  }
+
+  @XmlType(name = "Group")
+  public static class Group extends Grantee {
+    public Group() {
+    }
+
+    public Group(String id, String displayName, String emailAddress, URI uri) {
+      super(id, displayName, emailAddress, uri);
+    }
+  }
+
+  @XmlType(name = "AmazonCustomerByEmail")
+  public static class AmazonCustomerByEmail extends Grantee {
+    public AmazonCustomerByEmail() {
+    }
+
+    public AmazonCustomerByEmail(String id, String displayName, String emailAddress,
+        URI uri) {
+      super(id, displayName, emailAddress, uri);
+    }
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Owner.java
@@ -17,21 +17,31 @@
 package com.adobe.testing.s3mock.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * Owner of a Bucket.
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_Owner.html">API Reference</a>
  */
+@XmlRootElement(name = "Owner")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class Owner {
 
   /**
    * Default owner in S3Mock until support for ownership is implemented.
    */
-  public static final Owner DEFAULT_OWNER = new Owner(123, "s3-mock-file-store");
+  public static final Owner DEFAULT_OWNER =
+      new Owner("79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be",
+          "s3-mock-file-store");
 
+  @XmlElement(name = "ID")
   @JsonProperty("ID")
-  private long id;
-
+  private String id;
+  @XmlElement(name = "DisplayName")
   @JsonProperty("DisplayName")
   private String displayName;
 
@@ -39,7 +49,7 @@ public class Owner {
     // Jackson needs the default constructor for deserialization.
   }
 
-  public Owner(final long id, final String displayName) {
+  public Owner(String id, String displayName) {
     this.id = id;
     this.displayName = displayName;
   }
@@ -48,15 +58,33 @@ public class Owner {
     return displayName;
   }
 
-  public long getId() {
+  public String getId() {
     return id;
   }
 
-  public void setDisplayName(final String displayName) {
+  public void setDisplayName(String displayName) {
     this.displayName = displayName;
   }
 
-  public void setId(final long id) {
+  public void setId(String id) {
     this.id = id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Owner owner = (Owner) o;
+    return Objects.equals(id, owner.id) && Objects.equals(displayName,
+        owner.displayName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, displayName);
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Retention.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Retention.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.Instant;
+import java.util.Objects;
 
 /**
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_S3Retention.html">API Reference</a>.
@@ -63,5 +64,23 @@ public class Retention {
 
   public void setRetainUntilDate(Instant retainUntilDate) {
     this.retainUntilDate = retainUntilDate;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Retention retention = (Retention) o;
+    return mode == retention.mode && Objects.equals(retainUntilDate,
+        retention.retainUntilDate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mode, retainUntilDate);
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/package-info.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/package-info.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * This set the namespace for all JAX-B serialization / deserialization POJOs in this package.
+ */
+@XmlSchema(namespace = "http://s3.amazonaws.com/doc/2006-03-01/",
+    xmlns = { @XmlNs(prefix = "", namespaceURI = "http://s3.amazonaws.com/doc/2006-03-01/") },
+    elementFormDefault = XmlNsForm.QUALIFIED)
+package com.adobe.testing.s3mock.dto;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
@@ -230,7 +230,8 @@ public class MultipartStore {
             encryption,
             kmsKeyId,
             etag,
-            Collections.emptyList() //TODO: no tags for multi part uploads?
+            Collections.emptyList(), //TODO: no tags for multi part uploads?
+            Owner.DEFAULT_OWNER
         );
         uploadIdToInfo.remove(uploadId);
         FileUtils.deleteDirectory(partFolder.toFile());

--- a/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
@@ -16,7 +16,9 @@
 
 package com.adobe.testing.s3mock.store;
 
+import com.adobe.testing.s3mock.dto.AccessControlPolicy;
 import com.adobe.testing.s3mock.dto.LegalHold;
+import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Retention;
 import com.adobe.testing.s3mock.dto.Tag;
 import java.nio.file.Path;
@@ -66,6 +68,16 @@ public class S3ObjectMetadata {
   private LegalHold legalHold;
 
   private Retention retention;
+
+  private Owner owner;
+
+  public Owner getOwner() {
+    return owner;
+  }
+
+  public void setOwner(Owner owner) {
+    this.owner = owner;
+  }
 
   public Retention getRetention() {
     return retention;

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpParameters.java
@@ -23,6 +23,8 @@ public class AwsHttpParameters {
 
   private static final String NOT = "!";
 
+  public static final String ACL = "acl";
+  public static final String NOT_ACL = NOT + ACL;
   public static final String CONTINUATION_TOKEN = "continuation-token";
   public static final String DELETE = "delete";
   public static final String ENCODING_TYPE = "encoding-type";

--- a/server/src/main/java/com/adobe/testing/s3mock/util/XmlUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/XmlUtil.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.util;
+
+import com.adobe.testing.s3mock.dto.AccessControlPolicy;
+import com.adobe.testing.s3mock.dto.Grantee;
+import java.io.StringReader;
+import java.io.StringWriter;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+/**
+ * Utility class with helper methods to serialize / deserialize JAXB annotated classes.
+ */
+public class XmlUtil {
+
+  public static AccessControlPolicy deserializeJaxb(String toDeserialize)
+      throws JAXBException, XMLStreamException {
+    return deserializeJaxb(AccessControlPolicy.class, toDeserialize,
+        AccessControlPolicy.class,
+        Grantee.CanonicalUser.class,
+        Grantee.Group.class,
+        Grantee.AmazonCustomerByEmail.class);
+  }
+
+  public static <T> T deserializeJaxb(Class<T> clazz, String toDeserialize,
+      Class<?>... additionalTypes)
+      throws JAXBException, XMLStreamException {
+
+    XMLStreamReader reader = XMLInputFactory.newInstance()
+        .createXMLStreamReader(new StringReader(toDeserialize));
+    JAXBContext jaxbContext = JAXBContext.newInstance(additionalTypes);
+    Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+    return jaxbUnmarshaller.unmarshal(reader, clazz).getValue();
+  }
+
+  public static String serializeJaxb(AccessControlPolicy toSerialize)
+      throws JAXBException {
+    return serializeJaxb(toSerialize, AccessControlPolicy.class,
+        Grantee.CanonicalUser.class,
+        Grantee.Group.class,
+        Grantee.AmazonCustomerByEmail.class);
+  }
+
+  public static String serializeJaxb(Object toSerialize, Class<?>... additionalTypes)
+      throws JAXBException {
+    JAXBContext jaxbContext = JAXBContext.newInstance(additionalTypes);
+    Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+
+    StringWriter writer = new StringWriter();
+    jaxbMarshaller.marshal(toSerialize, writer);
+
+    return writer.toString();
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/BucketControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/BucketControllerTest.java
@@ -76,7 +76,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @SpringBootTest(classes = {S3MockConfiguration.class})
 class BucketControllerTest {
 
-  private static final Owner TEST_OWNER = new Owner(123, "s3-mock-file-store");
+  private static final Owner TEST_OWNER = new Owner("123", "s3-mock-file-store");
   private static final ObjectMapper MAPPER = new XmlMapper();
   private static final String TEST_BUCKET_NAME = "test-bucket";
   private static final Bucket TEST_BUCKET =

--- a/server/src/test/java/com/adobe/testing/s3mock/ContextPathObjectStoreControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/ContextPathObjectStoreControllerTest.java
@@ -52,7 +52,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @SpringBootTest(classes = {S3MockConfiguration.class},
     properties = {"com.adobe.testing.s3mock.contextPath=s3-mock"})
 class ContextPathObjectStoreControllerTest {
-  private static final Owner TEST_OWNER = new Owner(123, "s3-mock-file-store");
+  private static final Owner TEST_OWNER = new Owner("123", "s3-mock-file-store");
   private static final ObjectMapper MAPPER = new XmlMapper();
 
   private static final String TEST_BUCKET_NAME = "testBucket";

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/AccessControlPolicyTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/AccessControlPolicyTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.dto;
+
+import static com.adobe.testing.s3mock.dto.DtoTestUtil.getExpected;
+import static com.adobe.testing.s3mock.dto.DtoTestUtil.getFile;
+import static com.adobe.testing.s3mock.dto.Grant.Permission.FULL_CONTROL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.adobe.testing.s3mock.util.XmlUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import javax.xml.bind.JAXBException;
+import javax.xml.stream.XMLStreamException;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.xmlunit.assertj3.XmlAssert;
+
+public class AccessControlPolicyTest {
+  @Test
+  void testDeserialization(TestInfo testInfo) throws IOException, XMLStreamException,
+      JAXBException {
+    File expected = getFile(testInfo);
+    String contents = FileUtils.readFileToString(expected, StandardCharsets.UTF_8);
+    AccessControlPolicy iut = XmlUtil.deserializeJaxb(contents);
+
+    Owner owner = iut.getOwner();
+    assertThat(owner).isNotNull();
+    assertThat(owner.getId()).isEqualTo(
+        "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a");
+    assertThat(owner.getDisplayName()).isEqualTo("mtd@amazon.com");
+    assertThat(iut.getAccessControlList()).hasSize(1);
+    Grant grant = iut.getAccessControlList().get(0);
+    assertThat(grant.getPermission()).isEqualTo(FULL_CONTROL);
+    assertThat(grant.getGrantee()).isNotNull();
+    assertThat(grant.getGrantee().getId()).isEqualTo(
+        "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a");
+    assertThat(grant.getGrantee().getDisplayName()).isEqualTo("mtd@amazon.com");
+    assertThat(grant.getGrantee()).isInstanceOf(Grantee.CanonicalUser.class);
+  }
+
+  @Test
+  void testSerialization(TestInfo testInfo) throws IOException, JAXBException {
+    Owner owner = new Owner("75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a",
+        "mtd@amazon.com");
+    Grantee grantee = Grantee.from(owner);
+    AccessControlPolicy iut = new AccessControlPolicy(owner,
+        Collections.singletonList(new Grant(grantee, FULL_CONTROL))
+    );
+    String out = XmlUtil.serializeJaxb(iut);
+    assertThat(out).isNotNull();
+    String expected = getExpected(testInfo);
+    XmlAssert.assertThat(out).and(expected)
+        .ignoreChildNodesOrder()
+        .ignoreWhitespace()
+        .ignoreComments()
+        .areIdentical();
+  }
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/DtoTestUtil.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/DtoTestUtil.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -79,12 +78,12 @@ class DtoTestUtil {
   /**
    * Reads the test file and returns its contents.
    */
-  private static String getExpected(TestInfo testInfo) throws IOException {
+  static String getExpected(TestInfo testInfo) throws IOException {
     File file = getFile(testInfo);
     return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
   }
 
-  private static File getFile(TestInfo testInfo) {
+  static File getFile(TestInfo testInfo) {
     Class<?> testClass = testInfo.getTestClass().get();
     String packageName = testClass.getPackage().getName();
     String className = testClass.getSimpleName();

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListAllMyBucketsResultTest.java
@@ -30,7 +30,9 @@ class ListAllMyBucketsResultTest {
   @Test
   void testSerialization(TestInfo testInfo) throws IOException {
     ListAllMyBucketsResult iut =
-        new ListAllMyBucketsResult(new Owner(10L, "displayName"), createBuckets(2));
+        new ListAllMyBucketsResult(
+            new Owner(String.valueOf(10L), "displayName"), createBuckets(2)
+        );
 
     serializeAndAssert(iut, testInfo);
   }

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultTest.java
@@ -42,7 +42,7 @@ class ListBucketResultTest {
       S3Object s3Object =
           new S3Object("key" + i, "2009-10-12T17:50:30.000Z",
               "\"fba9dede5f27731c9771645a39863328\"", "434234", StorageClass.STANDARD,
-              new Owner(10L + i, "displayName"));
+              new Owner(String.valueOf(10L + i), "displayName"));
       s3ObjectList.add(s3Object);
     }
     return s3ObjectList;

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultV2Test.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListBucketResultV2Test.java
@@ -43,7 +43,7 @@ class ListBucketResultV2Test {
       S3Object s3Object =
           new S3Object("key" + i, "2009-10-12T17:50:30.000Z",
               "\"fba9dede5f27731c9771645a39863328\"", "434234", StorageClass.STANDARD,
-              new Owner(10L + i, "displayName"));
+              new Owner(String.valueOf(10L + i), "displayName"));
       s3ObjectList.add(s3Object);
     }
     return s3ObjectList;

--- a/server/src/test/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResultTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/dto/ListMultipartUploadsResultTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2021 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -43,8 +43,8 @@ class ListMultipartUploadsResultTest {
     for (int i = 0; i < count; i++) {
       MultipartUpload multipartUpload =
           new MultipartUpload("key" + i, "uploadId" + i,
-              new Owner(10L + i, "displayName10" + i),
-              new Owner(100L + i, "displayName100" + i),
+              new Owner(String.valueOf(10L + i), "displayName10" + i),
+              new Owner(String.valueOf(100L + i), "displayName100" + i),
               new Date(1514477008120L));
       multipartUploads.add(multipartUpload);
     }

--- a/server/src/test/java/com/adobe/testing/s3mock/service/ServiceTestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/service/ServiceTestBase.java
@@ -105,7 +105,7 @@ abstract class ServiceTestBase {
     String lastModified = "lastModified";
     String etag = "etag";
     String size = "size";
-    Owner owner = new Owner(0L, "name");
+    Owner owner = new Owner(String.valueOf(0L), "name");
     return new S3Object(key, lastModified, etag, size, StorageClass.STANDARD, owner);
   }
 

--- a/server/src/test/java/com/adobe/testing/s3mock/store/MultipartStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/MultipartStoreTest.java
@@ -70,7 +70,7 @@ class MultipartStoreTest {
   private static final Map<String, String> NO_USER_METADATA = emptyMap();
   private static final String DEFAULT_CONTENT_TYPE =
       ContentType.APPLICATION_OCTET_STREAM.toString();
-  private static final Owner TEST_OWNER = new Owner(123, "s3-mock-file-store");
+  private static final Owner TEST_OWNER = new Owner("123", "s3-mock-file-store");
   private static final String TEXT_PLAIN = ContentType.TEXT_PLAIN.toString();
   private static final String ENCODING_GZIP = "gzip";
   private static final List<UUID> idCache = Collections.synchronizedList(new ArrayList<>());
@@ -385,7 +385,7 @@ class MultipartStoreTest {
     final byte[] contentBytes = UUID.randomUUID().toString().getBytes();
     objectStore.storeS3ObjectMetadata(metadataFrom(TEST_BUCKET_NAME), sourceId, sourceFile,
         DEFAULT_CONTENT_TYPE, ENCODING_GZIP, new ByteArrayInputStream(contentBytes), false,
-        NO_USER_METADATA, NO_ENC, NO_ENC_KEY, null, emptyList());
+        NO_USER_METADATA, NO_ENC, NO_ENC_KEY, null, emptyList(), Owner.DEFAULT_OWNER);
 
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), targetFile, destinationId,
         DEFAULT_CONTENT_TYPE, ENCODING_GZIP, uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
@@ -414,7 +414,7 @@ class MultipartStoreTest {
     BucketMetadata bucketMetadata = metadataFrom(TEST_BUCKET_NAME);
     objectStore.storeS3ObjectMetadata(bucketMetadata, sourceId, sourceFile, DEFAULT_CONTENT_TYPE,
         ENCODING_GZIP, new ByteArrayInputStream(contentBytes), false,
-        NO_USER_METADATA, NO_ENC, NO_ENC_KEY, null, emptyList());
+        NO_USER_METADATA, NO_ENC, NO_ENC_KEY, null, emptyList(), Owner.DEFAULT_OWNER);
 
     multipartStore.prepareMultipartUpload(bucketMetadata, targetFile, destinationId,
         DEFAULT_CONTENT_TYPE, ENCODING_GZIP, uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/AccessControlPolicyTest_testDeserialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/AccessControlPolicyTest_testDeserialization.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2022 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Owner>
+    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+    <DisplayName>mtd@amazon.com</DisplayName>
+  </Owner>
+  <AccessControlList>
+    <Grant>
+      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+        <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+        <DisplayName>mtd@amazon.com</DisplayName>
+      </Grantee>
+      <Permission>FULL_CONTROL</Permission>
+    </Grant>
+  </AccessControlList>
+</AccessControlPolicy>

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/AccessControlPolicyTest_testSerialization.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/AccessControlPolicyTest_testSerialization.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017-2022 Adobe.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Owner>
+    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+    <DisplayName>mtd@amazon.com</DisplayName>
+  </Owner>
+  <AccessControlList>
+    <Grant>
+      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+        <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+        <DisplayName>mtd@amazon.com</DisplayName>
+      </Grantee>
+      <Permission>FULL_CONTROL</Permission>
+    </Grant>
+  </AccessControlList>
+</AccessControlPolicy>

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-common</artifactId>

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit4</artifactId>

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit5</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testcontainers/pom.xml
+++ b/testsupport/testcontainers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testcontainers</artifactId>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.6.4-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testng</artifactId>


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
* Features and fixes
  * Add support for ACL APIs (fixes #213 / #290)
    * Implement GetObjectACL / PutObjectACL
    * Return / accept String instead of a POJO. We need to use JAX-B annotations instead of Jackson annotations
      because AWS decided to use xsi:type annotations in the XML representation, which are not supported
      by Jackson. It doesn't seem to be possible to use bot JAX-B and Jackson for (de-)serialization in parallel.

## Related Issue
<!--- if applicable -->
fixes #213 
fixes #290

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
