### PR TITLE
IDs in stores must be different for all objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
+## 2.9.1
+2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * IDs in stores must be different for all objects (fixes #877) 
+
 ## 2.9.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
@@ -43,6 +43,25 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  fun testPutGetDeleteObject_twoBuckets(testInfo: TestInfo) {
+    val bucket1 = givenRandomBucketV2()
+    val bucket2 = givenRandomBucketV2()
+    givenObjectV2(bucket1, UPLOAD_FILE_NAME)
+    givenObjectV2(bucket2, UPLOAD_FILE_NAME)
+    getObjectV2(bucket1, UPLOAD_FILE_NAME)
+    val object2 = getObjectV2(bucket2, UPLOAD_FILE_NAME)
+
+    deleteObjectV2(bucket1, UPLOAD_FILE_NAME)
+    Assertions.assertThatThrownBy {
+      getObjectV2(bucket1, UPLOAD_FILE_NAME)
+    }.isInstanceOf(S3Exception::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 404")
+
+    val object2Again = getObjectV2(bucket2, UPLOAD_FILE_NAME)
+    assertThat(object2.response().eTag()).isEqualTo(object2Again.response().eTag())
+  }
+
+  @Test
   fun testGetObject_successWithMatchingEtag(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val uploadFileIs: InputStream = FileInputStream(uploadFile)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.ResponseInputStream
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.http.SdkHttpConfigurationOption
 import software.amazon.awssdk.http.apache.ApacheHttpClient
@@ -45,8 +46,11 @@ import software.amazon.awssdk.services.s3.model.Bucket
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
 import software.amazon.awssdk.services.s3.model.EncodingType
 import software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
@@ -199,12 +203,24 @@ internal abstract class S3TestBase {
     return givenBucketV2(randomName)
   }
 
-  private fun givenObjectV2(bucketName: String, key: String): PutObjectResponse {
+  fun givenObjectV2(bucketName: String, key: String): PutObjectResponse {
     val uploadFile = File(key)
     return s3ClientV2.putObject(
       software.amazon.awssdk.services.s3.model.PutObjectRequest.builder()
         .bucket(bucketName).key(key).build(),
       RequestBody.fromFile(uploadFile)
+    )
+  }
+
+  fun deleteObjectV2(bucketName: String, key: String): DeleteObjectResponse {
+    return s3ClientV2.deleteObject(
+      DeleteObjectRequest.builder().bucket(bucketName).key(key).build()
+    )
+  }
+
+  fun getObjectV2(bucketName: String, key: String): ResponseInputStream<GetObjectResponse> {
+    return s3ClientV2.getObject(
+      GetObjectRequest.builder().bucket(bucketName).key(key).build()
     )
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/store/BucketMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/BucketMetadata.java
@@ -16,8 +16,6 @@
 
 package com.adobe.testing.s3mock.store;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.adobe.testing.s3mock.dto.BucketLifecycleConfiguration;
 import com.adobe.testing.s3mock.dto.ObjectLockConfiguration;
 import java.nio.file.Path;
@@ -99,7 +97,7 @@ public class BucketMetadata {
     if (doesKeyExist(key)) {
       return getID(key);
     } else {
-      UUID uuid = UUID.nameUUIDFromBytes(key.getBytes(UTF_8));
+      UUID uuid = UUID.randomUUID();
       this.objects.put(key, uuid);
       return uuid;
     }


### PR DESCRIPTION
## Description
UUIDs were the same for the same keys even in different buckets.

## Related Issue
Fixes #877

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
