### PR TITLE
Consistent consumes / produces declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
 # Changelog
 
-**The current major version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration. 
-It will receive new features, dependency updates and bug fixes on a continuous basis.**
+**The CURRENT major version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration. 
+3.x will receive new features, dependency updates and bug fixes on a continuous basis.**
+
+**The DEPRECATED major version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+2.x may receive bug fixes and features, this will be best-effort only.**
 
 <!-- TOC -->
 * [Changelog](#changelog)
 * [PLANNED - 4.x - RELEASE TBD ~ late 2023 / early 2024](#planned---4x---release-tbd--late-2023--early-2024)
     * [Planned changes](#planned-changes)
-* [PLANNED - 3.x - RELEASE TBD ~ July 2023](#planned---3x---release-tbd--july-2023)
+* [CURRENT - 3.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---3x---this-version-is-under-active-development)
   * [3.2.0 - PLANNED](#320---planned)
   * [3.1.0 - PLANNED](#310---planned)
-  * [3.0.0 - PLANNED RELEASE TBD ~ July 2023](#300---planned-release-tbd--july-2023)
-* [CURRENT - 2.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---2x---this-version-is-under-active-development)
+  * [3.0.0 - PLANNED ~ July 2023](#300---planned--july-2023)
+* [DEPRECATED - 2.x](#deprecated---2x)
   * [2.17.0](#2170)
   * [2.16.0](#2160)
   * [2.15.1](#2151)
@@ -87,8 +90,6 @@ Running S3Mock in unit tests is still supported by using [TestContainers](https:
 
 **Once 4.x is released, 3.x may receive bug fixes and features, this will be best-effort only.**
 
-**Once 4.x is released, 2.x support will be best-effort entirely.**
-
 ### Planned changes
 
 * Features and fixes
@@ -101,12 +102,10 @@ Running S3Mock in unit tests is still supported by using [TestContainers](https:
 * Version updates
   * Bump java version from 17 to 21 (?)
 
-# PLANNED - 3.x - RELEASE TBD ~ July 2023
+# CURRENT - 3.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT
 Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
-**Once 3.x is released, 2.x may receive bug fixes and features, this will be best-effort only.**
-
-**Once 4.x is released, 3.x may receive bug fixes and features, this will be best-effort only.**
+**The current major version 3 will receive new features, dependency updates and bug fixes on a continuous basis.**
 
 ## 3.2.0 - PLANNED
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
@@ -128,7 +127,7 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Version updates
   * TBD
 
-## 3.0.0 - PLANNED RELEASE TBD ~ July 2023
+## 3.0.0 - PLANNED ~ July 2023
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Refactorings
@@ -144,14 +143,10 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * Bump java version from 8 to 17
     * This change is necessary, as Spring Framework 6 and Spring Boot 3 raise the baseline Java version from 8 to 17.
 
-# CURRENT - 2.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT
+# DEPRECATED - 2.x
 Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
-**The current major version 2 will receive new features, dependency updates and bug fixes on a continuous basis.**
-
-**Once 3.x is released, 2.x may receive bug fixes and features, this will be best-effort only.**
-
-**Once 4.x is released, 2.x support will be best-effort entirely.**
+**2.x is DEPRECATED and may receive bug fixes and features, this will be best-effort only.**
 
 ## 2.17.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
@@ -161,10 +156,10 @@ Version 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java
     * Support checksumAlgorithm where AWS SDK locally calculates the checksum and sends it as part of the request body.
     * Support checksum headers where clients can send an already calculated checksum for the backend to persist
     * Return checksum in getObject / putObject / headObject / getObjectAttributes
-* Refactorings
-  * TBD
+  * Consistent consumes / produces declarations (fixes #1208)
 * Version updates
-  * TBD
+  * Bump aws-v2.version from 2.20.96 to 2.20.98
+  * Bump aws-java-sdk-s3 from 1.12.499 to 1.12.501
 
 ## 2.16.0
 2.x is JDK8 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
@@ -81,6 +81,22 @@ internal class PlainHttpIT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedFailure(year = 2022,
+    reason = "No credentials sent in plain HTTP request")
+  fun testGetObject_withAcceptHeader(testInfo: TestInfo) {
+    val (targetBucket, _) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
+
+    val getObject = HttpGet("/$targetBucket/$UPLOAD_FILE_NAME")
+    getObject.addHeader(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN_VALUE)
+    val getObjectResponse: HttpResponse = httpClient.execute(
+      HttpHost(
+        host, httpPort
+      ), getObject
+    )
+    assertThat(getObjectResponse.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+  }
+
+  @Test
   @S3VerifiedFailure(year = 2023,
     reason = "No credentials sent in plain HTTP request")
   fun putHeadObject_withUserMetadata(testInfo: TestInfo) {

--- a/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
@@ -76,9 +76,7 @@ public class BucketController {
   @RequestMapping(
       value = "/",
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<ListAllMyBucketsResult> listBuckets() {
     ListAllMyBucketsResult listAllMyBucketsResult = bucketService.listBuckets();
@@ -171,9 +169,7 @@ public class BucketController {
           NOT_LIST_TYPE
       },
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<ObjectLockConfiguration> getObjectLockConfiguration(
       @PathVariable String bucketName) {
@@ -221,9 +217,7 @@ public class BucketController {
           NOT_LIST_TYPE
       },
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<BucketLifecycleConfiguration> getBucketLifecycleConfiguration(
       @PathVariable String bucketName) {
@@ -321,9 +315,7 @@ public class BucketController {
       },
       value = "/{bucketName:.+}",
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   @Deprecated
   public ResponseEntity<ListBucketResult> listObjects(
@@ -359,9 +351,7 @@ public class BucketController {
           LIST_TYPE_V2
       },
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<ListBucketResultV2> listObjectsV2(
       @PathVariable String bucketName,

--- a/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
@@ -110,9 +110,7 @@ public class MultipartController {
           UPLOADS
       },
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<ListMultipartUploadsResult> listMultipartUploads(
       @PathVariable String bucketName,
@@ -142,10 +140,7 @@ public class MultipartController {
           UPLOAD_ID,
           NOT_LIFECYCLE
       },
-      method = RequestMethod.DELETE,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      method = RequestMethod.DELETE
   )
   public ResponseEntity<Void> abortMultipartUpload(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
@@ -171,9 +166,7 @@ public class MultipartController {
           UPLOAD_ID
       },
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<ListPartsResult> listParts(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
@@ -257,9 +250,7 @@ public class MultipartController {
           PART_NUMBER
       },
       method = RequestMethod.PUT,
-      produces = {
-          APPLICATION_XML_VALUE
-      })
+      produces = APPLICATION_XML_VALUE)
   public ResponseEntity<CopyPartResult> uploadPartCopy(
       @PathVariable String bucketName,
       @PathVariable ObjectKey key,
@@ -305,9 +296,7 @@ public class MultipartController {
           UPLOADS
       },
       method = RequestMethod.POST,
-      produces = {
-          APPLICATION_XML_VALUE
-      })
+      produces = APPLICATION_XML_VALUE)
   public ResponseEntity<InitiateMultipartUploadResult> createMultipartUpload(
       @PathVariable String bucketName,
       @PathVariable ObjectKey key,
@@ -343,9 +332,7 @@ public class MultipartController {
           UPLOAD_ID
       },
       method = RequestMethod.POST,
-      produces = {
-          APPLICATION_XML_VALUE
-      })
+      produces = APPLICATION_XML_VALUE)
   public ResponseEntity<CompleteMultipartUploadResult> completeMultipartUpload(
       @PathVariable String bucketName,
       @PathVariable ObjectKey key,

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -62,8 +62,6 @@ import static org.springframework.http.HttpStatus.REQUESTED_RANGE_NOT_SATISFIABL
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 import com.adobe.testing.s3mock.dto.AccessControlPolicy;
-import com.adobe.testing.s3mock.dto.Checksum;
-import com.adobe.testing.s3mock.dto.ChecksumAlgorithm;
 import com.adobe.testing.s3mock.dto.CopyObjectResult;
 import com.adobe.testing.s3mock.dto.CopySource;
 import com.adobe.testing.s3mock.dto.Delete;
@@ -143,9 +141,8 @@ public class ObjectController {
           DELETE
       },
       method = RequestMethod.POST,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      consumes = APPLICATION_XML_VALUE,
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<DeleteResult> deleteObjects(
       @PathVariable String bucketName,
@@ -242,10 +239,7 @@ public class ObjectController {
           NOT_ACL,
           NOT_ATTRIBUTES
       },
-      method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      method = RequestMethod.GET
   )
   public ResponseEntity<StreamingResponseBody> getObject(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
@@ -330,9 +324,7 @@ public class ObjectController {
           ACL,
       },
       method = RequestMethod.GET,
-      produces = {
-          APPLICATION_XML_VALUE
-      }
+      produces = APPLICATION_XML_VALUE
   )
   public ResponseEntity<String> getObjectAcl(@PathVariable final String bucketName,
       @PathVariable ObjectKey key) throws JAXBException {
@@ -387,7 +379,7 @@ public class ObjectController {
       method = RequestMethod.PUT,
       consumes = APPLICATION_XML_VALUE
   )
-  public ResponseEntity<String> putObjectTagging(@PathVariable String bucketName,
+  public ResponseEntity<Void> putObjectTagging(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
       @RequestBody Tagging body) {
     bucketService.verifyBucketExists(bucketName);
@@ -443,7 +435,7 @@ public class ObjectController {
       method = RequestMethod.PUT,
       consumes = APPLICATION_XML_VALUE
   )
-  public ResponseEntity<String> putLegalHold(@PathVariable String bucketName,
+  public ResponseEntity<Void> putLegalHold(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
       @RequestBody LegalHold body) {
     bucketService.verifyBucketExists(bucketName);
@@ -642,9 +634,7 @@ public class ObjectController {
           NOT_ACL
       },
       method = RequestMethod.PUT,
-      produces = {
-          APPLICATION_XML_VALUE
-      })
+      produces = APPLICATION_XML_VALUE)
   public ResponseEntity<CopyObjectResult> copyObject(@PathVariable String bucketName,
       @PathVariable ObjectKey key,
       @RequestHeader(value = X_AMZ_COPY_SOURCE) CopySource copySource,


### PR DESCRIPTION
## Description
GetObject had a wrong "produces" declarations, some others were not consistent. AWS SDK does not send "Accept" headers, but if we're using plain HTTP requests, a 406 NOT_ACCEPTABLE is returned from Spring MVC when a request comes in and the "Accept" / "Content-Type" headers do not match the expectations.

## Related Issue
Fixes #1208

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
