### PR TITLE
Store and return all encryption headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,12 +105,21 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
     * This will update all Spring Boot dependencies as well, including Spring Framework 6.x
   * Bump java version from 8 to 17
 
-## 2.15.0 - PLANNED
+## 2.16.0 - PLANNED
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
-  * Support for GetObjectAttributes API
-    * Started draft PR: [#832](https://github.com/adobe/S3Mock/pull/832/)
+  * Add support for GetObjectAttributes API (fixes #536)
+* Refactorings
+  * TBD
+* Version updates
+  * TBD
+
+## 2.15.0
+2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Store and return all encryption headers (fixes #1178)
 * Refactorings
   * TBD
 * Version updates

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-build-config</artifactId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-docker</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-integration-tests</artifactId>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV1IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2023 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -151,6 +151,7 @@ internal class GetPutDeleteObjectV1IT : S3TestBase() {
     assertThat(objectMetadata.userMetadata)
       .`as`("User metadata should be identical!")
       .isEqualTo(metadata.userMetadata)
+    assertThat(objectMetadata.sseAwsKmsKeyId).isEqualTo(TEST_ENC_KEY_ID)
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>2.14.1-SNAPSHOT</version>
+  <version>2.15.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -74,8 +74,6 @@ public class ObjectService {
    * @param sourceKey object key to copy.
    * @param destinationBucketName destination bucket.
    * @param destinationKey destination object key.
-   * @param encryption The Encryption Type.
-   * @param kmsKeyId The KMS encryption key id.
    * @param userMetadata User metadata to store for destination object
    *
    * @return an {@link CopyObjectResult} or null if source couldn't be found.
@@ -84,8 +82,7 @@ public class ObjectService {
       String sourceKey,
       String destinationBucketName,
       String destinationKey,
-      String encryption,
-      String kmsKeyId,
+      Map<String, String> encryptionHeaders,
       Map<String, String> userMetadata) {
     BucketMetadata sourceBucketMetadata = bucketStore.getBucketMetadata(sourceBucketName);
     BucketMetadata destinationBucketMetadata = bucketStore.getBucketMetadata(destinationBucketName);
@@ -104,7 +101,7 @@ public class ObjectService {
     try {
       return objectStore.copyS3Object(sourceBucketMetadata, sourceId,
           destinationBucketMetadata, destinationId, destinationKey,
-          encryption, kmsKeyId, userMetadata);
+          encryptionHeaders, userMetadata);
     } catch (Exception e) {
       //something went wrong with writing the destination file, clean up ID from BucketStore.
       bucketStore.removeFromBucket(destinationKey, destinationBucketName);
@@ -123,8 +120,6 @@ public class ObjectService {
    * @param useV4ChunkedWithSigningFormat If {@code true}, V4-style signing is enabled.
    * @param userMetadata User metadata to store for this object, will be available for the
    *     object with the key prefixed with "x-amz-meta-".
-   * @param encryption The Encryption Type.
-   * @param kmsKeyId The KMS encryption key id.
    *
    * @return {@link S3ObjectMetadata}.
    */
@@ -135,8 +130,7 @@ public class ObjectService {
       InputStream dataStream,
       boolean useV4ChunkedWithSigningFormat,
       Map<String, String> userMetadata,
-      String encryption,
-      String kmsKeyId,
+      Map<String, String> encryptionHeaders,
       List<Tag> tags,
       Owner owner) {
     BucketMetadata bucketMetadata = bucketStore.getBucketMetadata(bucketName);
@@ -145,7 +139,7 @@ public class ObjectService {
       id = bucketStore.addToBucket(key, bucketName);
     }
     return objectStore.storeS3ObjectMetadata(bucketMetadata, id, key, contentType, storeHeaders,
-        dataStream, useV4ChunkedWithSigningFormat, userMetadata, encryption, kmsKeyId, null, tags,
+        dataStream, useV4ChunkedWithSigningFormat, userMetadata, encryptionHeaders, null, tags,
         owner);
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartUploadInfo.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartUploadInfo.java
@@ -28,16 +28,19 @@ class MultipartUploadInfo {
   final String contentType;
   final Map<String, String> userMetadata;
   final Map<String, String> storeHeaders;
+  final Map<String, String> encryptionHeaders;
   final String bucket;
 
   MultipartUploadInfo(final MultipartUpload upload, final String contentType,
       final Map<String, String> storeHeaders,
       final Map<String, String> userMetadata,
-      String bucket) {
+      String bucket,
+      Map<String, String> encryptionHeaders) {
     this.upload = upload;
     this.contentType = contentType;
     this.storeHeaders = storeHeaders;
     this.userMetadata = userMetadata;
     this.bucket = bucket;
+    this.encryptionHeaders = encryptionHeaders;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
@@ -48,15 +48,9 @@ public class S3ObjectMetadata {
 
   private String contentType = DEFAULT_CONTENT_TYPE;
 
-  private String kmsEncryption;
-
-  private boolean isEncrypted;
-
   private long lastModified;
 
   private Path dataPath;
-
-  private String kmsKeyId;
 
   private Map<String, String> userMetadata;
 
@@ -68,6 +62,17 @@ public class S3ObjectMetadata {
 
   private Owner owner;
 
+  private Map<String, String> storeHeaders;
+  private Map<String, String> encryptionHeaders;
+
+  public Map<String, String> getEncryptionHeaders() {
+    return encryptionHeaders == null ? Collections.emptyMap() : encryptionHeaders;
+  }
+
+  public void setEncryptionHeaders(Map<String, String> encryptionHeaders) {
+    this.encryptionHeaders = encryptionHeaders;
+  }
+
   public Map<String, String> getStoreHeaders() {
     return storeHeaders == null ? Collections.emptyMap() : storeHeaders;
   }
@@ -75,8 +80,6 @@ public class S3ObjectMetadata {
   public void setStoreHeaders(Map<String, String> storeHeaders) {
     this.storeHeaders = storeHeaders;
   }
-
-  Map<String, String> storeHeaders;
 
   public Owner getOwner() {
     return owner;
@@ -131,7 +134,7 @@ public class S3ObjectMetadata {
   }
 
   public void setEtag(String etag) {
-    // make sure to store the etag correctly here, every usage depends on this..
+    // make sure to store the etag correctly here, every usage depends on this.
     if (etag == null) {
       this.etag = etag;
     } else if (etag.startsWith("\"") && etag.endsWith("\"")) {
@@ -168,36 +171,12 @@ public class S3ObjectMetadata {
     this.dataPath = dataPath;
   }
 
-  public String getKmsEncryption() {
-    return kmsEncryption;
-  }
-
-  public void setKmsEncryption(final String kmsEncryption) {
-    this.kmsEncryption = kmsEncryption;
-  }
-
-  public boolean isEncrypted() {
-    return isEncrypted;
-  }
-
-  public void setEncrypted(final boolean isEncrypted) {
-    this.isEncrypted = isEncrypted;
-  }
-
   public long getLastModified() {
     return lastModified;
   }
 
   public void setLastModified(final long lastModified) {
     this.lastModified = lastModified;
-  }
-
-  public String getKmsKeyId() {
-    return kmsKeyId;
-  }
-
-  public void setKmsKeyId(final String kmsKeyId) {
-    this.kmsKeyId = kmsKeyId;
   }
 
   public Map<String, String> getUserMetadata() {

--- a/server/src/test/java/com/adobe/testing/s3mock/ObjectControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/ObjectControllerTest.java
@@ -65,6 +65,8 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
@@ -114,8 +116,7 @@ class ObjectControllerTest {
         isNull(),
         eq(false),
         anyMap(),
-        isNull(),
-        isNull(),
+        anyMap(),
         isNull(),
         eq(Owner.DEFAULT_OWNER))
     ).thenReturn(s3ObjectMetadata(key, digest));
@@ -146,8 +147,7 @@ class ObjectControllerTest {
         isNull(),
         eq(false),
         anyMap(),
-        isNull(),
-        isNull(),
+        anyMap(),
         isNull(),
         eq(Owner.DEFAULT_OWNER))
     ).thenReturn(s3ObjectMetadata(key, digest));
@@ -192,8 +192,7 @@ class ObjectControllerTest {
         isNull(),
         eq(false),
         anyMap(),
-        isNull(),
-        isNull(),
+        anyMap(),
         isNull(),
         eq(Owner.DEFAULT_OWNER))
     ).thenReturn(s3ObjectMetadata(key, hexDigest));
@@ -425,13 +424,18 @@ class ObjectControllerTest {
   static S3ObjectMetadata s3ObjectEncrypted(
       String id, String encryption, String encryptionKey) {
     S3ObjectMetadata s3ObjectMetadata = s3ObjectMetadata(id, "digest");
-    s3ObjectMetadata.setEncrypted(true);
-    s3ObjectMetadata.setKmsEncryption(encryption);
-    s3ObjectMetadata.setKmsKeyId(encryptionKey);
+    s3ObjectMetadata.setEncryptionHeaders(encryptionHeaders(encryption, encryptionKey));
     s3ObjectMetadata.setSize("12345");
     final File sourceFile = new File("src/test/resources/sampleFile.txt");
     s3ObjectMetadata.setDataPath(sourceFile.toPath());
     return s3ObjectMetadata;
+  }
+
+  private static Map<String, String> encryptionHeaders(String encryption, String encryptionKey) {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(X_AMZ_SERVER_SIDE_ENCRYPTION, encryption);
+    headers.put(X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID, encryptionKey);
+    return headers;
   }
 }
 

--- a/server/src/test/java/com/adobe/testing/s3mock/store/MultipartStoreTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/MultipartStoreTest.java
@@ -16,7 +16,10 @@
 
 package com.adobe.testing.s3mock.store;
 
+import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENCRYPTION;
+import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,12 +86,15 @@ class MultipartStoreTest extends StoreTestBase {
     String uploadId = "12345";
     UUID id = managedId();
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
     final File destinationFolder =
         Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, id.toString(), uploadId)
             .toFile();
 
-    assertThat(destinationFolder).exists().isDirectory();
+    assertThat(destinationFolder)
+        .exists()
+        .isDirectory();
 
     multipartStore.abortMultipartUpload(metadataFrom(TEST_BUCKET_NAME), id, uploadId);
   }
@@ -99,13 +105,16 @@ class MultipartStoreTest extends StoreTestBase {
     String fileName = "aFile";
     UUID id = managedId();
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
 
     final File destinationFolder =
         Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, id.toString(), uploadId)
             .toFile();
 
-    assertThat(destinationFolder).exists().isDirectory();
+    assertThat(destinationFolder)
+        .exists()
+        .isDirectory();
 
     multipartStore.abortMultipartUpload(metadataFrom(TEST_BUCKET_NAME), id, uploadId);
   }
@@ -117,11 +126,12 @@ class MultipartStoreTest extends StoreTestBase {
     final String partNumber = "1";
     UUID id = managedId();
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
 
     multipartStore.putPart(
         metadataFrom(TEST_BUCKET_NAME), id, uploadId, partNumber,
-        new ByteArrayInputStream("Test".getBytes()), false, NO_ENC, NO_ENC_KEY);
+        new ByteArrayInputStream("Test".getBytes()), false, emptyMap());
     assertThat(
         Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, id.toString(), uploadId,
                 partNumber + ".part")
@@ -136,17 +146,18 @@ class MultipartStoreTest extends StoreTestBase {
     final String uploadId = "12345";
     UUID id = managedId();
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
     multipartStore
         .putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "1",
-            new ByteArrayInputStream("Part1".getBytes()), false, NO_ENC, NO_ENC_KEY);
+            new ByteArrayInputStream("Part1".getBytes()), false, emptyMap());
     multipartStore
         .putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "2",
-            new ByteArrayInputStream("Part2".getBytes()), false, NO_ENC, NO_ENC_KEY);
+            new ByteArrayInputStream("Part2".getBytes()), false, emptyMap());
 
     final String etag =
         multipartStore.completeMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-            uploadId, getParts(2), NO_ENC, NO_ENC_KEY);
+            uploadId, getParts(2), emptyMap());
     final byte[] allMd5s = ArrayUtils.addAll(
         DigestUtils.md5("Part1"),
         DigestUtils.md5("Part2")
@@ -168,16 +179,17 @@ class MultipartStoreTest extends StoreTestBase {
     final String uploadId = "12345";
     UUID id = managedId();
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
     multipartStore
         .putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "1",
-            new ByteArrayInputStream("Part1".getBytes()), false, NO_ENC, NO_ENC_KEY);
+            new ByteArrayInputStream("Part1".getBytes()), false, emptyMap());
     multipartStore
         .putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "2",
-            new ByteArrayInputStream("Part2".getBytes()), false, NO_ENC, NO_ENC_KEY);
+            new ByteArrayInputStream("Part2".getBytes()), false, emptyMap());
 
     multipartStore.completeMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id, uploadId,
-        getParts(2), NO_ENC, NO_ENC_KEY);
+        getParts(2), emptyMap());
 
     final S3ObjectMetadata s3ObjectMetadata =
         objectStore.getS3ObjectMetadata(metadataFrom(TEST_BUCKET_NAME), id);
@@ -206,12 +218,13 @@ class MultipartStoreTest extends StoreTestBase {
     final Part expectedPart2 = prepareExpectedPart(2, part2);
 
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
 
     multipartStore.putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "1", part1Stream, false,
-        NO_ENC, NO_ENC_KEY);
+        emptyMap());
     multipartStore.putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "2", part2Stream, false,
-        NO_ENC, NO_ENC_KEY);
+        emptyMap());
 
     List<Part> parts =
         multipartStore.getMultipartUploadParts(metadataFrom(TEST_BUCKET_NAME), id, uploadId);
@@ -240,13 +253,14 @@ class MultipartStoreTest extends StoreTestBase {
     final String uploadId = "12345";
     UUID id = managedId();
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
     multipartStore
         .putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "1",
-            new ByteArrayInputStream("Part1".getBytes()), false, NO_ENC, NO_ENC_KEY);
+            new ByteArrayInputStream("Part1".getBytes()), false, emptyMap());
 
     multipartStore.completeMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id, uploadId,
