### PR TITLE
Let S3Mock use streams for MD5 verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,11 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
+## 2.10.1
+* Features and fixes
+  * Let S3Mock use streams for MD5 verification (fixes #939)
+    * Previous implementation read the full stream into memory, leading to OutOfMemory errors if the file is larger than the available heap.
+
 ## 2.10.0
 * Features and fixes
   * Let S3Mock use container memory and cpu (fixes #922)

--- a/server/src/main/java/com/adobe/testing/s3mock/S3Exception.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3Exception.java
@@ -92,6 +92,9 @@ public class S3Exception extends RuntimeException {
   public static final S3Exception BAD_REQUEST_MD5 =
       new S3Exception(BAD_REQUEST.value(), "BadRequest",
           "Content-MD5 does not match object md5");
+  public static final S3Exception BAD_REQUEST_CONTENT =
+      new S3Exception(BAD_REQUEST.value(), "UnexpectedContent",
+          "This request contains unsupported content.");
   private final int status;
   private final String code;
   private final String message;


### PR DESCRIPTION
## Description
Previous implementation read the full stream into memory, leading to OutOfMemory errors if the file is larger than the available heap.

## Related Issue
fixes #939

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
