### PR TITLE
Expose all headers for CORS requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,16 +121,24 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
 * Version updates
   * TBD
 
-## 2.12.0 - PLANNED
+## 2.12.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
+  * Expose all headers for CORS requests (fixes #1023)
   * Fixed various error responses, validations and http return codes
-    * Verified all integration tests against the AWS S3 API, fixed S3Mock to match S3 responses exactly. 
-* Refactorings
-  * TBD
+    * Verified all integration tests against the AWS S3 API, fixed S3Mock to match S3 responses exactly.
 * Version updates
-  * TBD
+  * Bump spring-boot.version from 2.7.6 to 2.7.7
+  * Bump testng from 7.7.0 to 7.7.1
+  * Bump checkstyle from 10.5.0 to 10.6.0
+  * Bump alpine from 3.17.0 to 3.17.1 in /docker
+  * Bump xmlunit-assertj3 from 2.9.0 to 2.9.1
+  * Bump maven-failsafe-plugin from 3.0.0-M7 to 3.0.0-M8
+  * Bump maven-checkstyle-plugin from 3.2.0 to 3.2.1
+  * Bump maven-surefire-plugin from 3.0.0-M7 to 3.0.0-M8
+  * Bump aws-java-sdk-s3 from 1.12.369 to 1.12.389
+  * Bump aws-v2.version from 2.19.1 to 2.19.16
 
 ## 2.11.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CorsV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CorsV2IT.kt
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2017-2023 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.its
+
+import com.adobe.testing.s3mock.util.DigestUtil
+import org.apache.http.HttpHost
+import org.apache.http.HttpResponse
+import org.apache.http.HttpStatus
+import org.apache.http.client.methods.HttpOptions
+import org.apache.http.client.methods.HttpPut
+import org.apache.http.entity.ByteArrayEntity
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.client.HttpClients
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import java.io.IOException
+import java.util.UUID
+
+
+/**
+ * Test the application using the AmazonS3 SDK V2.
+ */
+internal class CorsV2IT : S3TestBase() {
+  private lateinit var httpClient: CloseableHttpClient
+
+  @BeforeEach
+  fun setupHttpClient() {
+    httpClient = HttpClients.createDefault()
+  }
+
+  @AfterEach
+  @Throws(IOException::class)
+  fun shutdownHttpClient() {
+    httpClient.close()
+  }
+
+  @Test
+  fun testPutObject_cors(testInfo: TestInfo) {
+    val bucketName = givenBucketV2(testInfo)
+    val httpclient = HttpClientBuilder.create().build()
+    val optionsRequest = HttpOptions("/${bucketName}/testObjectName")
+    optionsRequest.addHeader("Origin", "http://localhost/")
+    val optionsResponse: HttpResponse = httpclient.execute(HttpHost(
+      host, httpPort
+    ), optionsRequest)
+    val allow = optionsResponse.getFirstHeader("Allow")
+    assertThat(allow.value).contains("PUT")
+
+    val putObject = HttpPut("/$bucketName/testObjectName")
+    val byteArray = UUID.randomUUID().toString().toByteArray()
+    val expectedEtag = "\"${DigestUtil.hexDigest(byteArray)}\""
+    putObject.entity = ByteArrayEntity(byteArray)
+    putObject.addHeader("Origin", "http://localhost/")
+    val putObjectResponse: HttpResponse = httpClient.execute(
+      HttpHost(
+        host, httpPort
+      ), putObject
+    )
+    assertThat(putObjectResponse.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+    val eTag = putObjectResponse.getFirstHeader("ETag")
+    assertThat(eTag.value).isEqualTo(expectedEtag)
+    val allowOrigin = putObjectResponse.getFirstHeader("Access-Control-Allow-Origin")
+    assertThat(allowOrigin.value).isEqualTo("*")
+    val exposeHeaders = putObjectResponse.getFirstHeader("Access-Control-Expose-Headers")
+    assertThat(exposeHeaders.value).isEqualTo("*")
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2023 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ import software.amazon.awssdk.regions.Region;
 /**
  * Handles requests related to buckets.
  */
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = "*", exposedHeaders = "*")
 @RequestMapping("${com.adobe.testing.s3mock.contextPath:}")
 public class BucketController {
   private final BucketService bucketService;

--- a/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2023 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 /**
  * Handles requests related to parts.
  */
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = "*", exposedHeaders = "*")
 @RequestMapping("${com.adobe.testing.s3mock.contextPath:}")
 public class MultipartController {
 

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2023 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -97,7 +97,9 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 /**
  * Handles requests related to objects.
  */
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = "*",
+    exposedHeaders = "*"
+)
 @RequestMapping("${com.adobe.testing.s3mock.contextPath:}")
 public class ObjectController {
   private static final String RANGES_BYTES = "bytes";


### PR DESCRIPTION
## Description
This is a test application supposed to be used locally only. No reason to limit exposed response headers, since we want clients to receive the headers we add to responses.

## Related Issue
Fixes #1023

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
