### PR TITLE
fix:Improve test compatibility for hostname verifier

### DIFF
--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV1IT.kt
@@ -430,9 +430,14 @@ internal class GetPutDeleteObjectV1IT : S3TestBase() {
     val sc = SSLContext.getInstance("SSL")
     sc.init(null, trustAllCerts, SecureRandom())
     HttpsURLConnection.setDefaultSSLSocketFactory(sc.socketFactory)
-    HttpsURLConnection.setDefaultHostnameVerifier { hostname: String, _: SSLSession? -> hostname == "localhost" }
+    HttpsURLConnection.setDefaultHostnameVerifier { hostname: String, _: SSLSession? -> hostname == hostFromEndpoint() }
     val urlConnection = resourceUrl.openConnection()
     urlConnection.connect()
     return urlConnection
+  }
+
+  private fun hostFromEndpoint(): String {
+    val str = serviceEndpoint.substring(serviceEndpoint.indexOf("//") + 2)
+    return str.substring(0, str.indexOf(":"));
   }
 }


### PR DESCRIPTION
## Description
The configuration item 'it.s3mock.host' supports setting to ip or other non-localhost domain names. The check here should not be hard-coded as 'localhost'

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
