### PR TITLE
ci: migrate to Temurin

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: 17
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: 'maven'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/maven-ci-and-prb.yml
+++ b/.github/workflows/maven-ci-and-prb.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Build with Maven
         run: ./mvnw -B -V -Dstyle.color=always clean verify

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       # The release build pushes a Docker image to Docker Hub, so we need to log in
       - name: Perform docker login


### PR DESCRIPTION
## Description

Adopt is no longer maintained https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