-        getParts(1), NO_ENC, NO_ENC_KEY);
+        getParts(1), emptyMap());
 
     assertThat(
         Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, fileName, uploadId)
@@ -263,7 +277,7 @@ class MultipartStoreTest extends StoreTestBase {
     BucketMetadata bucketMetadata = metadataFrom(TEST_BUCKET_NAME);
     final MultipartUpload initiatedUpload = multipartStore
         .prepareMultipartUpload(bucketMetadata, fileName, id, DEFAULT_CONTENT_TYPE, storeHeaders(),
-            uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+            uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA, emptyMap());
 
     final Collection<MultipartUpload> uploads =
         multipartStore.listMultipartUploads(TEST_BUCKET_NAME, NO_PREFIX);
@@ -275,7 +289,7 @@ class MultipartStoreTest extends StoreTestBase {
     assertThat(upload.getKey()).isEqualTo(fileName);
 
     multipartStore.completeMultipartUpload(bucketMetadata, fileName, id, uploadId, getParts(0),
-        NO_ENC, NO_ENC_KEY);
+        emptyMap());
 
     assertThat(multipartStore.listMultipartUploads(ALL_BUCKETS, NO_PREFIX)).isEmpty();
   }
@@ -290,14 +304,14 @@ class MultipartStoreTest extends StoreTestBase {
     UUID id1 = managedId();
     final MultipartUpload initiatedUpload1 = multipartStore
         .prepareMultipartUpload(metadataFrom(bucketName1), fileName1, id1, DEFAULT_CONTENT_TYPE,
-            storeHeaders(), uploadId1, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+            storeHeaders(), uploadId1, TEST_OWNER, TEST_OWNER, NO_USER_METADATA, emptyMap());
     final String fileName2 = "PartFile2";
     final String uploadId2 = "123452";
     final String bucketName2 = "bucket2";
     UUID id2 = managedId();
     final MultipartUpload initiatedUpload2 = multipartStore
         .prepareMultipartUpload(metadataFrom(bucketName2), fileName2, id2, DEFAULT_CONTENT_TYPE,
-            storeHeaders(), uploadId2, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+            storeHeaders(), uploadId2, TEST_OWNER, TEST_OWNER, NO_USER_METADATA, emptyMap());
 
     final Collection<MultipartUpload> uploads1 = multipartStore.listMultipartUploads(bucketName1,
         NO_PREFIX);
@@ -318,9 +332,9 @@ class MultipartStoreTest extends StoreTestBase {
     assertThat(upload2.getKey()).isEqualTo(fileName2);
 
     multipartStore.completeMultipartUpload(metadataFrom(bucketName1), fileName1, id1, uploadId1,
-        getParts(0), NO_ENC, NO_ENC_KEY);
+        getParts(0), emptyMap());
     multipartStore.completeMultipartUpload(metadataFrom(bucketName2), fileName2, id2, uploadId2,
-        getParts(0), NO_ENC, NO_ENC_KEY);
+        getParts(0), emptyMap());
 
     assertThat(multipartStore.listMultipartUploads(ALL_BUCKETS, NO_PREFIX)).isEmpty();
   }
