### PR TITLE
Let AWS SDKv2 use path style access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 
 * Features and fixes
   * Support restarting S3Mock with the `retainFilesOnExit` option enabled. (fixes #818) 
+  * Let AWS SDKv2 use path style access (fixes #880)
+    * Starting with AWS SDKv2.18.x domain style access is the default. This is currently not
+      supported by S3Mock.
 
 ## 2.8.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -39,6 +39,7 @@ import software.amazon.awssdk.http.SdkHttpConfigurationOption
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest
 import software.amazon.awssdk.services.s3.model.Bucket
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
@@ -131,6 +132,7 @@ internal abstract class S3TestBase {
       .credentialsProvider(
         StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey))
       )
+      .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
       .endpointOverride(URI.create(serviceEndpoint))
       .httpClient(
         ApacheHttpClient.builder().buildWithDefaults(

--- a/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
+++ b/testsupport/common/src/main/java/com/adobe/testing/s3mock/testsupport/common/S3MockStarter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2020 Adobe.
+ *  Copyright 2017-2022 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.utils.AttributeMap;
 
 /**
@@ -79,6 +80,7 @@ public abstract class S3MockStarter {
       .region(Region.of("us-east-1"))
       .credentialsProvider(
         StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
+      .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
       .endpointOverride(URI.create(getServiceEndpoint()))
       .httpClient(UrlConnectionHttpClient.builder().buildWithDefaults(AttributeMap.builder()
         .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)

--- a/testsupport/testcontainers/src/test/java/com/adobe/testing/s3mock/testcontainers/S3MockContainerTestBase.java
+++ b/testsupport/testcontainers/src/test/java/com/adobe/testing/s3mock/testcontainers/S3MockContainerTestBase.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.Bucket;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -131,6 +132,7 @@ abstract class S3MockContainerTestBase {
         .region(Region.of("us-east-1"))
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
+        .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
         .endpointOverride(URI.create(endpoint))
         .httpClient(UrlConnectionHttpClient.builder().buildWithDefaults(
             AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, Boolean.TRUE).build()))


### PR DESCRIPTION
## Description
This was the default in 2.17.x, changed in 2.18.x
S3Mock currently does not support subdomain style access to buckets.

## Related Issue
Fixes #880
The real issue is #144, which is *not* fixed with this change.

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
