### PR TITLE
Support restarting S3Mock on existing root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
+## 2.8.1 - PLANNED
+* Features and fixes
+  * Support restarting S3Mock with the `retainFilesOnExit` option enabled. (fixes #818) 
+* Refactorings
+  * TBD
+
 ## 2.8.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
-## 2.12.0 - PLANNED
+## 2.13.0 - PLANNED
 * Features and fixes
   * Support for Bucket subdomains
     * This one may be impossible to do in a minor version update, as all paths would need to match
@@ -85,7 +85,7 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
-## 2.11.0 - PLANNED
+## 2.12.0 - PLANNED
 * Features and fixes
   * Support for Version APIs
 * Refactorings
@@ -93,7 +93,7 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
-## 2.10.0 - PLANNED
+## 2.11.0 - PLANNED
 * Features and fixes
   * Support for Presigned URIs
 * Refactorings
@@ -101,7 +101,7 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
-## 2.9.0 - PLANNED
+## 2.10.0 - PLANNED
 * Features and fixes
   * Support for GetObjectAttributes API
     * Started draft PR: [#832](https://github.com/adobe/S3Mock/pull/832/)
@@ -110,11 +110,11 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
-## 2.8.1 - PLANNED
+## 2.9.0
+2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
 * Features and fixes
   * Support restarting S3Mock with the `retainFilesOnExit` option enabled. (fixes #818) 
-* Refactorings
-  * TBD
 
 ## 2.8.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-build-config</artifactId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-docker</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-integration-tests</artifactId>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
@@ -31,7 +31,7 @@ import java.util.stream.Collectors
 /**
  * Test the application using the AmazonS3 SDK V1.
  */
-internal class BucketTestsV1IT : S3TestBase() {
+internal class BucketV1IT : S3TestBase() {
 
   @Test
   fun testCreateBucketAndListAllBuckets(testInfo: TestInfo) {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
@@ -40,7 +40,7 @@ import software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationR
 /**
  * Test the application using the AmazonS3 SDK V2.
  */
-internal class BucketTestsV2IT : S3TestBase() {
+internal class BucketV2IT : S3TestBase() {
 
   @Test
   fun createAndDeleteBucket(testInfo: TestInfo) {

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>2.8.1-SNAPSHOT</version>
+  <version>2.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockConfiguration.java
@@ -96,8 +96,7 @@ public class S3MockConfiguration implements WebMvcConfigurer {
   @Bean
   @Profile("debug")
   public CommonsRequestLoggingFilter logFilter() {
-    CommonsRequestLoggingFilter filter
-        = new CommonsRequestLoggingFilter();
+    CommonsRequestLoggingFilter filter = new CommonsRequestLoggingFilter();
     filter.setIncludeQueryString(true);
     filter.setIncludePayload(true);
     filter.setMaxPayloadLength(10000);
@@ -141,8 +140,7 @@ public class S3MockConfiguration implements WebMvcConfigurer {
   }
 
   @Bean
-  ObjectController fileStoreController(ObjectService objectService,
-      BucketService bucketService) {
+  ObjectController fileStoreController(ObjectService objectService, BucketService bucketService) {
     return new ObjectController(bucketService, objectService);
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
@@ -23,6 +23,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,22 +40,48 @@ import org.springframework.context.annotation.Configuration;
 public class StoreConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(StoreConfiguration.class);
-  private static final DateTimeFormatter S3_OBJECT_DATE_FORMAT = DateTimeFormatter
+  static final DateTimeFormatter S3_OBJECT_DATE_FORMAT = DateTimeFormatter
       .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
       .withZone(ZoneId.of("UTC"));
 
   @Bean
-  ObjectStore fileStore(StoreProperties properties,
-      ObjectMapper objectMapper) {
-    return new ObjectStore(properties.isRetainFilesOnExit(),
+  ObjectStore objectStore(StoreProperties properties, List<String> bucketNames,
+      BucketStore bucketStore, ObjectMapper objectMapper) {
+    ObjectStore objectStore = new ObjectStore(properties.isRetainFilesOnExit(),
         S3_OBJECT_DATE_FORMAT, objectMapper);
+    for (String bucketName : bucketNames) {
+      BucketMetadata bucketMetadata = bucketStore.getBucketMetadata(bucketName);
+      if (bucketMetadata != null) {
+        objectStore.loadObjects(bucketMetadata, bucketMetadata.getObjects().values());
+      }
+    }
+    return objectStore;
   }
 
   @Bean
-  BucketStore bucketStore(StoreProperties properties, File bucketRootFolder,
+  BucketStore bucketStore(StoreProperties properties, File rootFolder, List<String> bucketNames,
       ObjectMapper objectMapper) {
-    return new BucketStore(bucketRootFolder, properties.isRetainFilesOnExit(),
-        properties.getInitialBuckets(), S3_OBJECT_DATE_FORMAT, objectMapper);
+    BucketStore bucketStore = new BucketStore(rootFolder, properties.isRetainFilesOnExit(),
+        S3_OBJECT_DATE_FORMAT, objectMapper);
+    if (bucketNames.isEmpty()) {
+      properties
+          .getInitialBuckets()
+          .forEach(bucketName -> bucketStore.createBucket(bucketName, false));
+    } else {
+      bucketStore.loadBuckets(bucketNames);
+    }
+
+    return bucketStore;
+  }
+
+  @Bean
+  List<String> bucketNames(File rootFolder) {
+    File[] buckets = rootFolder.listFiles((File dir, String name) -> !Objects.equals(name, "test"));
+    if (buckets != null) {
+      return Arrays.stream(buckets).map(File::getName).collect(Collectors.toList());
+    } else {
+      return Collections.emptyList();
+    }
   }
 
   @Bean
@@ -61,11 +92,6 @@ public class StoreConfiguration {
   @Bean
   KmsKeyStore kmsKeyStore(StoreProperties properties) {
     return new KmsKeyStore(properties.getValidKmsKeys());
-  }
-
-  @Bean
-  File bucketRootFolder(File rootFolder) {
-    return rootFolder;
   }
 
   @Bean
@@ -90,6 +116,7 @@ public class StoreConfiguration {
       if (root.exists()) {
         LOG.info("Using existing folder \"{}\" as root folder. Will retain files on exit: {}",
             root.getAbsolutePath(), properties.isRetainFilesOnExit());
+        //TODO: need to validate folder structure here?
       } else if (!root.mkdir()) {
         throw new IllegalStateException("Root folder could not be created. Path: "
             + root.getAbsolutePath());

--- a/server/src/test/java/com/adobe/testing/s3mock/store/BucketStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/BucketStoreTest.java
@@ -38,16 +38,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @AutoConfigureMockMvc
 @MockBean(classes = {KmsKeyStore.class, ObjectStore.class, MultipartStore.class})
 @SpringBootTest(classes = {StoreConfiguration.class})
-class BucketStoreTest {
-
-  private static final String TEST_BUCKET_NAME = "test-bucket";
-
+class BucketStoreTest extends StoreTestBase {
   @Autowired
   private BucketStore bucketStore;
 
   @Test
   void testCreateBucket() {
-    final BucketMetadata bucket = bucketStore.createBucket(TEST_BUCKET_NAME, false);
+    BucketMetadata bucket = bucketStore.createBucket(TEST_BUCKET_NAME, false);
     assertThat(bucket.getName()).as("Bucket should have been created.").endsWith(TEST_BUCKET_NAME);
     assertThat(bucket.getPath()).exists();
   }
@@ -56,7 +53,7 @@ class BucketStoreTest {
   void testDoesBucketExist_ok() {
     bucketStore.createBucket(TEST_BUCKET_NAME, false);
 
-    final Boolean doesBucketExist = bucketStore.doesBucketExist(TEST_BUCKET_NAME);
+    Boolean doesBucketExist = bucketStore.doesBucketExist(TEST_BUCKET_NAME);
 
     assertThat(doesBucketExist).as(
             String.format("The previously created bucket, '%s', should exist!", TEST_BUCKET_NAME))
@@ -65,7 +62,7 @@ class BucketStoreTest {
 
   @Test
   void testDoesBucketExist_nonExistingBucket() {
-    final Boolean doesBucketExist = bucketStore.doesBucketExist(TEST_BUCKET_NAME);
+    Boolean doesBucketExist = bucketStore.doesBucketExist(TEST_BUCKET_NAME);
 
     assertThat(doesBucketExist).as(
         String.format("The bucket, '%s', should not exist!", TEST_BUCKET_NAME)).isFalse();
@@ -73,15 +70,15 @@ class BucketStoreTest {
 
   @Test
   void testCreateAndListBucketsWithUmlauts() {
-    final String bucketName1 = "myNüwNämeÄins";
-    final String bucketName2 = "myNüwNämeZwöei";
-    final String bucketName3 = "myNüwNämeDrü";
+    String bucketName1 = "myNüwNämeÄins";
+    String bucketName2 = "myNüwNämeZwöei";
+    String bucketName3 = "myNüwNämeDrü";
 
     bucketStore.createBucket(bucketName1, false);
     bucketStore.createBucket(bucketName2, false);
     bucketStore.createBucket(bucketName3, false);
 
-    final List<BucketMetadata> buckets = bucketStore.listBuckets();
+    List<BucketMetadata> buckets = bucketStore.listBuckets();
 
     assertThat(buckets.size()).as("FileStore should hold three Buckets").isEqualTo(3);
   }
@@ -141,7 +138,7 @@ class BucketStoreTest {
    */
   @AfterEach
   void cleanupStores() {
-    for (final BucketMetadata bucket : bucketStore.listBuckets()) {
+    for (BucketMetadata bucket : bucketStore.listBuckets()) {
       bucketStore.deleteBucket(bucket.getName());
     }
   }

--- a/server/src/test/java/com/adobe/testing/s3mock/store/MultipartStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/MultipartStoreTest.java
@@ -17,7 +17,6 @@
 package com.adobe.testing.s3mock.store;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,12 +37,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -61,18 +58,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @MockBean(classes = {KmsKeyStore.class, BucketStore.class})
 @SpringBootTest(classes = {StoreConfiguration.class})
 @Execution(SAME_THREAD)
-class MultipartStoreTest {
-  private static final String TEST_BUCKET_NAME = "test-bucket";
+class MultipartStoreTest extends StoreTestBase {
   private static final String ALL_BUCKETS = null;
-  private static final String NO_PREFIX = null;
-  private static final String NO_ENC = null;
-  private static final String NO_ENC_KEY = null;
-  private static final Map<String, String> NO_USER_METADATA = emptyMap();
-  private static final String DEFAULT_CONTENT_TYPE =
-      ContentType.APPLICATION_OCTET_STREAM.toString();
-  private static final Owner TEST_OWNER = new Owner("123", "s3-mock-file-store");
-  private static final String TEXT_PLAIN = ContentType.TEXT_PLAIN.toString();
-  private static final String ENCODING_GZIP = "gzip";
   private static final List<UUID> idCache = Collections.synchronizedList(new ArrayList<>());
 
   @Autowired
@@ -173,7 +160,7 @@ class MultipartStoreTest {
             .exists()).as("File does not exist!").isTrue();
     assertThat(
         Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, id.toString(),
-                "objectMetadata").toFile()
+                "objectMetadata.json").toFile()
             .exists()).as("Metadata does not exist!").isTrue();
     assertThat(etag).as("Special etag doesn't match.")
         .isEqualTo(DigestUtils.md5Hex(allMd5s) + "-2");
@@ -465,13 +452,6 @@ class MultipartStoreTest {
 
     assertThat(s).contains(rangeClosed(1, 10).mapToObj(Integer::toString)
         .collect(toList()).toArray(new String[] {}));
-  }
-
-  private BucketMetadata metadataFrom(String bucketName) {
-    BucketMetadata metadata = new BucketMetadata();
-    metadata.setName(bucketName);
-    metadata.setPath(Paths.get(rootFolder.toString(), bucketName));
-    return metadata;
   }
 
   private UUID managedId() {

--- a/server/src/test/java/com/adobe/testing/s3mock/store/StoreTestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/StoreTestBase.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.store;
+
+import static java.util.Collections.emptyMap;
+
+import com.adobe.testing.s3mock.dto.Owner;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.http.entity.ContentType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+abstract class StoreTestBase {
+  static final String TEST_BUCKET_NAME = "test-bucket";
+  static final String TEST_FILE_PATH = "src/test/resources/sampleFile.txt";
+  static final String NO_ENC = null;
+  static final String NO_ENC_KEY = null;
+  static final Map<String, String> NO_USER_METADATA = emptyMap();
+  static final String TEST_ENC_TYPE = "aws:kms";
+  static final String TEST_ENC_KEY = "aws:kms" + UUID.randomUUID();
+  static final String TEXT_PLAIN = ContentType.TEXT_PLAIN.toString();
+  static final String ENCODING_GZIP = "gzip";
+  static final String NO_PREFIX = null;
+  static final String DEFAULT_CONTENT_TYPE =
+      ContentType.APPLICATION_OCTET_STREAM.toString();
+  static final Owner TEST_OWNER = new Owner("123", "s3-mock-file-store");
+
+  @Autowired
+  private File rootFolder;
+
+  BucketMetadata metadataFrom(String bucketName) {
+    BucketMetadata metadata = new BucketMetadata();
+    metadata.setName(bucketName);
+    metadata.setPath(Paths.get(rootFolder.toString(), bucketName));
+    return metadata;
+  }
+
+}

--- a/server/src/test/java/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.store;
+
+import static com.adobe.testing.s3mock.store.StoreConfiguration.S3_OBJECT_DATE_FORMAT;
+import static com.adobe.testing.s3mock.util.DigestUtil.hexDigest;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.adobe.testing.s3mock.dto.Owner;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@AutoConfigureWebMvc
+@AutoConfigureMockMvc
+@MockBean(classes = {KmsKeyStore.class})
+@SpringBootTest(classes = {StoreConfiguration.class,
+    StoresWithExistingFileRootTest.TestConfig.class})
+public class StoresWithExistingFileRootTest extends StoreTestBase {
+  @Autowired
+  private BucketStore bucketStore;
+  @Autowired
+  private BucketStore testBucketStore;
+
+  @Autowired
+  private ObjectStore objectStore;
+
+  @Autowired
+  private ObjectStore testObjectStore;
+
+  @Test
+  void testBucketStoreWithExistingRoot() {
+    bucketStore.createBucket(TEST_BUCKET_NAME, false);
+    BucketMetadata bucket = bucketStore.getBucketMetadata(TEST_BUCKET_NAME);
+
+    assertThatThrownBy(() ->
+        testBucketStore.getBucketMetadata(TEST_BUCKET_NAME)
+    ).isInstanceOf(NullPointerException.class);
+
+    testBucketStore.loadBuckets(Collections.singletonList(TEST_BUCKET_NAME));
+    BucketMetadata reloadedBucket = testBucketStore.getBucketMetadata(TEST_BUCKET_NAME);
+    assertThat(reloadedBucket.getCreationDate()).isEqualTo(bucket.getCreationDate());
+    assertThat(reloadedBucket.getPath()).isEqualTo(bucket.getPath());
+  }
+
+  @Test
+  void testObjectStoreWithExistingRoot() throws IOException {
+    File sourceFile = new File(TEST_FILE_PATH);
+    Path path = sourceFile.toPath();
+    UUID id = UUID.randomUUID();
+    String name = sourceFile.getName();
+    BucketMetadata bucketMetadata = metadataFrom(TEST_BUCKET_NAME);
+    objectStore
+        .storeS3ObjectMetadata(bucketMetadata, id, name, TEXT_PLAIN, ENCODING_GZIP,
+            Files.newInputStream(path), false,
+            emptyMap(), null, null, null, emptyList(), Owner.DEFAULT_OWNER);
+
+    S3ObjectMetadata object = objectStore.getS3ObjectMetadata(bucketMetadata, id);
+
+    assertThatThrownBy(() ->
+        testObjectStore.getS3ObjectMetadata(bucketMetadata, id)
+    ).isInstanceOf(NullPointerException.class);
+
+    testObjectStore.loadObjects(bucketMetadata, Collections.singletonList(object.getId()));
+
+    S3ObjectMetadata reloadedObject = testObjectStore.getS3ObjectMetadata(bucketMetadata, id);
+    assertThat(reloadedObject.getModificationDate()).isEqualTo(object.getModificationDate());
+    assertThat(reloadedObject.getMd5()).isEqualTo(object.getMd5());
+  }
+
+  @Configuration
+  static class TestConfig {
+    @Bean
+    BucketStore testBucketStore(StoreProperties properties, File rootFolder,
+        ObjectMapper objectMapper) {
+      return new BucketStore(rootFolder, properties.isRetainFilesOnExit(),
+          S3_OBJECT_DATE_FORMAT, objectMapper);
+    }
+
+    @Bean
+    ObjectStore testObjectStore(StoreProperties properties, ObjectMapper objectMapper) {
+      return new ObjectStore(properties.isRetainFilesOnExit(),
+          S3_OBJECT_DATE_FORMAT, objectMapper);
+    }
+  }
+}

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-common</artifactId>

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit4</artifactId>

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit5</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testcontainers/pom.xml
+++ b/testsupport/testcontainers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testcontainers</artifactId>

--- a/testsupport/testcontainers/src/main/java/com/adobe/testing/s3mock/testcontainers/S3MockContainer.java
+++ b/testsupport/testcontainers/src/main/java/com/adobe/testing/s3mock/testcontainers/S3MockContainer.java
@@ -24,7 +24,6 @@ import org.testcontainers.utility.DockerImageName;
 
 public class S3MockContainer extends GenericContainer<S3MockContainer> {
   public static final String IMAGE_NAME = "adobe/s3mock";
-
   private static final int S3MOCK_DEFAULT_HTTP_PORT = 9090;
   private static final int S3MOCK_DEFAULT_HTTPS_PORT = 9191;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse(IMAGE_NAME);
@@ -48,12 +47,17 @@ public class S3MockContainer extends GenericContainer<S3MockContainer> {
     super(dockerImageName);
 
     dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+    addExposedPort(S3MOCK_DEFAULT_HTTP_PORT);
+    addExposedPort(S3MOCK_DEFAULT_HTTPS_PORT);
     waitingFor(Wait.forHttp("/favicon.ico")
         .forPort(S3MOCK_DEFAULT_HTTP_PORT)
         .withMethod("GET")
         .forStatusCode(200));
-    addExposedPort(S3MOCK_DEFAULT_HTTP_PORT);
-    addExposedPort(S3MOCK_DEFAULT_HTTPS_PORT);
+  }
+
+  public S3MockContainer withRetainFilesOnExit(boolean retainFilesOnExit) {
+    this.addEnv("retainFilesOnExit", String.valueOf(retainFilesOnExit));
+    return self();
   }
 
   public S3MockContainer withValidKmsKeys(String kmsKeys) {

--- a/testsupport/testcontainers/src/test/java/com/adobe/testing/s3mock/testcontainers/S3MockContainerRestartOnRootfolderTest.java
+++ b/testsupport/testcontainers/src/test/java/com/adobe/testing/s3mock/testcontainers/S3MockContainerRestartOnRootfolderTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2017-2022 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.testcontainers;
+
+import java.io.File;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.shaded.com.google.common.io.Files;
+
+public class S3MockContainerRestartOnRootfolderTest extends S3MockContainerTestBase {
+
+  private S3MockContainer s3Mock;
+  private static final File tempDir = Files.createTempDir();
+
+  @BeforeEach
+  void setUp() {
+    s3Mock = new S3MockContainer(S3MOCK_VERSION)
+        .withValidKmsKeys(TEST_ENC_KEYREF)
+        .withRetainFilesOnExit(true)
+        .withEnv("debug", "true")
+        .withInitialBuckets(String.join(",", INITIAL_BUCKET_NAMES));
+    s3Mock.withVolumeAsRoot(tempDir.getAbsolutePath());
+    s3Mock.start();
+    Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LOG);
+    s3Mock.followOutput(logConsumer);
+    // Must create S3Client after S3MockContainer is started, otherwise we can't request the random
+    // locally mapped port for the endpoint
+    String endpoint = s3Mock.getHttpsEndpoint();
+    s3Client = createS3ClientV2(endpoint);
+  }
+
+  @AfterEach
+  void tearDown() {
+    s3Mock.stop();
+  }
+}

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testng</artifactId>


### PR DESCRIPTION
## Description
If the `root` configured for S3Mock contains files of a previous run (for instance because S3Mock is started with the `retainFilesOnExit` option), it should try and restore all in-memory data so that requests can be served using the existing files.

## Related Issue
Fixes #818

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
