### PR TITLE
Fix startup on existing data folder issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [CURRENT - 3.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---3x---this-version-is-under-active-development)
   * [3.2.0 - PLANNED](#320---planned)
   * [3.1.0 - PLANNED](#310---planned)
+  * [3.0.1](#301)
   * [3.0.0](#300)
 * [DEPRECATED - 2.x](#deprecated---2x)
   * [2.17.0](#2170)
@@ -129,6 +130,13 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * TBD
 * Version updates
   * TBD
+
+## 3.0.1
+3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Fix startup on existing data folder issues (fixes #1245)
+  * Return checksumAlgorithm in ListObjects / ListObjectsV2 (fixes #1220)
 
 ## 3.0.0
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class BucketStore {
 
   private static final Logger LOG = LoggerFactory.getLogger(BucketStore.class);
-  private static final String BUCKET_META_FILE = "bucketMetadata.json";
+  static final String BUCKET_META_FILE = "bucketMetadata.json";
   /**
    * This map stores one lock object per Bucket name.
    * Any method modifying the underlying file must aquire the lock object before the modification.

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
@@ -407,10 +407,11 @@ public class MultipartStore {
 
   private boolean createPartsFolder(BucketMetadata bucket, UUID id, String uploadId) {
     var partsFolder = getPartsFolderPath(bucket, id, uploadId).toFile();
-    if (!retainFilesOnExit) {
+    var created = partsFolder.mkdirs();
+    if (created && !retainFilesOnExit) {
       partsFolder.deleteOnExit();
     }
-    return partsFolder.mkdirs();
+    return created;
   }
 
   private Path getPartsFolderPath(BucketMetadata bucket, UUID id, String uploadId) {

--- a/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
@@ -53,11 +53,14 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.xml.stream.XMLStreamException;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Stores objects and their metadata created in S3Mock.
  */
 public class ObjectStore {
+  private static final Logger LOG = LoggerFactory.getLogger(ObjectStore.class);
   private static final String META_FILE = "objectMetadata.json";
   private static final String ACL_FILE = "objectAcl.xml";
   private static final String DATA_FILE = "binaryData";
@@ -401,10 +404,15 @@ public class ObjectStore {
   }
 
   void loadObjects(BucketMetadata bucketMetadata, Collection<UUID> ids) {
+    var loaded = 0;
     for (var id : ids) {
       lockStore.putIfAbsent(id, new Object());
-      getS3ObjectMetadata(bucketMetadata, id);
+      var s3ObjectMetadata = getS3ObjectMetadata(bucketMetadata, id);
+      if (s3ObjectMetadata != null) {
+        loaded++;
+      }
     }
+    LOG.info("Loaded {}/{} objects for bucket {}", loaded, ids.size(), bucketMetadata.name());
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
@@ -460,7 +460,9 @@ public class ObjectStore {
    */
   private void createObjectRootFolder(BucketMetadata bucket, UUID id) {
     var objectRootFolder = getObjectFolderPath(bucket, id).toFile();
-    objectRootFolder.mkdirs();
+    if (objectRootFolder.mkdirs() && !retainFilesOnExit) {
+      objectRootFolder.deleteOnExit();
+    }
   }
 
   private Path getObjectFolderPath(BucketMetadata bucket, UUID id) {

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
@@ -25,7 +25,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +76,7 @@ public class StoreConfiguration {
 
   @Bean
   List<String> bucketNames(File rootFolder) {
-    var buckets = rootFolder.listFiles((File dir, String name) -> !Objects.equals(name, "test"));
+    var buckets = rootFolder.listFiles();
     if (buckets != null) {
       return Arrays.stream(buckets).map(File::getName).toList();
     } else {

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
@@ -16,14 +16,15 @@
 
 package com.adobe.testing.s3mock.store;
 
+import static com.adobe.testing.s3mock.store.BucketStore.BUCKET_META_FILE;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -76,12 +77,21 @@ public class StoreConfiguration {
 
   @Bean
   List<String> bucketNames(File rootFolder) {
-    var buckets = rootFolder.listFiles();
-    if (buckets != null) {
-      return Arrays.stream(buckets).map(File::getName).toList();
-    } else {
-      return Collections.emptyList();
+    var bucketNames = new ArrayList<String>();
+    try (var paths = Files.newDirectoryStream(rootFolder.toPath())) {
+      paths.forEach(
+          path ->  {
+            var resolved = path.resolve(BUCKET_META_FILE);
+            if (resolved.toFile().exists()) {
+              bucketNames.add(path.getFileName().toString());
+            }
+          }
+      );
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not load buckets from data directory "
+          + rootFolder, e);
     }
+    return bucketNames;
   }
 
   @Bean


### PR DESCRIPTION
## Description
* Always delete directories if retainFilesOnExit==false
* Do not exclude buckets called "test"
* Lock bucket when loading its objects
* Log # of objects loaded for each bucket.

## Related Issue
Fixes #1224

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
