### PR TITLE
Return correct errors for invalid bucket names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
+## 2.10.2
+2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Let S3Mock return correct errors for invalid bucket names (fixes #935)
+    * Previous implementation returned a Spring generated error which does not disclose what's actually wrong
+    * If the bucket name is not valid, the bucket can't be created. If a later request still contains this invalid name, S3Mock will now return a 404 not found.
+
 ## 2.10.1
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -149,7 +149,7 @@
                     <validKmsKeys>arn:aws:kms:us-east-1:1234567890:key/valid-test-key-id</validKmsKeys>
                     <initialBuckets>bucket-a, bucket-b</initialBuckets>
                   </env>
-                  <memory>256000000</memory>
+                  <memory>128000000</memory>
                 </run>
               </image>
             </images>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
@@ -41,7 +41,7 @@ internal class BucketV1IT : S3TestBase() {
     // and account for a clock-skew in the Docker container of up to a minute.
     val creationDate = Date(System.currentTimeMillis() / 1000 * 1000 - 60000)
     assertThat(bucket.name)
-      .`as`(String.format("Bucket name should match '%s'!", bucketName))
+      .`as`("Bucket name should match '$bucketName'!")
       .isEqualTo(bucketName)
     val buckets = s3Client.listBuckets().stream().filter { b: Bucket -> bucketName == b.name }
       .collect(Collectors.toList())
@@ -95,7 +95,7 @@ internal class BucketV1IT : S3TestBase() {
     s3Client.createBucket(bucketName)
     val doesBucketExist = s3Client.doesBucketExistV2(bucketName)
     assertThat(doesBucketExist)
-      .`as`(String.format("The previously created bucket, '%s', should exist!", bucketName))
+      .`as`("The previously created bucket, '$bucketName', should exist!")
       .isTrue
   }
 
@@ -104,7 +104,7 @@ internal class BucketV1IT : S3TestBase() {
     val bucketName = bucketName(testInfo)
     val doesBucketExist = s3Client.doesBucketExistV2(bucketName)
     assertThat(doesBucketExist)
-      .`as`(String.format("The bucket, '%s', should not exist!", bucketName))
+      .`as`("The bucket, '$bucketName', should not exist!")
       .isFalse
   }
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
@@ -122,15 +122,15 @@ internal class BucketV2IT : S3TestBase() {
   @Test
   fun getBucketLifecycle_notFound(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
-    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
 
-    val bucketCreated = s3ClientV2!!.waiter()
+    val bucketCreated = s3ClientV2.waiter()
       .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
     val bucketCreatedResponse = bucketCreated.matched().response()!!.get()
     assertThat(bucketCreatedResponse).isNotNull
 
     assertThatThrownBy {
-      s3ClientV2!!.getBucketLifecycleConfiguration(
+      s3ClientV2.getBucketLifecycleConfiguration(
         GetBucketLifecycleConfigurationRequest.builder().bucket(bucketName).build()
       )
     }
@@ -145,9 +145,9 @@ internal class BucketV2IT : S3TestBase() {
   @Test
   fun putGetDeleteBucketLifecycle(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
-    s3ClientV2!!.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
 
-    val bucketCreated = s3ClientV2!!.waiter()
+    val bucketCreated = s3ClientV2.waiter()
       .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
     val bucketCreatedResponse = bucketCreated.matched().response()!!.get()
     assertThat(bucketCreatedResponse).isNotNull
@@ -176,7 +176,7 @@ internal class BucketV2IT : S3TestBase() {
       )
       .build()
 
-    s3ClientV2!!.putBucketLifecycleConfiguration(
+    s3ClientV2.putBucketLifecycleConfiguration(
       PutBucketLifecycleConfigurationRequest
         .builder()
         .bucket(bucketName)
@@ -186,7 +186,7 @@ internal class BucketV2IT : S3TestBase() {
         .build()
     )
 
-    val configurationResponse = s3ClientV2!!.getBucketLifecycleConfiguration(
+    val configurationResponse = s3ClientV2.getBucketLifecycleConfiguration(
       GetBucketLifecycleConfigurationRequest
         .builder()
         .bucket(bucketName)
@@ -195,12 +195,12 @@ internal class BucketV2IT : S3TestBase() {
 
     assertThat(configurationResponse.rules()[0]).isEqualTo(configuration.rules()[0])
 
-    s3ClientV2!!.deleteBucketLifecycle(
+    s3ClientV2.deleteBucketLifecycle(
       DeleteBucketLifecycleRequest.builder().bucket(bucketName).build()
     )
 
     assertThatThrownBy {
-      s3ClientV2!!.getBucketLifecycleConfiguration(
+      s3ClientV2.getBucketLifecycleConfiguration(
         GetBucketLifecycleConfigurationRequest.builder().bucket(bucketName).build()
       )
     }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
@@ -68,7 +68,7 @@ internal class ListObjectV1IT : S3TestBase() {
     }
 
     override fun toString(): String {
-      return String.format("prefix=%s, delimiter=%s", prefix, delimiter)
+      return "prefix=$prefix, delimiter=$delimiter"
     }
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
@@ -80,7 +80,7 @@ public class BucketController {
   }
 
   //================================================================================================
-  // /{bucketName:[a-z0-9.-]+}
+  // /{bucketName:.+}
   //================================================================================================
 
   /**
@@ -94,7 +94,6 @@ public class BucketController {
    */
   @RequestMapping(
       value = {
-          "/{bucketName:[a-z0-9.-]+}",
           "/{bucketName:.+}"
       },
       params = {
@@ -121,7 +120,7 @@ public class BucketController {
    * @return 200 if it exists; 404 if not found.
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       method = RequestMethod.HEAD
   )
   public ResponseEntity<Void> headBucket(@PathVariable final String bucketName) {
@@ -138,7 +137,7 @@ public class BucketController {
    * @return 204 if Bucket was deleted; 404 if not found
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       params = {
           NOT_LIFECYCLE
       },
@@ -160,7 +159,7 @@ public class BucketController {
    * @return 200, ObjectLockConfiguration
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       params = {
           OBJECT_LOCK,
           NOT_LIST_TYPE
@@ -186,7 +185,7 @@ public class BucketController {
    * @return 200, ObjectLockConfiguration
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       params = {
           OBJECT_LOCK
       },
@@ -210,7 +209,7 @@ public class BucketController {
    * @return 200, ObjectLockConfiguration
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       params = {
           LIFECYCLE,
           NOT_LIST_TYPE
@@ -237,7 +236,7 @@ public class BucketController {
    * @return 200, ObjectLockConfiguration
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       params = {
           LIFECYCLE
       },
@@ -261,7 +260,7 @@ public class BucketController {
    * @return 200, ObjectLockConfiguration
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       params = {
           LIFECYCLE
       },
@@ -292,7 +291,7 @@ public class BucketController {
           NOT_LIST_TYPE,
           NOT_LIFECYCLE
       },
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       method = RequestMethod.GET,
       produces = {
           APPLICATION_XML_VALUE
@@ -327,7 +326,7 @@ public class BucketController {
    *
    * @return {@link ListBucketResultV2} a list of objects in Bucket
    */
-  @RequestMapping(value = "/{bucketName:[a-z0-9.-]+}",
+  @RequestMapping(value = "/{bucketName:.+}",
       params = {
           LIST_TYPE_V2
       },

--- a/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
@@ -83,7 +83,7 @@ public class MultipartController {
   }
 
   //================================================================================================
-  // /{bucketName:[a-z0-9.-]+}
+  // /{bucketName:.+}
   //================================================================================================
 
   /**
@@ -100,9 +100,9 @@ public class MultipartController {
   @RequestMapping(
       value = {
           //AWS SDK V2 pattern
-          "/{bucketName:[a-z0-9.-]+}",
+          "/{bucketName:.+}",
           //AWS SDK V1 pattern
-          "/{bucketName:[a-z0-9.-]+}/"
+          "/{bucketName:.+}/"
       },
       params = {
           UPLOADS
@@ -124,7 +124,7 @@ public class MultipartController {
   }
 
   //================================================================================================
-  // /{bucketName:[a-z0-9.-]+}/{*key}
+  // /{bucketName:.+}/{*key}
   //================================================================================================
 
   /**
@@ -135,7 +135,7 @@ public class MultipartController {
    * @param uploadId id of the upload. Has to match all other part's uploads.
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           UPLOAD_ID,
           NOT_LIFECYCLE
@@ -164,7 +164,7 @@ public class MultipartController {
    * @return the {@link ListPartsResult}
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           UPLOAD_ID
       },
@@ -199,7 +199,7 @@ public class MultipartController {
    *
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           UPLOAD_ID,
           PART_NUMBER
@@ -250,7 +250,7 @@ public class MultipartController {
    *
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       headers = {
           X_AMZ_COPY_SOURCE,
       },
@@ -303,7 +303,7 @@ public class MultipartController {
    * @return the {@link InitiateMultipartUploadResult}.
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           UPLOADS
       },
@@ -344,7 +344,7 @@ public class MultipartController {
    * @return {@link CompleteMultipartUploadResult}
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           UPLOAD_ID
       },

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -111,7 +111,7 @@ public class ObjectController {
   }
 
   //================================================================================================
-  // /{bucketName:[a-z0-9.-]+}
+  // /{bucketName:.+}
   //================================================================================================
 
   /**
@@ -124,7 +124,7 @@ public class ObjectController {
    * @return The {@link DeleteResult}
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}",
+      value = "/{bucketName:.+}",
       params = {
           DELETE
       },
@@ -142,7 +142,7 @@ public class ObjectController {
   }
 
   //================================================================================================
-  // /{bucketName:[a-z0-9.-]+}/{*key}
+  // /{bucketName:.+}/{*key}
   //================================================================================================
 
   /**
@@ -154,7 +154,7 @@ public class ObjectController {
    * @return 200 with object metadata headers, 404 if not found.
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       method = RequestMethod.HEAD
   )
   public ResponseEntity<Void> headObject(@PathVariable String bucketName,
@@ -189,7 +189,7 @@ public class ObjectController {
    * @return ResponseEntity with Status Code 204 if object was successfully deleted.
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           NOT_LIFECYCLE
       },
@@ -215,7 +215,7 @@ public class ObjectController {
    *
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           NOT_UPLOADS,
           NOT_UPLOAD_ID,
@@ -273,7 +273,7 @@ public class ObjectController {
    * @return {@link ResponseEntity} with Status Code and empty ETag.
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           ACL,
       },
@@ -306,7 +306,7 @@ public class ObjectController {
    * @return {@link ResponseEntity} with Status Code and empty ETag.
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           ACL,
       },
@@ -330,7 +330,7 @@ public class ObjectController {
    * @param bucketName The Bucket's name
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           TAGGING
       },
@@ -361,7 +361,7 @@ public class ObjectController {
    * @param body Tagging object
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           TAGGING
       },
@@ -390,7 +390,7 @@ public class ObjectController {
    * @param bucketName The Bucket's name
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           LEGAL_HOLD
       },
@@ -417,7 +417,7 @@ public class ObjectController {
    * @param body legal hold
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           LEGAL_HOLD
       },
@@ -445,7 +445,7 @@ public class ObjectController {
    * @param bucketName The Bucket's name
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           RETENTION
       },
@@ -472,7 +472,7 @@ public class ObjectController {
    * @param body retention
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       params = {
           RETENTION
       },
@@ -515,7 +515,7 @@ public class ObjectController {
       headers = {
           NOT_X_AMZ_COPY_SOURCE
       },
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       method = RequestMethod.PUT
   )
   public ResponseEntity<Void> putObject(@PathVariable String bucketName,
@@ -571,7 +571,7 @@ public class ObjectController {
    *
    */
   @RequestMapping(
-      value = "/{bucketName:[a-z0-9.-]+}/{*key}",
+      value = "/{bucketName:.+}/{*key}",
       headers = {
           X_AMZ_COPY_SOURCE
       },

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectKey.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectKey.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
  * Removes the trailing slash extracted from paths by Spring.
  * Used in conjunction with the PathVariable extracted by using "{*key}" in the path pattern.
  * See {@link org.springframework.web.util.pattern.PathPattern}
- * Example path pattern: "/{bucketName:[a-z0-9.-]+}/{*key}"
+ * Example path pattern: "/{bucketName:.+}/{*key}"
  * Example incoming path: "/my-bucket/prefix/before/my/key"
  * By declaring "{*key}", Spring extracts the absolute path "/prefix/before/my/key", but in S3, all
  * keys within a bucket are relative to the bucket, in this example "prefix/before/my/key".


### PR DESCRIPTION
## Description
Match all bucket names in path pattern.

This makes it possible to return real S3 errors if buckets have invalid
names.

## Related Issue
Fixes #935

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
