### PR TITLE
Add support for StorageClass

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,10 @@ on: [pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-ci-and-prb.yml
+++ b/.github/workflows/maven-ci-and-prb.yml
@@ -27,6 +27,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,6 +17,10 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * [PLANNED - 4.x - RELEASE TBD ~ late 2023 / early 2024](#planned---4x---release-tbd--late-2023--early-2024)
     * [Planned changes](#planned-changes)
 * [CURRENT - 3.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---3x---this-version-is-under-active-development)
-  * [3.4.0 - PLANNED](#340---planned)
+  * [3.5.0 - PLANNED](#350---planned)
+  * [3.4.0](#340)
   * [3.3.0](#330)
   * [3.2.0](#320)
   * [3.1.0](#310)
@@ -113,15 +114,38 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 
 **The current major version 3 will receive new features, dependency updates and bug fixes on a continuous basis.**
 
-## 3.4.0 - PLANNED
+## 3.5.0 - PLANNED
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
   * Support Versions in APIs
+  * Add "DeleteObjectTagging" API
 * Refactorings
   * TBD
 * Version updates
   * TBD
+
+## 3.4.0
+3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Support storage classes in APIs
+  * Use "application/octet-stream" as default content-type
+* Refactorings
+  * Use JDK21 as runtime in the Docker container
+* Version updates
+  * Bump spring-boot.version from 3.2.1 to 3.2.2
+  * Bump aws-v2.version from 2.22.7 to 2.23.21
+  * Bump com.amazonaws:aws-java-sdk-s3 from 1.12.627 to 1.12.656
+  * Bump testcontainers.version from 1.19.3 to 1.19.5
+  * Bump com.puppycrawl.tools:checkstyle from 10.12.6 to 10.13.0
+  * Bump alpine from 3.19.0 to 3.19.1 in /docker
+  * Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.2.3 to 3.2.5
+  * Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.3 to 3.2.5
+  * Bump github/codeql-action from 3.22.12 to 3.24.0
+  * Bump actions/upload-artifact from 4.0.0 to 4.3.1
+  * Bump actions/dependency-review-action from 3.1.4 to 4.0.0
+  * Bump step-security/harden-runner from 2.6.1 to 2.7.0
 
 ## 3.3.0
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017-2023 Adobe.
+#  Copyright 2017-2024 Adobe.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 FROM alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48 as staging_area
 
-RUN apk --no-cache add openjdk17-jdk openjdk17-jmods
+RUN apk --no-cache add openjdk21-jdk openjdk21-jmods
 
 ENV JAVA_MINIMAL="/opt/java-minimal"
 
 #TODO: running jdeps does not work with spring-boot 2.5 or later.
-#TODO: supposedly this will be fixed in Java 18.
+#TODO: Still not working with Java 21
 #FROM staging_area as builder
 # prepare dependencies for jdeps/jlink
 #COPY ./target/s3mock-exec.jar s3mock.jar
@@ -59,7 +59,7 @@ ENV JAVA_MINIMAL="/opt/java-minimal"
 #TODO: creating "static" minimal JRE here. Activate jdeps again later
 # create a minimal jdk assembly with those modules that we need
 RUN jlink \
-    --module-path $JAVA_HOME/jmods \
+    --module-path "$JAVA_HOME"/jmods \
     --verbose \
     --add-modules java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.crypto.ec \
     --compress 2 \

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -155,7 +155,7 @@
                     <initialBuckets>bucket-a, bucket-b</initialBuckets>
                     <COM_ADOBE_TESTING_S3MOCK_REGION>eu-west-1</COM_ADOBE_TESTING_S3MOCK_REGION>
                   </env>
-                  <memory>128000000</memory>
+                  <memory>192000000</memory>
                 </run>
               </image>
             </images>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -42,18 +42,16 @@ internal class BucketV1IT : S3TestBase() {
     // the returned creation date might strip off the millisecond-part, resulting in rounding down
     // and account for a clock-skew in the Docker container of up to a minute.
     val creationDate = Date(System.currentTimeMillis() / 1000 * 1000 - 60000)
-    assertThat(bucket.name)
-      .`as`("Bucket name should match '$bucketName'!")
-      .isEqualTo(bucketName)
-    val buckets = s3Client.listBuckets().stream().filter { b: Bucket -> bucketName == b.name }
+    assertThat(bucket.name).isEqualTo(bucketName)
+    val buckets = s3Client.listBuckets().stream()
+      .filter { b: Bucket -> bucketName == b.name }
       .collect(Collectors.toList())
-    assertThat(buckets).`as`("Expecting one bucket").hasSize(1)
+    assertThat(buckets).hasSize(1)
     val createdBucket = buckets[0]
     assertThat(createdBucket.creationDate).isAfterOrEqualTo(creationDate)
     val bucketOwner = createdBucket.owner
     assertThat(bucketOwner.displayName).isEqualTo("s3-mock-file-store")
-    assertThat(bucketOwner.id)
-      .isEqualTo("79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be")
+    assertThat(bucketOwner.id).isEqualTo("79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be")
   }
 
   @Test
@@ -67,7 +65,6 @@ internal class BucketV1IT : S3TestBase() {
       .collect(Collectors.toSet())
     assertThat(bucketNames)
       .containsAll(INITIAL_BUCKET_NAMES)
-      .`as`("Not all default Buckets got created")
   }
 
   @Test
@@ -78,9 +75,7 @@ internal class BucketV1IT : S3TestBase() {
     s3Client.headBucket(HeadBucketRequest(bucketName))
     s3Client.deleteBucket(bucketName)
     val doesBucketExist = s3Client.doesBucketExistV2(bucketName)
-    assertThat(doesBucketExist)
-      .`as`("Deleted Bucket should not exist!")
-      .isFalse
+    assertThat(doesBucketExist).isFalse
   }
 
   @Test
@@ -101,9 +96,7 @@ internal class BucketV1IT : S3TestBase() {
     val bucketName = bucketName(testInfo)
     s3Client.createBucket(bucketName)
     val doesBucketExist = s3Client.doesBucketExistV2(bucketName)
-    assertThat(doesBucketExist)
-      .`as`("The previously created bucket, '$bucketName', should exist!")
-      .isTrue
+    assertThat(doesBucketExist).isTrue
   }
 
   @Test
@@ -111,9 +104,7 @@ internal class BucketV1IT : S3TestBase() {
   fun testBucketDoesExistV2_failure(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
     val doesBucketExist = s3Client.doesBucketExistV2(bucketName)
-    assertThat(doesBucketExist)
-      .`as`("The bucket, '$bucketName', should not exist!")
-      .isFalse
+    assertThat(doesBucketExist).isFalse
   }
 
   @Test

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV1IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -54,9 +54,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val copiedObject = s3Client.getObject(destinationBucketName, destinationKey)
     val copiedDigest = DigestUtil.hexDigest(copiedObject.objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
   }
 
   @Test
@@ -74,9 +72,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val copiedObject = s3Client.getObject(destinationBucketName, destinationKey)
     val copiedDigest = DigestUtil.hexDigest(copiedObject.objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
   }
 
   @Test
@@ -94,9 +90,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val copiedObject = s3Client.getObject(destinationBucketName, destinationKey)
     val copiedDigest = DigestUtil.hexDigest(copiedObject.objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
   }
 
   @Test
@@ -169,9 +163,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val objectContent = copiedObject.objectContent
     val copiedDigest = DigestUtil.hexDigest(objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
   }
 
   /**
@@ -202,17 +194,13 @@ internal class CopyObjectV1IT : S3TestBase() {
     s3Client.copyObject(copyObjectRequest)
     val copiedObject = s3Client.getObject(bucketName, sourceKey)
     val copiedObjectMetadata = copiedObject.objectMetadata
-    assertThat(copiedObjectMetadata.userMetadata["test-key"])
-      .`as`("Original userMetadata must have been replaced.")
-      .isNullOrEmpty()
+    assertThat(copiedObjectMetadata.userMetadata["test-key"]).isNullOrEmpty()
     assertThat(copiedObjectMetadata.userMetadata["test-key2"]).isEqualTo("test-value2")
 
     val objectContent = copiedObject.objectContent
     val copiedDigest = DigestUtil.hexDigest(objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
   }
 
   /**
@@ -237,12 +225,8 @@ internal class CopyObjectV1IT : S3TestBase() {
     val copiedObject = s3Client.getObject(destinationBucketName, destinationKey)
     val copiedDigest = DigestUtil.hexDigest(copiedObject.objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
-    assertThat(copiedObject.objectMetadata.userMetadata)
-      .`as`("User metadata should be identical!")
-      .isEqualTo(objectMetadata.userMetadata)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
+    assertThat(copiedObject.objectMetadata.userMetadata).isEqualTo(objectMetadata.userMetadata)
   }
 
   /**
@@ -270,12 +254,8 @@ internal class CopyObjectV1IT : S3TestBase() {
     val copiedObject = s3Client.getObject(destinationBucketName, destinationKey)
     val copiedDigest = DigestUtil.hexDigest(copiedObject.objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
-    assertThat(copiedObject.objectMetadata.userMetadata)
-      .`as`("User metadata should be identical!")
-      .isEqualTo(sourceObjectMetadata.userMetadata)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
+    assertThat(copiedObject.objectMetadata.userMetadata).isEqualTo(sourceObjectMetadata.userMetadata)
   }
 
   /**
@@ -298,9 +278,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val copiedObject = s3Client.getObject(destinationBucketName, destinationKey)
     val copiedDigest = DigestUtil.hexDigest(copiedObject.objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
   }
 
   /**
@@ -323,9 +301,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val copiedObject = s3Client.getObject(destinationBucketName, destinationKey)
     val copiedDigest = DigestUtil.hexDigest(copiedObject.objectContent)
     copiedObject.close()
-    assertThat(copiedDigest)
-      .`as`("Source file and copied File should have same digests")
-      .isEqualTo(putObjectResult.eTag)
+    assertThat(copiedDigest).isEqualTo(putObjectResult.eTag)
   }
 
   /**
@@ -349,12 +325,8 @@ internal class CopyObjectV1IT : S3TestBase() {
     val metadata = s3Client.getObjectMetadata(destinationBucketName, destinationKey)
     val uploadFileIs: InputStream = FileInputStream(uploadFile)
     val uploadDigest = DigestUtil.hexDigest(TEST_ENC_KEY_ID, uploadFileIs)
-    assertThat(copyObjectResult.eTag)
-      .`as`("ETag should match")
-      .isEqualTo(uploadDigest)
-    assertThat(metadata.contentLength)
-      .`as`("Files should have the same length")
-      .isEqualTo(uploadFile.length())
+    assertThat(copyObjectResult.eTag).isEqualTo(uploadDigest)
+    assertThat(metadata.contentLength).isEqualTo(uploadFile.length())
   }
 
   /**
@@ -417,8 +389,6 @@ internal class CopyObjectV1IT : S3TestBase() {
     )
     val copyResult = copy.waitForCopyResult()
     assertThat(copyResult.destinationKey).isEqualTo(assumedDestinationKey)
-    assertThat(uploadResult.eTag)
-      .`as`("Hashes for source and target S3Object do not match.")
-      .isEqualTo(copyResult.eTag)
+    assertThat(uploadResult.eTag).isEqualTo(copyResult.eTag)
   }
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CrtAsyncV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CrtAsyncV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -171,19 +171,15 @@ internal class CrtAsyncV2IT : S3TestBase() {
     )
 
     // verify special etag
-    assertThat(completeMultipartUploadResponse.eTag())
-      .`as`("Special etag doesn't match.")
-      .isEqualTo("\"" + DigestUtils.md5Hex(allMd5s) + "-2" + "\"")
+    assertThat(completeMultipartUploadResponse.eTag()).isEqualTo("\"" + DigestUtils.md5Hex(allMd5s) + "-2" + "\"")
 
     // verify content size
     assertThat(getObjectResponse.response().contentLength())
-      .`as`("Content length doesn't match")
       .isEqualTo(randomBytes.size.toLong() + uploadFileBytes.size.toLong())
 
     // verify contents
-    assertThat(readStreamIntoByteArray(getObjectResponse.asInputStream())).`as`(
-      "Object contents doesn't match"
-    ).isEqualTo(concatByteArrays(randomBytes, uploadFileBytes))
+    assertThat(readStreamIntoByteArray(getObjectResponse.asInputStream()))
+      .isEqualTo(concatByteArrays(randomBytes, uploadFileBytes))
 
     assertThat(completeMultipartUploadResponse.location())
       .matches("http.*/$bucketName/src%2Ftest%2Fresources%2FsampleFile.txt")

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -83,8 +83,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
 
     assertThat(objectAttributes.eTag()).isEqualTo(eTag)
     assertThat(objectAttributes.storageClass()).isEqualTo(StorageClass.STANDARD)
-    assertThat(objectAttributes.objectSize())
-      .isEqualTo(File(UPLOAD_FILE_NAME).length())
+    assertThat(objectAttributes.objectSize()).isEqualTo(File(UPLOAD_FILE_NAME).length())
     assertThat(objectAttributes.checksum().checksumSHA1()).isEqualTo(expectedChecksum)
   }
 
@@ -153,9 +152,9 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(key)
         .build()
-    )
-
-    assertThat(putObjectResponse.eTag()).isEqualTo(getObjectResponse.response().eTag())
+    ).use {
+      assertThat(putObjectResponse.eTag()).isEqualTo(it.response().eTag())
+    }
   }
 
   /**
@@ -183,9 +182,9 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(key)
         .build()
-    )
-
-    assertThat(putObjectResponse.eTag()).isEqualTo(getObjectResponse.response().eTag())
+    ).use {
+      assertThat(putObjectResponse.eTag()).isEqualTo(it.response().eTag())
+    }
   }
 
   @Test
@@ -211,10 +210,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    val getChecksum = getObjectResponse.response().checksumSHA1()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+    ).use {
+      val getChecksum = it.response().checksumSHA1()
+      assertThat(getChecksum).isNotBlank
+      assertThat(getChecksum).isEqualTo(expectedChecksum)
+    }
   }
 
   @Test
@@ -240,10 +240,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    val getChecksum = getObjectResponse.response().checksumSHA256()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+    ).use {
+      val getChecksum = it.response().checksumSHA256()
+      assertThat(getChecksum).isNotBlank
+      assertThat(getChecksum).isEqualTo(expectedChecksum)
+    }
   }
 
   @Test
@@ -269,10 +270,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    val getChecksum = getObjectResponse.response().checksumSHA256()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+    ).use {
+      val getChecksum = it.response().checksumSHA256()
+      assertThat(getChecksum).isNotBlank
+      assertThat(getChecksum).isEqualTo(expectedChecksum)
+    }
   }
 
   @Test
@@ -298,10 +300,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    val getChecksum = getObjectResponse.response().checksumCRC32()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+    ).use {
+      val getChecksum = it.response().checksumCRC32()
+      assertThat(getChecksum).isNotBlank
+      assertThat(getChecksum).isEqualTo(expectedChecksum)
+    }
   }
 
   @Test
@@ -327,10 +330,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    val getChecksum = getObjectResponse.response().checksumCRC32()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+    ).use {
+      val getChecksum = it.response().checksumCRC32()
+      assertThat(getChecksum).isNotBlank
+      assertThat(getChecksum).isEqualTo(expectedChecksum)
+    }
   }
 
   @Test
@@ -357,10 +361,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    val getChecksum = getObjectResponse.response().checksumCRC32C()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+    ).use {
+      val getChecksum = it.response().checksumCRC32C()
+      assertThat(getChecksum).isNotBlank
+      assertThat(getChecksum).isEqualTo(expectedChecksum)
+    }
   }
 
   @Test
@@ -387,10 +392,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    val getChecksum = getObjectResponse.response().checksumCRC32C()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+    ).use {
+      val getChecksum = it.response().checksumCRC32C()
+      assertThat(getChecksum).isNotBlank
+      assertThat(getChecksum).isEqualTo(expectedChecksum)
+    }
   }
 
   @Test
@@ -401,7 +407,6 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     givenObjectV2(bucket1, UPLOAD_FILE_NAME)
     givenObjectV2(bucket2, UPLOAD_FILE_NAME)
     getObjectV2(bucket1, UPLOAD_FILE_NAME)
-    val object2 = getObjectV2(bucket2, UPLOAD_FILE_NAME)
 
     deleteObjectV2(bucket1, UPLOAD_FILE_NAME)
     Assertions.assertThatThrownBy {
@@ -409,8 +414,10 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }.isInstanceOf(S3Exception::class.java)
       .hasMessageContaining("Service: S3, Status Code: 404")
 
-    val object2Again = getObjectV2(bucket2, UPLOAD_FILE_NAME)
-    assertThat(object2.response().eTag()).isEqualTo(object2Again.response().eTag())
+    getObjectV2(bucket2, UPLOAD_FILE_NAME)
+      .use {
+        assertThat(getObjectV2(bucket2, UPLOAD_FILE_NAME).response().eTag()).isEqualTo(it.response().eTag())
+      }
   }
 
   @Test
@@ -448,12 +455,9 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     // time in second precision, see
     // https://www.rfc-editor.org/rfc/rfc7234#section-5.3
     // https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
-    assertThat(getObjectResponseResponse.response().expires())
-      .isEqualTo(expires.truncatedTo(ChronoUnit.SECONDS))
-    assertThat(getObjectResponseResponse.response().contentLanguage())
-      .isEqualTo(contentLanguage)
-    assertThat(getObjectResponseResponse.response().cacheControl())
-      .isEqualTo(cacheControl)
+    assertThat(getObjectResponseResponse.response().expires()).isEqualTo(expires.truncatedTo(ChronoUnit.SECONDS))
+    assertThat(getObjectResponseResponse.response().contentLanguage()).isEqualTo(contentLanguage)
+    assertThat(getObjectResponseResponse.response().cacheControl()).isEqualTo(cacheControl)
 
     val headObjectResponse = s3ClientV2.headObject(
       HeadObjectRequest.builder()
@@ -478,14 +482,15 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val (bucketName, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
     val eTag = putObjectResponse.eTag()
     assertThat(eTag).isEqualTo(matchingEtag)
-    val responseInputStream = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .ifMatch(matchingEtag)
         .build()
-    )
-    assertThat(responseInputStream.response().eTag()).isEqualTo(eTag)
+    ).use {
+      assertThat(it.response().eTag()).isEqualTo(eTag)
+    }
   }
 
   @Test
@@ -496,14 +501,15 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val matchingEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
 
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
-    val responseInputStream = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .ifMatch(matchingEtag)
         .build()
-    )
-    assertThat(responseInputStream.response().contentLength()).isEqualTo(uploadFile.length())
+    ).use {
+      assertThat(it.response().contentLength()).isEqualTo(uploadFile.length())
+    }
   }
 
   @Test
@@ -513,14 +519,15 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val eTag = putObjectResponse.eTag()
     val matchingEtag = "\"*\""
 
-    val responseInputStream = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .ifMatch(matchingEtag)
         .build()
-    )
-    assertThat(responseInputStream.response().eTag()).isEqualTo(eTag)
+    ).use {
+      assertThat(it.response().eTag()).isEqualTo(eTag)
+    }
   }
 
   @Test
@@ -609,9 +616,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .range("bytes=1-2")
         .build()
     )
-    assertThat(smallObject.response().contentLength())
-      .`as`("Invalid file length")
-      .isEqualTo(2L)
+    assertThat(smallObject.response().contentLength()).isEqualTo(2L)
     assertThat(smallObject.response().contentRange()).isEqualTo("bytes 1-2/36")
 
     val largeObject = s3ClientV2.getObject(
@@ -620,11 +625,10 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(UPLOAD_FILE_NAME)
         .range("bytes=0-1000")
         .build()
-    )
-    assertThat(largeObject.response().contentLength())
-      .`as`("Invalid file length")
-      .isEqualTo(36L)
-    assertThat(largeObject.response().contentRange()).isEqualTo("bytes 0-35/36")
+    ).use {
+      assertThat(it.response().contentLength()).isEqualTo(36L)
+      assertThat(it.response().contentRange()).isEqualTo("bytes 0-35/36")
+    }
   }
 
   @Test
@@ -639,11 +643,10 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .range("bytes=4500-")
         .build()
-    )
-    assertThat(largeObject.response().contentLength())
-      .`as`("Invalid file length")
-      .isEqualTo(5238380L)
-    assertThat(largeObject.response().contentRange()).isEqualTo("bytes 4500-5242879/5242880")
+    ).use {
+      assertThat(it.response().contentLength()).isEqualTo(5238380L)
+      assertThat(it.response().contentRange()).isEqualTo("bytes 4500-5242879/5242880")
+    }
   }
 
   @Test
@@ -658,11 +661,10 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .range("bytes=-500")
         .build()
-    )
-    assertThat(getObject.response().contentLength())
-      .`as`("Invalid file length")
-      .isEqualTo(500L)
-    assertThat(getObject.response().contentRange()).isEqualTo("bytes 5242380-5242879/5242880")
+    ).use {
+      assertThat(it.response().contentLength()).isEqualTo(500L)
+      assertThat(it.response().contentRange()).isEqualTo("bytes 5242380-5242879/5242880")
+    }
   }
 
   /**
@@ -703,12 +705,12 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-
-    assertThat(getObject.response().ssekmsKeyId()).isEqualTo(TEST_ENC_KEY_ID)
-    assertThat(getObject.response().sseCustomerAlgorithm()).isEqualTo(sseCustomerAlgorithm)
-    assertThat(getObject.response().sseCustomerKeyMD5()).isEqualTo(sseCustomerKeyMD5)
-    assertThat(getObject.response().serverSideEncryption()).isEqualTo(ServerSideEncryption.AWS_KMS)
+    ).use {
+      assertThat(it.response().ssekmsKeyId()).isEqualTo(TEST_ENC_KEY_ID)
+      assertThat(it.response().sseCustomerAlgorithm()).isEqualTo(sseCustomerAlgorithm)
+      assertThat(it.response().sseCustomerKeyMD5()).isEqualTo(sseCustomerKeyMD5)
+      assertThat(it.response().serverSideEncryption()).isEqualTo(ServerSideEncryption.AWS_KMS)
+    }
   }
 
   private fun givenObjectV2WithRandomBytes(bucketName: String): String {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
@@ -17,8 +17,8 @@
 package com.adobe.testing.s3mock.its
 
 import com.adobe.testing.s3mock.util.DigestUtil
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.springframework.http.ContentDisposition
@@ -41,6 +41,41 @@ import java.time.temporal.ChronoUnit
 internal class GetPutDeleteObjectV2IT : S3TestBase() {
 
   @Test
+  @S3VerifiedTodo
+  fun testPutObject_storageClass(testInfo: TestInfo) {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val bucketName = givenBucketV2(testInfo)
+
+    val key = UPLOAD_FILE_NAME
+
+    s3ClientV2.putObject(
+      PutObjectRequest.builder()
+        .bucket(bucketName)
+        .key(key)
+        .storageClass(StorageClass.DEEP_ARCHIVE)
+        .build(),
+      RequestBody.fromFile(uploadFile)
+    )
+
+    val headObjectResponse = s3ClientV2.headObject(
+      HeadObjectRequest.builder()
+        .bucket(bucketName)
+        .key(key)
+        .build()
+    )
+    assertThat(headObjectResponse.storageClass()).isEqualTo(StorageClass.DEEP_ARCHIVE)
+
+    s3ClientV2.getObject(
+      GetObjectRequest.builder()
+        .bucket(bucketName)
+        .key(key)
+        .build()
+    ).use {
+      assertThat(it.response().storageClass()).isEqualTo(StorageClass.DEEP_ARCHIVE)
+    }
+  }
+
+  @Test
   @S3VerifiedSuccess(year = 2022)
   fun testPutObject_etagCreation(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
@@ -54,6 +89,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_getObjectAttributes(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "+AXXQmKfnxMv0B57SJutbNpZBww="
@@ -88,6 +124,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checksumAlgorithm_sha1(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "+AXXQmKfnxMv0B57SJutbNpZBww="
@@ -147,7 +184,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(key)
@@ -177,7 +214,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(key)
@@ -188,6 +225,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checkSum_sha1(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "+AXXQmKfnxMv0B57SJutbNpZBww="
@@ -205,7 +243,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         assertThat(putChecksum).isNotBlank
         assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -218,6 +256,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checksumAlgorithm_sha256(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "1VcEifAruhjVvjzul4sC0B1EmlUdzqvsp6BP0KSVdTE="
@@ -235,7 +274,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         assertThat(putChecksum).isNotBlank
         assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -248,6 +287,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checkSum_sha256(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "1VcEifAruhjVvjzul4sC0B1EmlUdzqvsp6BP0KSVdTE="
@@ -265,7 +305,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         assertThat(putChecksum).isNotBlank
         assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -278,6 +318,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checksumAlgorithm_crc32(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "I6zdvg=="
@@ -295,7 +336,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         assertThat(putChecksum).isNotBlank
         assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -308,6 +349,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checkSum_crc32(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "I6zdvg=="
@@ -325,7 +367,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         assertThat(putChecksum).isNotBlank
         assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -338,6 +380,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checksumAlgorithm_crc32c(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "/Ho1Kg=="
@@ -356,7 +399,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         assertThat(putChecksum).isNotBlank
         assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -369,6 +412,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutObject_checkSum_crc32c(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "/Ho1Kg=="
@@ -387,7 +431,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         assertThat(putChecksum).isNotBlank
         assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -409,7 +453,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     getObjectV2(bucket1, UPLOAD_FILE_NAME)
 
     deleteObjectV2(bucket1, UPLOAD_FILE_NAME)
-    Assertions.assertThatThrownBy {
+    assertThatThrownBy {
       getObjectV2(bucket1, UPLOAD_FILE_NAME)
     }.isInstanceOf(S3Exception::class.java)
       .hasMessageContaining("Service: S3, Status Code: 404")
@@ -421,6 +465,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
+  @S3VerifiedTodo
   fun testPutGetHeadObject_storeHeaders(testInfo: TestInfo) {
     val bucket = givenRandomBucketV2()
     val uploadFile = File(UPLOAD_FILE_NAME)
@@ -566,7 +611,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val eTag = putObjectResponse.eTag()
     assertThat(eTag).isEqualTo(expectedEtag)
 
-    Assertions.assertThatThrownBy {
+    assertThatThrownBy {
       s3ClientV2.headObject(
         HeadObjectRequest.builder()
           .bucket(bucketName)
@@ -591,7 +636,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val eTag = putObjectResponse.eTag()
     assertThat(eTag).isEqualTo(expectedEtag)
 
-    Assertions.assertThatThrownBy {
+    assertThatThrownBy {
       s3ClientV2.headObject(
         HeadObjectRequest.builder()
           .bucket(bucketName)
@@ -619,7 +664,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     assertThat(smallObject.response().contentLength()).isEqualTo(2L)
     assertThat(smallObject.response().contentRange()).isEqualTo("bytes 1-2/36")
 
-    val largeObject = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -637,7 +682,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val bucketName = givenBucketV2(testInfo)
     val key = givenObjectV2WithRandomBytes(bucketName)
 
-    val largeObject = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(key)
@@ -655,7 +700,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val bucketName = givenBucketV2(testInfo)
     val key = givenObjectV2WithRandomBytes(bucketName)
 
-    val getObject = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(key)
@@ -700,7 +745,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     assertThat(putObject.sseCustomerKeyMD5()).isEqualTo(sseCustomerKeyMD5)
     assertThat(putObject.serverSideEncryption()).isEqualTo(ServerSideEncryption.AWS_KMS)
 
-    val getObject = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -104,16 +104,12 @@ internal class ListObjectV1IT : S3TestBase() {
         .map { toEncode: String? -> SdkHttpUtils.urlEncodeIgnoreSlashes(toEncode) }
         .toTypedArray()
     }
-    assertThat(l.objectSummaries.stream().map { obj: S3ObjectSummary -> obj.key }
-      .collect(Collectors.toList()))
-      .`as`("Returned keys are correct")
-      .containsExactlyInAnyOrderElementsOf(listOf(*parameters.expectedKeys))
-    assertThat(ArrayList(l.commonPrefixes))
-      .`as`("Returned prefixes are correct")
-      .containsExactlyInAnyOrderElementsOf(listOf(*expectedPrefixes))
-    assertThat(l.encodingType)
-      .`as`("Returned encodingType is correct")
-      .isEqualTo(parameters.expectedEncoding)
+    assertThat(l.objectSummaries.stream()
+      .map { obj: S3ObjectSummary -> obj.key }
+      .collect(Collectors.toList())
+    ).containsExactlyInAnyOrderElementsOf(listOf(*parameters.expectedKeys))
+    assertThat(ArrayList(l.commonPrefixes)).containsExactlyInAnyOrderElementsOf(listOf(*expectedPrefixes))
+    assertThat(l.encodingType).isEqualTo(parameters.expectedEncoding)
   }
 
   /**
@@ -147,17 +143,13 @@ internal class ListObjectV1IT : S3TestBase() {
     )
     // listV2 automatically decodes the keys so the expected keys have to be decoded
     val expectedDecodedKeys = parameters.decodedKeys()
-    assertThat(l.objectSummaries.stream().map { obj: S3ObjectSummary -> obj.key }
-      .collect(Collectors.toList()))
-      .`as`("Returned keys are correct")
-      .containsExactlyInAnyOrderElementsOf(listOf(*expectedDecodedKeys))
+    assertThat(l.objectSummaries.stream()
+      .map { obj: S3ObjectSummary -> obj.key }
+      .collect(Collectors.toList())
+    ).containsExactlyInAnyOrderElementsOf(listOf(*expectedDecodedKeys))
     // AmazonS3#listObjectsV2 returns decoded prefixes
-    assertThat(ArrayList(l.commonPrefixes))
-      .`as`("Returned prefixes are correct")
-      .containsExactlyInAnyOrderElementsOf(listOf(*parameters.expectedPrefixes))
-    assertThat(l.encodingType)
-      .`as`("Returned encodingType is correct")
-      .isEqualTo(parameters.expectedEncoding)
+    assertThat(ArrayList(l.commonPrefixes)).containsExactlyInAnyOrderElementsOf(listOf(*parameters.expectedPrefixes))
+    assertThat(l.encodingType).isEqualTo(parameters.expectedEncoding)
   }
 
   /**
@@ -178,12 +170,8 @@ internal class ListObjectV1IT : S3TestBase() {
     s3Client.putObject(PutObjectRequest(bucketName, key, uploadFile))
     val listing = s3Client.listObjects(bucketName, prefix)
     val summaries = listing.objectSummaries
-    assertThat(summaries)
-      .`as`("Must have exactly one match")
-      .hasSize(1)
-    assertThat(summaries[0].key)
-      .`as`("Object name must match")
-      .isEqualTo(key)
+    assertThat(summaries).hasSize(1)
+    assertThat(summaries[0].key).isEqualTo(key)
   }
 
   /**
@@ -209,12 +197,8 @@ internal class ListObjectV1IT : S3TestBase() {
     request.encodingType = "url" // do use encoding!
     val listing = s3Client.listObjectsV2(request)
     val summaries = listing.objectSummaries
-    assertThat(summaries)
-      .`as`("Must have exactly one match")
-      .hasSize(1)
-    assertThat(summaries[0].key)
-      .`as`("Object name must match")
-      .isEqualTo(key)
+    assertThat(summaries).hasSize(1)
+    assertThat(summaries[0].key).isEqualTo(key)
   }
 
 
@@ -241,12 +225,8 @@ internal class ListObjectV1IT : S3TestBase() {
 
     val listing = s3Client.listObjects(lor)
     val summaries = listing.objectSummaries
-    assertThat(summaries)
-      .`as`("Must have exactly one match")
-      .hasSize(1)
-    assertThat(summaries[0].key)
-      .`as`("Object name must match")
-      .isEqualTo("shouldHonorEncodingType/%01")
+    assertThat(summaries).hasSize(1)
+    assertThat(summaries[0].key).isEqualTo("shouldHonorEncodingType/%01")
   }
 
   /**
@@ -268,12 +248,8 @@ internal class ListObjectV1IT : S3TestBase() {
 
     val listing = s3Client.listObjectsV2(request)
     val summaries = listing.objectSummaries
-    assertThat(summaries)
-      .`as`("Must have exactly one match")
-      .hasSize(1)
-    assertThat(summaries[0].key)
-      .`as`("Object name must match")
-      .isEqualTo("shouldHonorEncodingType/\u0001")
+    assertThat(summaries).hasSize(1)
+    assertThat(summaries[0].key).isEqualTo("shouldHonorEncodingType/\u0001")
   }
 
   @Test
@@ -284,12 +260,8 @@ internal class ListObjectV1IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     s3Client.putObject(PutObjectRequest(bucketName, UPLOAD_FILE_NAME, uploadFile))
     val objectListingResult = s3Client.listObjects(bucketName, UPLOAD_FILE_NAME)
-    assertThat(objectListingResult.objectSummaries)
-      .`as`("ObjectListing has no S3Objects.")
-      .hasSizeGreaterThan(0)
-    assertThat(objectListingResult.objectSummaries[0].key)
-      .`as`("The Name of the first S3ObjectSummary item has not expected the key name.")
-      .isEqualTo(UPLOAD_FILE_NAME)
+    assertThat(objectListingResult.objectSummaries).hasSizeGreaterThan(0)
+    assertThat(objectListingResult.objectSummaries[0].key).isEqualTo(UPLOAD_FILE_NAME)
   }
 
   /**
@@ -319,10 +291,8 @@ internal class ListObjectV1IT : S3TestBase() {
         uploadFile.name + "copy2", uploadFile
       )
     )
-    val listReq = ListObjectsV2Request()
-      .withBucketName(bucketName)
-      .withMaxKeys(3)
-    val listResult = s3Client.listObjectsV2(listReq)
+    val request = ListObjectsV2Request().withBucketName(bucketName).withMaxKeys(3)
+    val listResult = s3Client.listObjectsV2(request)
     assertThat(listResult.keyCount).isEqualTo(3)
     for (objectSummary in listResult.objectSummaries) {
       assertThat(objectSummary.key).contains(uploadFile.name)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -46,8 +46,7 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2022)
   fun returnsAllObjectsIfMaxKeysEqualToAmountOfObjects(testInfo: TestInfo) {
     val bucketName = givenBucketWithTwoObjects(testInfo)
-    val request = ListObjectsRequest().withBucketName(bucketName)
-      .withMaxKeys(2)
+    val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(2)
     val objectListing = s3Client.listObjects(request)
     assertThat(objectListing.objectSummaries).hasSize(2)
     assertThat(objectListing.maxKeys).isEqualTo(2)
@@ -57,8 +56,7 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2022)
   fun returnsAllObjectsIfMaxKeysMoreThanAmountOfObjects(testInfo: TestInfo) {
     val bucketName = givenBucketWithTwoObjects(testInfo)
-    val request = ListObjectsRequest().withBucketName(bucketName)
-      .withMaxKeys(3)
+    val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(3)
     val objectListing = s3Client.listObjects(request)
     assertThat(objectListing.objectSummaries).hasSize(2)
     assertThat(objectListing.maxKeys).isEqualTo(3)
@@ -68,8 +66,7 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2022)
   fun returnsEmptyListIfMaxKeysIsZero(testInfo: TestInfo) {
     val bucketName = givenBucketWithTwoObjects(testInfo)
-    val request = ListObjectsRequest().withBucketName(bucketName)
-      .withMaxKeys(0)
+    val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(0)
     val objectListing = s3Client.listObjects(request)
     assertThat(objectListing.objectSummaries).hasSize(0)
     assertThat(objectListing.maxKeys).isEqualTo(0)
@@ -79,8 +76,7 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2022)
   fun returnsAllObjectsIfMaxKeysIsNegative(testInfo: TestInfo) {
     val bucketName = givenBucketWithTwoObjects(testInfo)
-    val request = ListObjectsRequest().withBucketName(bucketName)
-      .withMaxKeys(-1)
+    val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(-1)
     val objectListing = s3Client.listObjects(request)
 
     // Apparently, the Amazon SDK rejects negative max keys, and by default it's 1000

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -134,12 +134,8 @@ internal class ListObjectV2IT : S3TestBase() {
         .build()
     )
     val summaries = listing.contents()
-    assertThat(summaries)
-      .`as`("Must have exactly one match")
-      .hasSize(1)
-    assertThat(summaries[0].key())
-      .`as`("Object name must match")
-      .isEqualTo(key)
+    assertThat(summaries).hasSize(1)
+    assertThat(summaries[0].key()).isEqualTo(key)
   }
 
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV1IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -36,19 +36,15 @@ internal class ObjectTaggingV1IT : S3TestBase() {
     val (bucketName, _) = givenBucketAndObjectV1(testInfo, UPLOAD_FILE_NAME)
     val s3Object = s3Client.getObject(bucketName, UPLOAD_FILE_NAME)
 
-    val tagList: MutableList<Tag> = ArrayList()
     val tag = Tag("foo", "bar")
-    tagList.add(tag)
-    val setObjectTaggingRequest =
-      SetObjectTaggingRequest(bucketName, s3Object.key, ObjectTagging(tagList))
+    val tagList: MutableList<Tag> = mutableListOf(tag)
+    val setObjectTaggingRequest = SetObjectTaggingRequest(bucketName, s3Object.key, ObjectTagging(tagList))
     s3Client.setObjectTagging(setObjectTaggingRequest)
     val getObjectTaggingRequest = GetObjectTaggingRequest(bucketName, s3Object.key)
     val getObjectTaggingResult = s3Client.getObjectTagging(getObjectTaggingRequest)
 
     // There should be 'foo:bar' here
-    assertThat(getObjectTaggingResult.tagSet)
-      .`as`("Couldn't find that the tag that was placed")
-      .hasSize(1)
+    assertThat(getObjectTaggingResult.tagSet).hasSize(1)
     assertThat(getObjectTaggingResult.tagSet).contains(tag)
   }
 
@@ -57,27 +53,20 @@ internal class ObjectTaggingV1IT : S3TestBase() {
   fun testPutObjectAndGetObjectTagging_withTagging(testInfo: TestInfo) {
     val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
-    val tagList: MutableList<Tag> = ArrayList()
-    tagList.add(Tag("foo", "bar"))
     val putObjectRequest = PutObjectRequest(
       bucketName,
       uploadFile.name,
       uploadFile
     )
-      .withTagging(ObjectTagging(tagList))
+      .withTagging(ObjectTagging(mutableListOf(Tag("foo", "bar"))))
     s3Client.putObject(putObjectRequest)
     val s3Object = s3Client.getObject(bucketName, uploadFile.name)
-    val getObjectTaggingRequest =
-      GetObjectTaggingRequest(bucketName, s3Object.key)
+    val getObjectTaggingRequest = GetObjectTaggingRequest(bucketName, s3Object.key)
     val getObjectTaggingResult = s3Client.getObjectTagging(getObjectTaggingRequest)
 
     // There should be 'foo:bar' here
-    assertThat(getObjectTaggingResult.tagSet)
-      .`as`("Couldn't find that the tag that was placed")
-      .hasSize(1)
-    assertThat(getObjectTaggingResult.tagSet[0].value)
-      .`as`("The value of the tag placed did not match")
-      .isEqualTo("bar")
+    assertThat(getObjectTaggingResult.tagSet).hasSize(1)
+    assertThat(getObjectTaggingResult.tagSet[0].value).isEqualTo("bar")
   }
 
   /**
@@ -88,11 +77,9 @@ internal class ObjectTaggingV1IT : S3TestBase() {
   fun testPutObjectAndGetObjectTagging_multipleTags(testInfo: TestInfo) {
     val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
-    val tagList: MutableList<Tag> = ArrayList()
     val tag1 = Tag("foo1", "bar1")
     val tag2 = Tag("foo2", "bar2")
-    tagList.add(tag1)
-    tagList.add(tag2)
+    val tagList: MutableList<Tag> = mutableListOf(tag1, tag2)
     val putObjectRequest = PutObjectRequest(
       bucketName,
       uploadFile.name,

--- a/pom.xml
+++ b/pom.xml
@@ -292,25 +292,29 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>${license-maven-plugin-git.version}</version>
           <configuration>
-            <header>etc/license-template.txt</header>
             <strictCheck>true</strictCheck>
-            <excludes>
-              <exclude>.idea/**</exclude>
-              <exclude>.springBeans</exclude>
-              <exclude>.editorconfig</exclude>
-              <exclude>**/*.jks</exclude>
-              <exclude>**/sample*.txt</exclude>
-              <exclude>COPYRIGHT</exclude>
-              <exclude>LICENSE</exclude>
-              <exclude>AUTHORS</exclude>
-              <exclude>README.md</exclude>
-              <exclude>.github/workflows/**</exclude>
-              <exclude>CONTRIBUTING.md</exclude>
-              <exclude>.gitattributes</exclude>
-              <exclude>.gitignore</exclude>
-              <exclude>.pre-commit-config.yaml</exclude>
-              <exclude>src/main/resources/banner.txt</exclude>
-            </excludes>
+            <licenseSets>
+              <licenseSet>
+                <header>etc/license-template.txt</header>
+                <excludes>
+                  <exclude>.idea/**</exclude>
+                  <exclude>.springBeans</exclude>
+                  <exclude>.editorconfig</exclude>
+                  <exclude>**/*.jks</exclude>
+                  <exclude>**/sample*.txt</exclude>
+                  <exclude>COPYRIGHT</exclude>
+                  <exclude>LICENSE</exclude>
+                  <exclude>AUTHORS</exclude>
+                  <exclude>README.md</exclude>
+                  <exclude>.github/workflows/**</exclude>
+                  <exclude>CONTRIBUTING.md</exclude>
+                  <exclude>.gitattributes</exclude>
+                  <exclude>.gitignore</exclude>
+                  <exclude>.pre-commit-config.yaml</exclude>
+                  <exclude>src/main/resources/banner.txt</exclude>
+                </excludes>
+              </licenseSet>
+            </licenseSets>
             <mapping>
               <java>SLASHSTAR_STYLE</java>
             </mapping>

--- a/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/BucketController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -145,6 +145,8 @@ public class BucketController {
   )
   public ResponseEntity<Void> headBucket(@PathVariable final String bucketName) {
     bucketService.verifyBucketExists(bucketName);
+    //return bucket region
+    //return bucket location
     return ResponseEntity.ok().build();
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/GetObjectAttributesOutput.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/GetObjectAttributesOutput.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -50,6 +50,6 @@ public record GetObjectAttributesOutput(
         metadata.etag(),
         null,
         Long.valueOf(metadata.size()),
-        null);
+        metadata.storageClass());
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectVersion.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ObjectVersion.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -53,15 +53,25 @@ public record ObjectVersion(
 
   public static ObjectVersion from(S3ObjectMetadata s3ObjectMetadata) {
     return new ObjectVersion(s3ObjectMetadata.key(),
-        s3ObjectMetadata.modificationDate(), s3ObjectMetadata.etag(),
-        s3ObjectMetadata.size(), StorageClass.STANDARD, Owner.DEFAULT_OWNER,
-        s3ObjectMetadata.checksumAlgorithm(), true, "staticVersion");
+        s3ObjectMetadata.modificationDate(),
+        s3ObjectMetadata.etag(),
+        s3ObjectMetadata.size(),
+        s3ObjectMetadata.storageClass(),
+        s3ObjectMetadata.owner(),
+        s3ObjectMetadata.checksumAlgorithm(),
+        true,
+        "staticVersion");
   }
 
   public static ObjectVersion from(S3Object s3Object) {
     return new ObjectVersion(s3Object.key(),
-        s3Object.lastModified(), s3Object.etag(),
-        s3Object.size(), StorageClass.STANDARD, Owner.DEFAULT_OWNER,
-        s3Object.checksumAlgorithm(), true, "staticVersion");
+        s3Object.lastModified(),
+        s3Object.etag(),
+        s3Object.size(),
+        s3Object.storageClass(),
+        s3Object.owner(),
+        s3Object.checksumAlgorithm(),
+        true,
+        "staticVersion");
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/S3Object.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/S3Object.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -50,8 +50,11 @@ public record S3Object(
 
   public static S3Object from(S3ObjectMetadata s3ObjectMetadata) {
     return new S3Object(s3ObjectMetadata.key(),
-        s3ObjectMetadata.modificationDate(), s3ObjectMetadata.etag(),
-        s3ObjectMetadata.size(), StorageClass.STANDARD, Owner.DEFAULT_OWNER,
+        s3ObjectMetadata.modificationDate(),
+        s3ObjectMetadata.etag(),
+        s3ObjectMetadata.size(),
+        s3ObjectMetadata.storageClass(),
+        s3ObjectMetadata.owner(),
         s3ObjectMetadata.checksumAlgorithm());
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/service/MultipartService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/MultipartService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static com.adobe.testing.s3mock.S3Exception.INVALID_PART_ORDER;
 import static com.adobe.testing.s3mock.S3Exception.NO_SUCH_UPLOAD_MULTIPART;
 
 import com.adobe.testing.s3mock.S3Exception;
+import com.adobe.testing.s3mock.dto.ChecksumAlgorithm;
 import com.adobe.testing.s3mock.dto.CompleteMultipartUploadResult;
 import com.adobe.testing.s3mock.dto.CompletedPart;
 import com.adobe.testing.s3mock.dto.CopyPartResult;
@@ -31,6 +32,7 @@ import com.adobe.testing.s3mock.dto.ListMultipartUploadsResult;
 import com.adobe.testing.s3mock.dto.ListPartsResult;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Part;
+import com.adobe.testing.s3mock.dto.StorageClass;
 import com.adobe.testing.s3mock.store.BucketStore;
 import com.adobe.testing.s3mock.store.MultipartStore;
 import java.io.InputStream;
@@ -203,16 +205,35 @@ public class MultipartService {
    *
    * @return upload result
    */
-  public InitiateMultipartUploadResult prepareMultipartUpload(String bucketName, String key,
-      String contentType, Map<String, String> storeHeaders, String uploadId,
-      Owner owner, Owner initiator, Map<String, String> userMetadata,
-      Map<String, String> encryptionHeaders) {
+  public InitiateMultipartUploadResult prepareMultipartUpload(String bucketName,
+      String key,
+      String contentType,
+      Map<String, String> storeHeaders,
+      String uploadId,
+      Owner owner,
+      Owner initiator,
+      Map<String, String> userMetadata,
+      Map<String, String> encryptionHeaders,
+      StorageClass storageClass,
+      String checksum,
+      ChecksumAlgorithm checksumAlgorithm) {
     var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
     var id = bucketStore.addToBucket(key, bucketName);
 
     try {
-      multipartStore.prepareMultipartUpload(bucketMetadata, key, id, contentType, storeHeaders,
-          uploadId, owner, initiator, userMetadata, encryptionHeaders);
+      multipartStore.prepareMultipartUpload(bucketMetadata,
+          key,
+          id,
+          contentType,
+          storeHeaders,
+          uploadId,
+          owner,
+          initiator,
+          userMetadata,
+          encryptionHeaders,
+          storageClass,
+          checksum,
+          checksumAlgorithm);
       return new InitiateMultipartUploadResult(bucketName, key, uploadId);
     } catch (Exception e) {
       //something went wrong with writing the destination file, clean up ID from BucketStore.

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import com.adobe.testing.s3mock.dto.DeletedS3Object;
 import com.adobe.testing.s3mock.dto.LegalHold;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Retention;
+import com.adobe.testing.s3mock.dto.StorageClass;
 import com.adobe.testing.s3mock.dto.Tag;
 import com.adobe.testing.s3mock.store.BucketStore;
 import com.adobe.testing.s3mock.store.ObjectStore;
@@ -130,7 +131,8 @@ public class ObjectService {
       List<Tag> tags,
       ChecksumAlgorithm checksumAlgorithm,
       String checksum,
-      Owner owner) {
+      Owner owner,
+      StorageClass storageClass) {
     var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
     var id = bucketMetadata.getID(key);
     if (id == null) {
@@ -138,7 +140,7 @@ public class ObjectService {
     }
     return objectStore.storeS3ObjectMetadata(bucketMetadata, id, key, contentType, storeHeaders,
         dataStream, useV4ChunkedWithSigningFormat, userMetadata, encryptionHeaders, null, tags,
-        checksumAlgorithm, checksum, owner);
+        checksumAlgorithm, checksum, owner, storageClass);
   }
 
   public DeleteResult deleteObjects(String bucketName, Delete delete) {

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartUploadInfo.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartUploadInfo.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package com.adobe.testing.s3mock.store;
 
+import com.adobe.testing.s3mock.dto.ChecksumAlgorithm;
 import com.adobe.testing.s3mock.dto.MultipartUpload;
+import com.adobe.testing.s3mock.dto.StorageClass;
 import java.util.Map;
 
 /**
@@ -27,6 +29,9 @@ record MultipartUploadInfo(MultipartUpload upload,
                            Map<String, String> userMetadata,
                            Map<String, String> storeHeaders,
                            Map<String, String> encryptionHeaders,
-                           String bucket) {
+                           String bucket,
+                           StorageClass storageClass,
+                           String checksum,
+                           ChecksumAlgorithm checksumAlgorithm) {
 
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/ObjectStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.adobe.testing.s3mock.dto.Grantee;
 import com.adobe.testing.s3mock.dto.LegalHold;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Retention;
+import com.adobe.testing.s3mock.dto.StorageClass;
 import com.adobe.testing.s3mock.dto.Tag;
 import com.adobe.testing.s3mock.util.AwsChecksumInputStream;
 import com.adobe.testing.s3mock.util.AwsChunkedDecodingChecksumInputStream;
@@ -113,7 +114,8 @@ public class ObjectStore {
       List<Tag> tags,
       ChecksumAlgorithm checksumAlgorithm,
       String checksum,
-      Owner owner) {
+      Owner owner,
+      StorageClass storageClass) {
     lockStore.putIfAbsent(id, new Object());
     synchronized (lockStore.get(id)) {
       createObjectRootFolder(bucket, id);
@@ -144,7 +146,8 @@ public class ObjectStore {
           storeHeaders,
           encryptionHeaders,
           checksumAlgorithm,
-          checksum
+          checksum,
+          storageClass
       );
       writeMetafile(bucket, s3ObjectMetadata);
       return s3ObjectMetadata;
@@ -183,7 +186,8 @@ public class ObjectStore {
           s3ObjectMetadata.storeHeaders(),
           s3ObjectMetadata.encryptionHeaders(),
           s3ObjectMetadata.checksumAlgorithm(),
-          s3ObjectMetadata.checksum()
+          s3ObjectMetadata.checksum(),
+          s3ObjectMetadata.storageClass()
       ));
     }
   }
@@ -215,7 +219,8 @@ public class ObjectStore {
           s3ObjectMetadata.storeHeaders(),
           s3ObjectMetadata.encryptionHeaders(),
           s3ObjectMetadata.checksumAlgorithm(),
-          s3ObjectMetadata.checksum()
+          s3ObjectMetadata.checksum(),
+          s3ObjectMetadata.storageClass()
       ));
     }
   }
@@ -267,7 +272,8 @@ public class ObjectStore {
           s3ObjectMetadata.storeHeaders(),
           s3ObjectMetadata.encryptionHeaders(),
           s3ObjectMetadata.checksumAlgorithm(),
-          s3ObjectMetadata.checksum()
+          s3ObjectMetadata.checksum(),
+          s3ObjectMetadata.storageClass()
       ));
     }
   }
@@ -334,7 +340,9 @@ public class ObjectStore {
             sourceObject.tags(),
             sourceObject.checksumAlgorithm(),
             sourceObject.checksum(),
-            sourceObject.owner());
+            sourceObject.owner(),
+            sourceObject.storageClass()
+        );
         return new CopyObjectResult(copiedObject.modificationDate(), copiedObject.etag());
       } catch (IOException e) {
         throw new IllegalStateException("Could not write object binary-file.", e);
@@ -373,7 +381,8 @@ public class ObjectStore {
         sourceObject.storeHeaders(),
         sourceObject.encryptionHeaders(),
         sourceObject.checksumAlgorithm(),
-        sourceObject.checksum()
+        sourceObject.checksum(),
+        sourceObject.storageClass()
     ));
     return new CopyObjectResult(sourceObject.modificationDate(), sourceObject.etag());
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.adobe.testing.s3mock.dto.ChecksumAlgorithm;
 import com.adobe.testing.s3mock.dto.LegalHold;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Retention;
+import com.adobe.testing.s3mock.dto.StorageClass;
 import com.adobe.testing.s3mock.dto.Tag;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import org.springframework.http.MediaType;
 
 /**
  * Represents an object in S3, used to serialize and deserialize all metadata locally.
@@ -51,17 +53,17 @@ public record S3ObjectMetadata(
     Map<String, String> storeHeaders,
     Map<String, String> encryptionHeaders,
     ChecksumAlgorithm checksumAlgorithm,
-    String checksum
+    String checksum,
+    StorageClass storageClass
 ) {
-
-  private static final String DEFAULT_CONTENT_TYPE = "binary/octet-stream";
 
   public S3ObjectMetadata {
     etag = normalizeEtag(etag);
-    contentType = Objects.requireNonNullElse(contentType, DEFAULT_CONTENT_TYPE);
+    contentType = Objects.requireNonNullElse(contentType, MediaType.APPLICATION_OCTET_STREAM_VALUE);
     userMetadata = userMetadata == null ? Collections.emptyMap() : userMetadata;
     tags = Objects.requireNonNullElse(tags, new ArrayList<>());
     storeHeaders = storeHeaders == null ? Collections.emptyMap() : storeHeaders;
     encryptionHeaders = encryptionHeaders == null ? Collections.emptyMap() : encryptionHeaders;
+    storageClass = storageClass == null ? StorageClass.STANDARD : storageClass;
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/AwsHttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ public final class AwsHttpHeaders {
   public static final String X_AMZ_CHECKSUM_CRC32C = "x-amz-checksum-crc32c";
   public static final String X_AMZ_CHECKSUM_SHA1 = "x-amz-checksum-sha1";
   public static final String X_AMZ_CHECKSUM_SHA256 = "x-amz-checksum-sha256";
+  public static final String X_AMZ_STORAGE_CLASS = "x-amz-storage-class";
 
   private AwsHttpHeaders() {
     // private constructor for utility classes

--- a/server/src/main/java/com/adobe/testing/s3mock/util/HeaderUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/HeaderUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public final class HeaderUtil {
       "STREAMING-AWS4-HMAC-SHA256-PAYLOAD";
   private static final String STREAMING_AWS_4_HMAC_SHA_256_PAYLOAD_TRAILER =
       "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER";
-  private static final MediaType FALLBACK_MEDIA_TYPE = new MediaType("binary", "octet-stream");
+  private static final MediaType FALLBACK_MEDIA_TYPE = MediaType.APPLICATION_OCTET_STREAM;
 
   private HeaderUtil() {
     // private constructor for utility classes

--- a/server/src/test/java/com/adobe/testing/s3mock/ObjectControllerTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/ObjectControllerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import com.adobe.testing.s3mock.dto.Grantee;
 import com.adobe.testing.s3mock.dto.Mode;
 import com.adobe.testing.s3mock.dto.Owner;
 import com.adobe.testing.s3mock.dto.Retention;
+import com.adobe.testing.s3mock.dto.StorageClass;
 import com.adobe.testing.s3mock.dto.Tag;
 import com.adobe.testing.s3mock.dto.TagSet;
 import com.adobe.testing.s3mock.dto.Tagging;
@@ -120,7 +121,8 @@ class ObjectControllerTest {
         isNull(),
         isNull(),
         isNull(),
-        eq(Owner.DEFAULT_OWNER))
+        eq(Owner.DEFAULT_OWNER),
+        eq(StorageClass.STANDARD))
     ).thenReturn(s3ObjectMetadata(key, digest));
 
     var headers = new HttpHeaders();
@@ -157,7 +159,8 @@ class ObjectControllerTest {
         isNull(),
         isNull(),
         isNull(),
-        eq(Owner.DEFAULT_OWNER))
+        eq(Owner.DEFAULT_OWNER),
+        eq(StorageClass.STANDARD))
     ).thenReturn(s3ObjectMetadata(key, digest));
 
     var optionsResponse = restTemplate.optionsForAllow("/test-bucket/" + key);
@@ -200,7 +203,8 @@ class ObjectControllerTest {
         isNull(),
         isNull(),
         isNull(),
-        eq(Owner.DEFAULT_OWNER))
+        eq(Owner.DEFAULT_OWNER),
+        eq(StorageClass.STANDARD))
     ).thenReturn(s3ObjectMetadata(key, hexDigest));
 
     var base64Digest = DigestUtil.base64Digest(FileUtils.openInputStream(testFile));
@@ -513,7 +517,8 @@ class ObjectControllerTest {
         null,
         encryptionHeaders(encryption, encryptionKey),
         null,
-        null
+        null,
+        StorageClass.STANDARD
     );
   }
 

--- a/server/src/test/java/com/adobe/testing/s3mock/service/ServiceTestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/service/ServiceTestBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package com.adobe.testing.s3mock.service;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.adobe.testing.s3mock.dto.ChecksumAlgorithm;
@@ -129,7 +128,8 @@ abstract class ServiceTestBase {
         null,
         null,
         null,
-        null
+        null,
+        StorageClass.STANDARD
     );
   }
 

--- a/server/src/test/java/com/adobe/testing/s3mock/store/StoreTestBase.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/StoreTestBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.http.entity.ContentType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 
 abstract class StoreTestBase {
   static final String TEST_BUCKET_NAME = "test-bucket";
@@ -36,8 +37,7 @@ abstract class StoreTestBase {
   static final String TEXT_PLAIN = ContentType.TEXT_PLAIN.toString();
   static final String ENCODING_GZIP = "gzip";
   static final String NO_PREFIX = null;
-  static final String DEFAULT_CONTENT_TYPE =
-      ContentType.APPLICATION_OCTET_STREAM.toString();
+  static final String DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_OCTET_STREAM_VALUE;
   static final Owner TEST_OWNER = new Owner("123", "s3-mock-file-store");
 
   @Autowired

--- a/server/src/test/java/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.adobe.testing.s3mock.dto.Owner;
+import com.adobe.testing.s3mock.dto.StorageClass;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
@@ -80,7 +81,8 @@ class StoresWithExistingFileRootTest extends StoreTestBase {
     objectStore
         .storeS3ObjectMetadata(bucketMetadata, id, name, TEXT_PLAIN, storeHeaders(),
             Files.newInputStream(path), false,
-            emptyMap(), emptyMap(), null, emptyList(), null, null, Owner.DEFAULT_OWNER);
+            emptyMap(), emptyMap(), null, emptyList(), null, null, Owner.DEFAULT_OWNER,
+            StorageClass.STANDARD);
 
     var object = objectStore.getS3ObjectMetadata(bucketMetadata, id);
 

--- a/server/src/test/java/com/adobe/testing/s3mock/util/HeaderUtilTest.java
+++ b/server/src/test/java/com/adobe/testing/s3mock/util/HeaderUtilTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static com.adobe.testing.s3mock.util.HeaderUtil.userMetadataFrom;
 import static com.adobe.testing.s3mock.util.HeaderUtil.userMetadataHeadersFrom;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.adobe.testing.s3mock.dto.StorageClass;
 import com.adobe.testing.s3mock.store.S3ObjectMetadata;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -85,7 +86,8 @@ class HeaderUtilTest {
         null,
         null,
         null,
-        null
+        null,
+        StorageClass.STANDARD
     );
   }
 }


### PR DESCRIPTION
## Description
* Support StorageClass in all APIs, add tests
* Optimize code in ITs
* Increase S3Mock memory in ITs 
* Use JDK21 to run S3Mock in Docker container

## Related Issue
#1429

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