@@ -333,9 +347,10 @@ class MultipartStoreTest extends StoreTestBase {
     final String uploadId = "12345";
     UUID id = managedId();
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), fileName, id,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
     multipartStore.putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, "1",
-        new ByteArrayInputStream("Part1".getBytes()), false, NO_ENC, NO_ENC_KEY);
+        new ByteArrayInputStream("Part1".getBytes()), false, emptyMap());
     assertThat(multipartStore.listMultipartUploads(TEST_BUCKET_NAME, NO_PREFIX)).hasSize(1);
 
     multipartStore.abortMultipartUpload(metadataFrom(TEST_BUCKET_NAME), id, uploadId);
@@ -364,15 +379,16 @@ class MultipartStoreTest extends StoreTestBase {
     final byte[] contentBytes = UUID.randomUUID().toString().getBytes();
     objectStore.storeS3ObjectMetadata(metadataFrom(TEST_BUCKET_NAME), sourceId, sourceFile,
         DEFAULT_CONTENT_TYPE, storeHeaders(), new ByteArrayInputStream(contentBytes), false,
-        NO_USER_METADATA, NO_ENC, NO_ENC_KEY, null, emptyList(), Owner.DEFAULT_OWNER);
+        NO_USER_METADATA, emptyMap(), null, emptyList(), Owner.DEFAULT_OWNER);
 
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), targetFile, destinationId,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
 
     HttpRange range = HttpRange.createByteRange(0, contentBytes.length);
     multipartStore.copyPart(
         metadataFrom(TEST_BUCKET_NAME), sourceId, range, partNumber,
-        metadataFrom(TEST_BUCKET_NAME), destinationId, uploadId);
+        metadataFrom(TEST_BUCKET_NAME), destinationId, uploadId, emptyMap());
     assertThat(
         Paths.get(rootFolder.getAbsolutePath(), TEST_BUCKET_NAME, destinationId.toString(),
                 uploadId, partNumber + ".part")
@@ -392,14 +408,15 @@ class MultipartStoreTest extends StoreTestBase {
     BucketMetadata bucketMetadata = metadataFrom(TEST_BUCKET_NAME);
     objectStore.storeS3ObjectMetadata(bucketMetadata, sourceId, sourceFile, DEFAULT_CONTENT_TYPE,
         storeHeaders(), new ByteArrayInputStream(contentBytes), false,
-        NO_USER_METADATA, NO_ENC, NO_ENC_KEY, null, emptyList(), Owner.DEFAULT_OWNER);
+        NO_USER_METADATA, emptyMap(), null, emptyList(), Owner.DEFAULT_OWNER);
 
     multipartStore.prepareMultipartUpload(bucketMetadata, targetFile, destinationId,
-        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        DEFAULT_CONTENT_TYPE, storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA,
+        emptyMap());
 
     multipartStore.copyPart(
         bucketMetadata, sourceId, null, partNumber,
-        bucketMetadata, destinationId, uploadId);
+        bucketMetadata, destinationId, uploadId, emptyMap());
 
     assertThat(
         Paths.get(bucketMetadata.getPath().toString(), destinationId.toString(),
@@ -414,7 +431,8 @@ class MultipartStoreTest extends StoreTestBase {
     IllegalStateException e = assertThrows(IllegalStateException.class, () ->
         multipartStore.copyPart(
             metadataFrom(TEST_BUCKET_NAME), UUID.randomUUID(), range, "1",
-            metadataFrom(TEST_BUCKET_NAME), UUID.randomUUID(), UUID.randomUUID().toString())
+            metadataFrom(TEST_BUCKET_NAME), UUID.randomUUID(), UUID.randomUUID().toString(),
+            emptyMap())
     );
 
     assertThat(e.getMessage()).isEqualTo("Missed preparing Multipart Request.");
@@ -427,21 +445,28 @@ class MultipartStoreTest extends StoreTestBase {
     UUID id = managedId();
 
     multipartStore.prepareMultipartUpload(metadataFrom(TEST_BUCKET_NAME), filename, id, TEXT_PLAIN,
-        storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA);
+        storeHeaders(), uploadId, TEST_OWNER, TEST_OWNER, NO_USER_METADATA, emptyMap());
     for (int i = 1; i < 11; i++) {
       final ByteArrayInputStream inputStream = new ByteArrayInputStream((i + "\n").getBytes());
 
       multipartStore.putPart(metadataFrom(TEST_BUCKET_NAME), id, uploadId, String.valueOf(i),
-          inputStream, false, NO_ENC, NO_ENC_KEY);
+          inputStream, false, emptyMap());
     }
     multipartStore.completeMultipartUpload(metadataFrom(TEST_BUCKET_NAME), filename, id, uploadId,
-        getParts(10), NO_ENC, NO_ENC_KEY);
+        getParts(10), emptyMap());
     final List<String> s = FileUtils
         .readLines(objectStore.getS3ObjectMetadata(metadataFrom(TEST_BUCKET_NAME), id)
                 .getDataPath().toFile(), "UTF8");
 
     assertThat(s).contains(rangeClosed(1, 10).mapToObj(Integer::toString)
         .collect(toList()).toArray(new String[] {}));
