### PR TITLE
Prepare releases in 2023

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/testcontainers/pom.xml
+++ b/testsupport/testcontainers/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2022 Adobe.
+     Copyright 2017-2023 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
The "license-maven-plugin" configuration expects all changed files to have a copyright ending the year they are modified. A maven release updates all POMs, we need to update the copyright at the start of every year...

## Related Issue
N/A

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
