### PR TITLE
LastModified must be updated when copying an object onto itself.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
-  * TBD
+  * LastModified must be updated when copying an object onto itself (fixes #811)
 * Refactorings
   * Split up integration tests by type
 * Version updates

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -63,6 +63,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <scope>test</scope>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV1IT.kt
@@ -45,9 +45,8 @@ internal class CopyObjectV1IT : S3TestBase() {
   fun shouldCopyObject(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObjectV1(testInfo, sourceKey)
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf/$sourceKey"
-    s3Client!!.createBucket(destinationBucketName)
     val copyObjectRequest =
       CopyObjectRequest(bucketName, sourceKey, destinationBucketName, destinationKey)
     s3Client!!.copyObject(copyObjectRequest)
@@ -73,6 +72,9 @@ internal class CopyObjectV1IT : S3TestBase() {
     val putObjectRequest =
       PutObjectRequest(bucketName, sourceKey, uploadFile).withMetadata(objectMetadata)
     val putObjectResult = s3Client!!.putObject(putObjectRequest)
+    //TODO: this is actually illegal on S3. when copying to the same key like this, S3 will throw:
+    // This copy request is illegal because it is trying to copy an object to itself without
+    // changing the object's metadata, storage class, website redirect location or encryption attributes.
     val copyObjectRequest = CopyObjectRequest(bucketName, sourceKey, bucketName, sourceKey)
 
     s3Client!!.copyObject(copyObjectRequest)
@@ -146,9 +148,8 @@ internal class CopyObjectV1IT : S3TestBase() {
   fun shouldCopyObjectWithNewUserMetadata(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObjectV1(testInfo, sourceKey)
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf/$sourceKey/withNewUserMetadata"
-    s3Client!!.createBucket(destinationBucketName)
     val objectMetadata = ObjectMetadata()
     objectMetadata.addUserMetadata("key", "value")
     val copyObjectRequest =
@@ -177,9 +178,8 @@ internal class CopyObjectV1IT : S3TestBase() {
     val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf/$sourceKey/withSourceObjectUserMetadata"
-    s3Client!!.createBucket(destinationBucketName)
     val sourceObjectMetadata = ObjectMetadata()
     sourceObjectMetadata.addUserMetadata("key", "value")
     val putObjectRequest = PutObjectRequest(bucketName, sourceKey, uploadFile)
@@ -209,9 +209,8 @@ internal class CopyObjectV1IT : S3TestBase() {
     val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf/some escape-worthy characters %$@ $sourceKey"
-    s3Client!!.createBucket(destinationBucketName)
     val putObjectResult = s3Client!!.putObject(PutObjectRequest(bucketName, sourceKey, uploadFile))
     val copyObjectRequest =
       CopyObjectRequest(bucketName, sourceKey, destinationBucketName, destinationKey)
@@ -234,9 +233,8 @@ internal class CopyObjectV1IT : S3TestBase() {
     val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = "some escape-worthy characters %$@ $UPLOAD_FILE_NAME"
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf/$sourceKey"
-    s3Client!!.createBucket(destinationBucketName)
     val putObjectResult = s3Client!!.putObject(PutObjectRequest(bucketName, sourceKey, uploadFile))
     val copyObjectRequest =
       CopyObjectRequest(bucketName, sourceKey, destinationBucketName, destinationKey)
@@ -260,9 +258,8 @@ internal class CopyObjectV1IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     s3Client!!.putObject(PutObjectRequest(bucketName, sourceKey, uploadFile))
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf/$sourceKey"
-    s3Client!!.createBucket(destinationBucketName)
     val copyObjectRequest =
       CopyObjectRequest(bucketName, sourceKey, destinationBucketName, destinationKey)
     copyObjectRequest.sseAwsKeyManagementParams = SSEAwsKeyManagementParams(TEST_ENC_KEY_ID)
@@ -285,9 +282,8 @@ internal class CopyObjectV1IT : S3TestBase() {
   fun shouldNotObjectCopyWithWrongEncryptionKey(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObjectV1(testInfo, sourceKey)
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf$sourceKey"
-    s3Client!!.createBucket(destinationBucketName)
     val copyObjectRequest =
       CopyObjectRequest(bucketName, sourceKey, destinationBucketName, destinationKey)
     copyObjectRequest.sseAwsKeyManagementParams = SSEAwsKeyManagementParams(TEST_WRONG_KEY_ID)
@@ -303,9 +299,8 @@ internal class CopyObjectV1IT : S3TestBase() {
   fun shouldThrowNoSuchKeyOnCopyForNonExistingKey(testInfo: TestInfo) {
     val bucketName = givenBucketV1(testInfo)
     val sourceKey = randomName
-    val destinationBucketName = randomName
+    val destinationBucketName = givenRandomBucketV1()
     val destinationKey = "copyOf$sourceKey"
-    s3Client!!.createBucket(destinationBucketName)
     val copyObjectRequest =
       CopyObjectRequest(bucketName, sourceKey, destinationBucketName, destinationKey)
     Assertions.assertThatThrownBy { s3Client!!.copyObject(copyObjectRequest) }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its
+
+import com.adobe.testing.s3mock.util.DigestUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.MetadataDirective
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.io.File
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit.SECONDS
+
+/**
+ * Test the application using the AmazonS3 SDK V2.
+ */
+internal class CopyObjectV2IT : S3TestBase() {
+
+  @Test
+  fun testCopyObject(testInfo: TestInfo) {
+    val sourceKey = UPLOAD_FILE_NAME
+    val (bucketName, putObjectResult) = givenBucketAndObjectV2(testInfo, sourceKey)
+    val destinationBucketName = givenRandomBucketV2()
+    val destinationKey = "copyOf/$sourceKey"
+
+    s3ClientV2!!.copyObject(CopyObjectRequest
+      .builder()
+      .sourceBucket(bucketName)
+      .sourceKey(sourceKey)
+      .destinationBucket(destinationBucketName)
+      .destinationKey(destinationKey)
+      .build())
+
+    val copiedObject = s3ClientV2!!.getObject(GetObjectRequest
+      .builder()
+      .bucket(destinationBucketName)
+      .key(destinationKey)
+      .build()
+    )
+    val copiedDigest = DigestUtil.hexDigest(copiedObject)
+    copiedObject.close()
+    assertThat("\"$copiedDigest\"")
+      .`as`("Source file and copied File should have same digests")
+      .isEqualTo(putObjectResult.eTag())
+  }
+
+  @Test
+  fun testCopyObjectToSameBucketAndKey(testInfo: TestInfo) {
+    val bucketName = givenBucketV2(testInfo)
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val sourceKey = UPLOAD_FILE_NAME
+    val putObjectResult = s3ClientV2!!.putObject(PutObjectRequest
+      .builder()
+      .bucket(bucketName)
+      .key(sourceKey)
+      .metadata(mapOf("test-key" to "test-value"))
+      .build(),
+      RequestBody.fromFile(uploadFile)
+    )
+    val headObject = s3ClientV2!!.headObject(
+      HeadObjectRequest
+        .builder()
+        .bucket(bucketName)
+        .key(sourceKey)
+        .build()
+    )
+
+    val sourceLastModified = headObject.lastModified()
+
+    await("wait until source object is 5 seconds old").until {
+      sourceLastModified.plusSeconds(5).isBefore(Instant.now())
+    }
+
+    s3ClientV2!!.copyObject(
+      CopyObjectRequest
+        .builder()
+        .sourceBucket(bucketName)
+        .sourceKey(sourceKey)
+        .destinationBucket(bucketName)
+        .destinationKey(sourceKey)
+        .metadata(mapOf("test-key2" to "test-value2"))
+        .metadataDirective(MetadataDirective.REPLACE)
+        .build()
+    )
+
+    val responseInputStream =
+      s3ClientV2!!.getObject(GetObjectRequest
+        .builder()
+        .bucket(bucketName)
+        .key(sourceKey)
+        .build()
+      )
+
+    val response = responseInputStream.response()
+    val copiedObjectMetadata = response.metadata()
+    assertThat(copiedObjectMetadata["test-key2"]).isEqualTo("test-value2")
+    assertThat(copiedObjectMetadata["test-key"]).isNull()
+
+    val length = response.contentLength()
+    assertThat(length).isEqualTo(uploadFile.length())
+      .`as`("Copied item must be same length as uploaded file")
+
+    val copiedDigest = DigestUtil.hexDigest(responseInputStream)
+    assertThat("\"$copiedDigest\"")
+      .`as`("Source file and copied File should have same digests")
+      .isEqualTo(putObjectResult.eTag())
+
+    //we waited for 5 seconds above, so last modified dates should be about 5 seconds apart
+    val between = Duration.between(sourceLastModified, response.lastModified())
+    assertThat(between).isCloseTo(Duration.of(5, SECONDS), Duration.of(1, SECONDS))
+  }
+
+  @Test
+  fun testCopyObjectWithNewMetadata(testInfo: TestInfo) {
+    val sourceKey = UPLOAD_FILE_NAME
+    val (bucketName, putObjectResult) = givenBucketAndObjectV2(testInfo, sourceKey)
+    val destinationBucketName = givenRandomBucketV2()
+    val destinationKey = "copyOf/$sourceKey/withNewUserMetadata"
+
+    val metadata = mapOf("test-key2" to "test-value2")
+    s3ClientV2!!.copyObject(
+      CopyObjectRequest
+        .builder()
+        .sourceBucket(bucketName)
+        .sourceKey(sourceKey)
+        .destinationBucket(destinationBucketName)
+        .destinationKey(destinationKey)
+        .metadata(metadata)
+        .metadataDirective(MetadataDirective.REPLACE)
+        .build()
+    )
+
+    val responseInputStream =
+      s3ClientV2!!.getObject(GetObjectRequest
+        .builder()
+        .bucket(destinationBucketName)
+        .key(destinationKey)
+        .build()
+      )
+
+    val copiedDigest = DigestUtil.hexDigest(responseInputStream)
+    assertThat("\"$copiedDigest\"")
+      .`as`("Source file and copied File should have same digests")
+      .isEqualTo(putObjectResult.eTag())
+    assertThat(responseInputStream.response().metadata())
+      .`as`("User metadata should be identical!")
+      .isEqualTo(metadata)
+  }
+}

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -188,7 +188,7 @@ internal abstract class S3TestBase {
     return givenBucketV2(bucketName)
   }
 
-  private fun givenBucketV2(bucketName: String): String {
+  fun givenBucketV2(bucketName: String): String {
     s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
     return bucketName
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -509,6 +509,11 @@ public class ObjectController {
       metadata = getUserMetadata(httpHeaders);
     }
 
+    //TODO: this is potentially illegal on S3. S3 throws a 400:
+    // "This copy request is illegal because it is trying to copy an object to itself without
+    // changing the object's metadata, storage class, website redirect location or encryption
+    // attributes."
+
     CopyObjectResult copyObjectResult = objectService.copyS3Object(copySource.getBucket(),
         copySource.getKey(),
         bucketName,

--- a/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
@@ -176,21 +176,6 @@ public class ObjectStore {
   }
 
   /**
-   * Sets user metadata for a given object.
-   *
-   * @param bucket Bucket where the object is stored in.
-   * @param id object ID to store metadata for.
-   * @param metadata Map of metadata.
-   */
-  public void storeUserMetadata(BucketMetadata bucket, UUID id, Map<String, String> metadata) {
-    synchronized (lockStore.get(id)) {
-      S3ObjectMetadata s3ObjectMetadata = getS3ObjectMetadata(bucket, id);
-      s3ObjectMetadata.setUserMetadata(metadata);
-      writeMetafile(bucket, s3ObjectMetadata);
-    }
-  }
-
-  /**
    * Retrieves S3ObjectMetadata for a UUID of a key from a bucket.
    *
    * @param bucket Bucket from which to retrieve the object.
@@ -279,11 +264,10 @@ public class ObjectStore {
       return null;
     }
 
-    // overwrite metadata if necessary.
-    storeUserMetadata(sourceBucket, sourceId,
-        userMetadata == null || userMetadata.isEmpty()
-            ? sourceObject.getUserMetadata() : userMetadata);
-
+    sourceObject.setLastModified(Instant.now().toEpochMilli());
+    sourceObject.setUserMetadata(userMetadata == null || userMetadata.isEmpty()
+        ? sourceObject.getUserMetadata() : userMetadata);
+    writeMetafile(sourceBucket, sourceObject);
     return new CopyObjectResult(sourceObject.getModificationDate(), sourceObject.getEtag());
   }
 


### PR DESCRIPTION
## Description
2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

* Features and fixes
  * LastModified must be updated when copying an object onto itself (fixes #811)
* Refactorings
  * Split up integration tests by type

## Related Issue
Fixes #811

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