+  }
+
+  private Map<String, String> encryptionHeaders() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(X_AMZ_SERVER_SIDE_ENCRYPTION, TEST_ENC_TYPE);
+    headers.put(X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID, TEST_ENC_KEY);
+    return headers;
   }
 
   private Map<String, String> storeHeaders() {

--- a/server/src/test/java/com/adobe/testing/s3mock/store/StoreTestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/StoreTestBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2023 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -29,8 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 abstract class StoreTestBase {
   static final String TEST_BUCKET_NAME = "test-bucket";
   static final String TEST_FILE_PATH = "src/test/resources/sampleFile.txt";
-  static final String NO_ENC = null;
-  static final String NO_ENC_KEY = null;
   static final Map<String, String> NO_USER_METADATA = emptyMap();
   static final String TEST_ENC_TYPE = "aws:kms";
   static final String TEST_ENC_KEY = "aws:kms" + UUID.randomUUID();

--- a/server/src/test/java/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.java
@@ -84,7 +84,7 @@ class StoresWithExistingFileRootTest extends StoreTestBase {
     objectStore
         .storeS3ObjectMetadata(bucketMetadata, id, name, TEXT_PLAIN, storeHeaders(),
             Files.newInputStream(path), false,
-            emptyMap(), null, null, null, emptyList(), Owner.DEFAULT_OWNER);
+            emptyMap(), emptyMap(), null, emptyList(), Owner.DEFAULT_OWNER);
 
     S3ObjectMetadata object = objectStore.getS3ObjectMetadata(bucketMetadata, id);
 

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-common</artifactId>

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit4</artifactId>

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit5</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testcontainers/pom.xml
+++ b/testsupport/testcontainers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testcontainers</artifactId>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testng</artifactId>


### PR DESCRIPTION
## Description
Store and return all encryption headers

## Related Issue
Fixes #1178

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
