### PR TITLE
Support initial and existing buckets

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [PLANNED - 4.x - RELEASE TBD ~ late 2023 / early 2024](#planned---4x---release-tbd--late-2023--early-2024)
     * [Planned changes](#planned-changes)
 * [CURRENT - 3.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---3x---this-version-is-under-active-development)
+  * [3.4.0 - PLANNED](#340---planned)
   * [3.3.0 - PLANNED](#330---planned)
   * [3.2.0](#320)
   * [3.1.0](#310)
@@ -112,7 +113,7 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 
 **The current major version 3 will receive new features, dependency updates and bug fixes on a continuous basis.**
 
-## 3.3.0 - PLANNED
+## 3.4.0 - PLANNED
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
@@ -121,6 +122,33 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * TBD
 * Version updates
   * TBD
+
+## 3.3.0
+3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Support initial and existing buckets (fixes #1433)
+  * Compile with "parameters=true" (fixes #1555)
+* Version updates
+  * Bump com.amazonaws:aws-java-sdk-s3 from 1.12.580 to 1.12.627
+  * Bump aws-v2.version from 2.21.14 to 2.22.7
+  * Bump commons-io:commons-io from 2.15.0 to 2.15.1
+  * Bump testcontainers.version from 1.19.1 to 1.19.3
+  * Bump kotlin.version from 1.9.20 to 1.9.22
+  * Bump alpine from 3.18.4 to 3.19.0 in /docker
+  * Bump org.testng:testng from 7.8.0 to 7.9.0
+  * Bump org.mockito.kotlin:mockito-kotlin from 5.1.0 to 5.2.1
+  * Bump com.puppycrawl.tools:checkstyle from 10.12.4 to 10.12.6
+  * Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.2.1 to 3.2.3
+  * Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.1 to 3.2.3
+  * Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.0 to 3.6.2
+  * Bump org.apache.maven.plugins:maven-compiler-plugin from 3.11.0 to 3.12.1
+  * Bump actions/setup-java from 3.13.0 to 4.0.0
+  * Bump step-security/harden-runner from 2.6.0 to 2.6.1
+  * Bump actions/dependency-review-action from 3.1.0 to 3.1.4
+  * Bump actions/upload-artifact from 3.1.3 to 4.0.0
+  * Bump github/codeql-action from 2.22.5 to 3.22.12
+  * Bump mvn version from 3.5.4 to 3.8.5
 
 ## 3.2.0
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-build-config</artifactId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-docker</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-integration-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,7 @@
           <configuration>
             <release>${java.version}</release>
             <encoding>${project.build.sourceEncoding}</encoding>
+            <parameters>true</parameters>
           </configuration>
           <executions>
             <!-- Replacing default-compile as it is treated specially by maven -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/src/test/java/com/adobe/testing/s3mock/store/StoreConfigurationTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/StoreConfigurationTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright 2017-2023 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class StoreConfigurationTest {
+  private static final String BUCKET_META_FILE = "bucketMetadata.json";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  void bucketCreation_noExistingBuckets(@TempDir Path tempDir) throws IOException {
+    var initialBucketName = "initialBucketName";
+
+    var properties = new StoreProperties(false, null, Set.of(), List.of(initialBucketName));
+    var iut = new StoreConfiguration();
+    var bucketStore = iut.bucketStore(properties, tempDir.toFile(), List.of(), OBJECT_MAPPER);
+    assertThat(bucketStore.getBucketMetadata(initialBucketName).name())
+        .isEqualTo(initialBucketName);
+
+    var createdBuckets = new ArrayList<Path>();
+    try (var paths = Files.newDirectoryStream(tempDir)) {
+      paths.forEach(
+          createdBuckets::add
+      );
+    }
+    assertThat(createdBuckets).hasSize(1);
+    assertThat(createdBuckets.get(0).getFileName()).hasToString(initialBucketName);
+    assertThat(bucketStore.getBucketMetadata(initialBucketName).path())
+        .isEqualTo(createdBuckets.get(0));
+  }
+
+
+  @Test
+  void bucketCreation_existingBuckets(@TempDir Path tempDir) throws IOException {
+    var existingBucketName = "existingBucketName";
+    var existingBucket = Paths.get(tempDir.toAbsolutePath().toString(), existingBucketName);
+    FileUtils.forceMkdir(existingBucket.toFile());
+    var bucketMetadata =
+        new BucketMetadata(existingBucketName, Instant.now().toString(),
+            null, null, existingBucket);
+    Path metaFile = Paths.get(existingBucket.toString(), BUCKET_META_FILE);
+    OBJECT_MAPPER.writeValue(metaFile.toFile(), bucketMetadata);
+
+    var initialBucketName = "initialBucketName";
+
+    var properties = new StoreProperties(false, null, Set.of(), List.of(initialBucketName));
+    var iut = new StoreConfiguration();
+    var bucketStore =
+        iut.bucketStore(properties, tempDir.toFile(), List.of(existingBucketName), OBJECT_MAPPER);
+
+    assertThat(bucketStore.getBucketMetadata(initialBucketName).name())
+        .isEqualTo(initialBucketName);
+
+    var createdBuckets = new ArrayList<Path>();
+    try (var paths = Files.newDirectoryStream(tempDir)) {
+      paths.forEach(
+          createdBuckets::add
+      );
+    }
+    assertThat(createdBuckets)
+        .hasSize(2)
+        .containsAll(List.of(bucketStore.getBucketMetadata(existingBucketName).path(),
+            bucketStore.getBucketMetadata(initialBucketName).path())
+        )
+        .extracting(Path::getFileName)
+        .containsAll(List.of(Path.of(existingBucketName), Path.of(initialBucketName)));
+  }
+}

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-common</artifactId>

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit4</artifactId>

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit5</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testcontainers/pom.xml
+++ b/testsupport/testcontainers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testcontainers</artifactId>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testng</artifactId>


### PR DESCRIPTION
## Description
Let S3Mock load existing buckets and create initial buckets if they do not already exist.

## Related Issue
#1433 

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
