### PR TITLE
Adding project map link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Kotlin](https://img.shields.io/badge/MADE%20with-Kotlin-RED.svg)](#Kotlin)  
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7673/badge)](https://bestpractices.coreinfrastructure.org/projects/7673)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/adobe/S3Mock?label=openssf%20scorecard&style=flat)](https://api.securityscorecards.dev/projects/github.com/adobe/S3Mock)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/adobes3mock/)
 [![GitHub stars](https://img.shields.io/github/stars/adobe/S3Mock.svg?style=social&label=Star&maxAge=2592000)](https://github.com/adobe/S3Mock/stargazers/)
 
 <!-- TOC -->


### PR DESCRIPTION
## Description
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/adobes3mock/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.