### PR TITLE
Let Jetty process non-compliant URIs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,21 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Version updates
   * TBD
 
+## 3.5.2
+3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Support key names that lead to request paths that do not comply to RFC3986 (fixes #1686)
+* Refactorings
+  * Refactor IT usage of S3 clients, add more tests
+  * Use ZGC and ZGenerationalGC when running in Docker
+* Version updates
+  * Bump kotlin.version from 1.9.22 to 1.9.23
+  * Bump testcontainers.version from 1.19.6 to 1.19.7
+  * Bump github/codeql-action from 3.24.5 to 3.24.6
+  * Bump actions/setup-java from 4.0.0 to 4.1.0
+  * Bump com.puppycrawl.tools:checkstyle from 10.13.0 to 10.14.0
+
 ## 3.5.1
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,4 +86,4 @@ ENV root=/s3mockroot
 EXPOSE 9090 9191
 
 # run the app on startup
-ENTRYPOINT ["java", "--illegal-access=warn", "-Djava.security.egd=file:/dev/./urandom", "-jar", "s3mock.jar"]
+ENTRYPOINT ["java", "--illegal-access=warn", "-Djava.security.egd=file:/dev/./urandom", "-XX:+UseZGC", "-XX:+ZGenerational", "-jar", "s3mock.jar" ]

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
@@ -20,9 +20,8 @@ import com.adobe.testing.s3mock.dto.Owner.DEFAULT_OWNER
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
-import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.AccessControlPolicy
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.GetObjectAclRequest
 import software.amazon.awssdk.services.s3.model.Grant
 import software.amazon.awssdk.services.s3.model.Grantee
@@ -30,11 +29,10 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.Owner
 import software.amazon.awssdk.services.s3.model.Permission.FULL_CONTROL
 import software.amazon.awssdk.services.s3.model.PutObjectAclRequest
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.Type.CANONICAL_USER
-import java.io.File
 
 internal class AclIT : S3TestBase() {
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   fun testPutCannedAcl_OK(testInfo: TestInfo) {
@@ -69,8 +67,7 @@ internal class AclIT : S3TestBase() {
     reason = "Owner and Grantee not available on test AWS account.")
   fun testGetAcl_noAcl(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
-    val bucketName = bucketName(testInfo)
-    givenBucketAndObjectV2(testInfo, sourceKey)
+    val (bucketName, _) = givenBucketAndObjectV2(testInfo, sourceKey)
 
     val acl = s3ClientV2.getObjectAcl(
       GetObjectAclRequest

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEndcodingITV2.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEndcodingITV2.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import java.io.InputStream
  */
 internal class AwsChunkedEndcodingITV2 : S3TestBase() {
 
-  private val client = createS3ClientV2(serviceEndpointHttp)
+  private val s3ClientV2 = createS3ClientV2(serviceEndpointHttp)
 
   /**
    * Unfortunately the S3 API does not persist or return data that would let us verify if signed and chunked encoding
@@ -52,7 +52,7 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
     val expectedEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
     val expectedChecksum = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
 
-    val putObjectResponse = client.putObject(
+    val putObjectResponse = s3ClientV2.putObject(
       PutObjectRequest.builder()
         .bucket(bucket)
         .key(UPLOAD_FILE_NAME)
@@ -65,7 +65,7 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
     assertThat(putChecksum).isNotBlank
     assertThat(putChecksum).isEqualTo(expectedChecksum)
 
-    val getObjectResponse = client.getObject(
+    val getObjectResponse = s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucket)
         .key(UPLOAD_FILE_NAME)
@@ -95,7 +95,7 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
     val uploadFileIs: InputStream = FileInputStream(uploadFile)
     val expectedEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
 
-    client.putObject(
+    s3ClientV2.putObject(
       PutObjectRequest.builder()
         .bucket(bucket)
         .key(UPLOAD_FILE_NAME)
@@ -103,7 +103,7 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val getObjectResponse = client.getObject(
+    val getObjectResponse = s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucket)
         .key(UPLOAD_FILE_NAME)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
@@ -16,6 +16,7 @@
 
 package com.adobe.testing.s3mock.its
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.Bucket
 import com.amazonaws.services.s3.model.HeadBucketRequest
@@ -32,6 +33,8 @@ import java.util.stream.Collectors
  * Test the application using the AmazonS3 SDK V1.
  */
 internal class BucketV1IT : S3TestBase() {
+
+  private val s3Client: AmazonS3 = createS3ClientV1()
 
   @Test
   @S3VerifiedFailure(year = 2022,

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails
 import software.amazon.awssdk.awscore.exception.AwsServiceException
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.AbortIncompleteMultipartUpload
 import software.amazon.awssdk.services.s3.model.BucketLifecycleConfiguration
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
@@ -43,6 +44,8 @@ import java.util.concurrent.TimeUnit
  * Test the application using the AmazonS3 SDK V2.
  */
 internal class BucketV2IT : S3TestBase() {
+
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV1IT.kt
@@ -17,12 +17,14 @@
 package com.adobe.testing.s3mock.its
 
 import com.adobe.testing.s3mock.util.DigestUtil
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.CopyObjectRequest
 import com.amazonaws.services.s3.model.MetadataDirective
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams
+import com.amazonaws.services.s3.transfer.TransferManager
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -36,6 +38,9 @@ import java.util.UUID
  * Test the application using the AmazonS3 SDK V1.
  */
 internal class CopyObjectV1IT : S3TestBase() {
+
+  private val s3Client: AmazonS3 = createS3ClientV1()
+  private val transferManagerV1: TransferManager = createTransferManagerV1()
 
   /**
    * Puts an Object; Copies that object to a new bucket; Downloads the object from the new bucket;
@@ -374,8 +379,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val assumedSourceKey = UUID.randomUUID().toString()
     val sourceBucket = givenRandomBucketV1()
     val targetBucket = givenRandomBucketV1()
-    val transferManager = createTransferManager()
-    val upload = transferManager
+    val upload = transferManagerV1
       .upload(
         sourceBucket, assumedSourceKey,
         randomInputStream(contentLen), objectMetadata
@@ -383,7 +387,7 @@ internal class CopyObjectV1IT : S3TestBase() {
     val uploadResult = upload.waitForUploadResult()
     assertThat(uploadResult.key).isEqualTo(assumedSourceKey)
     val assumedDestinationKey = UUID.randomUUID().toString()
-    val copy = transferManager.copy(
+    val copy = transferManagerV1.copy(
       sourceBucket, assumedSourceKey, targetBucket,
       assumedDestinationKey
     )

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
@@ -24,6 +24,7 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
@@ -40,6 +41,8 @@ import java.time.temporal.ChronoUnit.SECONDS
  * Test the application using the AmazonS3 SDK V2.
  */
 internal class CopyObjectV2IT : S3TestBase() {
+
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CorsV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CorsV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -28,11 +28,8 @@ import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.message.BasicHeader
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
-import java.io.IOException
 import java.util.UUID
 
 
@@ -40,18 +37,7 @@ import java.util.UUID
  * Test the application using the AmazonS3 SDK V2.
  */
 internal class CorsV2IT : S3TestBase() {
-  private lateinit var httpClient: CloseableHttpClient
-
-  @BeforeEach
-  fun setupHttpClient() {
-    httpClient = HttpClients.createDefault()
-  }
-
-  @AfterEach
-  @Throws(IOException::class)
-  fun shutdownHttpClient() {
-    httpClient.close()
-  }
+  private val httpClient: CloseableHttpClient = HttpClients.createDefault()
 
   @Test
   @S3VerifiedTodo

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,25 +15,251 @@
  */
 package com.adobe.testing.s3mock.its
 
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest
+import software.amazon.awssdk.services.s3.model.Delete
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.S3Exception
+import software.amazon.awssdk.services.s3.model.UploadPartRequest
+import java.io.File
 
 internal class ErrorResponsesV2IT : S3TestBase() {
 
+  private val s3ClientV2: S3Client = createS3ClientV2()
+
   @Test
   @S3VerifiedSuccess(year = 2022)
-  fun nonExistingObject(testInfo: TestInfo) {
+  fun getObject_noSuchKey(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
-    val req = GetObjectRequest.builder().bucket(bucketName).key("NoSuchKey.json").build()
+    val req = GetObjectRequest.builder().bucket(bucketName).key(NON_EXISTING_KEY).build()
     assertThatThrownBy { s3ClientV2.getObject(req) }.isInstanceOf(
       NoSuchKeyException::class.java
     ).hasMessageContaining(NO_SUCH_KEY)
   }
 
+  @Test
+  @S3VerifiedTodo
+  fun getObject_noSuchKey_startingSlash(testInfo: TestInfo) {
+    val bucketName = givenBucketV2(testInfo)
+    val req = GetObjectRequest.builder().bucket(bucketName).key("/$NON_EXISTING_KEY").build()
+    assertThatThrownBy { s3ClientV2.getObject(req) }.isInstanceOf(
+      NoSuchKeyException::class.java
+    ).hasMessageContaining(NO_SUCH_KEY)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun putObject_noSuchBucket() {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    assertThatThrownBy {
+      s3ClientV2.putObject(
+        PutObjectRequest
+          .builder()
+          .bucket(randomName)
+          .key(UPLOAD_FILE_NAME)
+          .build(),
+        RequestBody.fromFile(uploadFile)
+      )
+    }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun copyObjectToNonExistingDestination_noSuchBucket(testInfo: TestInfo) {
+    val sourceKey = UPLOAD_FILE_NAME
+    val (bucketName, _) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
+    val destinationBucketName = randomName
+    val destinationKey = "copyOf/$sourceKey"
+
+    assertThatThrownBy { s3ClientV2.copyObject(
+      software.amazon.awssdk.services.s3.model.CopyObjectRequest
+        .builder()
+        .sourceBucket(bucketName)
+        .sourceKey(sourceKey)
+        .destinationBucket(destinationBucketName)
+        .destinationKey(destinationKey)
+        .build()
+    ) }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun deleteObject_noSuchBucket() {
+    assertThatThrownBy {
+      s3ClientV2.deleteObject(
+        DeleteObjectRequest
+          .builder()
+          .bucket(randomName)
+          .key(NON_EXISTING_KEY)
+          .build()
+      )
+    }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun deleteObject_nonExistent_OK(testInfo: TestInfo) {
+    val bucketName = givenBucketV2(testInfo)
+    s3ClientV2.deleteObject(
+      DeleteObjectRequest
+        .builder()
+        .bucket(bucketName)
+        .key(NON_EXISTING_KEY)
+        .build()
+    )
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun deleteObjects_noSuchBucket() {
+    assertThatThrownBy {
+      s3ClientV2.deleteObjects(
+        DeleteObjectsRequest
+          .builder()
+          .bucket(randomName)
+          .delete(
+            Delete
+              .builder()
+              .objects(ObjectIdentifier
+                .builder()
+                .key(NON_EXISTING_KEY)
+                .build()
+              ).build()
+          ).build()
+      )
+    }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun deleteBucket_noSuchBucket() {
+    assertThatThrownBy {
+      s3ClientV2.deleteBucket(
+        DeleteBucketRequest
+          .builder()
+          .bucket(randomName)
+          .build()
+      )
+    }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun multipartUploads_noSuchBucket() {
+    assertThatThrownBy {
+      s3ClientV2.createMultipartUpload(
+        CreateMultipartUploadRequest
+          .builder()
+          .bucket(randomName)
+          .key(UPLOAD_FILE_NAME)
+          .build()
+      )
+    }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun listMultipartUploads_noSuchBucket() {
+    assertThatThrownBy {
+      s3ClientV2.listMultipartUploads(
+        ListMultipartUploadsRequest
+          .builder()
+          .bucket(randomName)
+          .build()
+      )
+    }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun abortMultipartUpload_noSuchBucket() {
+    assertThatThrownBy {
+      s3ClientV2.abortMultipartUpload(
+        AbortMultipartUploadRequest
+          .builder()
+          .bucket(randomName)
+          .key(UPLOAD_FILE_NAME)
+          .uploadId("uploadId")
+          .build()
+        )
+    }
+      .isInstanceOf(NoSuchBucketException::class.java)
+      .hasMessageContaining(NO_SUCH_BUCKET)
+  }
+
+  @Test
+  @S3VerifiedTodo
+  fun uploadMultipart_invalidPartNumber(testInfo: TestInfo) {
+    val bucketName = givenBucketV1(testInfo)
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val initiateMultipartUploadResult = s3ClientV2
+      .createMultipartUpload(
+        CreateMultipartUploadRequest
+          .builder()
+          .bucket(bucketName)
+          .key(UPLOAD_FILE_NAME)
+          .build()
+      )
+    val uploadId = initiateMultipartUploadResult.uploadId()
+    assertThat(
+      s3ClientV2.listMultipartUploads(
+        ListMultipartUploadsRequest
+          .builder()
+          .bucket(bucketName)
+          .build()
+      ).uploads()
+    ).isNotEmpty
+    val invalidPartNumber = 0
+    assertThatThrownBy {
+      s3ClientV2.uploadPart(
+        UploadPartRequest
+          .builder()
+          .bucket(initiateMultipartUploadResult.bucket())
+          .key(initiateMultipartUploadResult.key())
+          .uploadId(uploadId)
+          .partNumber(invalidPartNumber)
+          .build(),
+        RequestBody.fromFile(uploadFile)
+      )
+    }
+      .isInstanceOf(S3Exception::class.java)
+      .hasMessageContaining(INVALID_PART_NUMBER)
+  }
+
   companion object {
+    private const val NON_EXISTING_KEY = "NoSuchKey.json"
     private const val NO_SUCH_KEY = "The specified key does not exist."
+    private const val NO_SUCH_BUCKET = "The specified bucket does not exist"
+    private const val STATUS_CODE_404 = "Status Code: 404"
+    private const val INVALID_PART_NUMBER = "Part number must be an integer between 1 and 10000, inclusive"
+    private const val INVALID_PART = "Status Code: 400; Error Code: InvalidPart"
   }
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest
 import software.amazon.awssdk.services.s3.model.ObjectLockLegalHold
@@ -31,6 +32,8 @@ import software.amazon.awssdk.services.s3.model.S3Exception
 import java.io.File
 
 internal class LegalHoldV2IT : S3TestBase() {
+
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
@@ -15,10 +15,12 @@
  */
 package com.adobe.testing.s3mock.its
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ListObjectsRequest
 import com.amazonaws.services.s3.model.ListObjectsV2Request
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.amazonaws.services.s3.transfer.TransferManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
@@ -32,6 +34,10 @@ import java.util.stream.Collectors
  * Test the application using the AmazonS3 SDK V1.
  */
 internal class ListObjectV1IT : S3TestBase() {
+
+  val s3Client: AmazonS3 = createS3ClientV1()
+  val transferManagerV1: TransferManager = createTransferManagerV1()
+
   class Param(
     val prefix: String?,
     val delimiter: String?,
@@ -77,8 +83,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @MethodSource("data")
   @S3VerifiedSuccess(year = 2022)
   fun listV1(parameters: Param, testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     // create all expected objects
     for (key in ALL_OBJECTS) {
       s3Client.putObject(bucketName, key, "Test")
@@ -119,8 +124,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @MethodSource("data")
   @S3VerifiedSuccess(year = 2022)
   fun listV2(parameters: Param, testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     // create all expected objects
     for (key in ALL_OBJECTS) {
       s3Client.putObject(bucketName, key, "Test")
@@ -161,8 +165,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2022)
   fun shouldListWithCorrectObjectNames(testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val weirdStuff = ("$&_ .,':\u0001") // use only characters that are safe or need special handling
     val prefix = "shouldListWithCorrectObjectNames/"
@@ -182,8 +185,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2022)
   fun shouldListV2WithCorrectObjectNames(testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val weirdStuff = ("$&_ .,':\u0001") // use only characters that are safe or need special handling
     val prefix = "shouldListWithCorrectObjectNames/"
@@ -214,8 +216,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2022)
   fun shouldHonorEncodingType(testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val prefix = "shouldHonorEncodingType/"
     val key = prefix + "\u0001" // key invalid in XML
@@ -235,8 +236,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2022)
   fun shouldHonorEncodingTypeV2(testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val prefix = "shouldHonorEncodingType/"
     val key = prefix + "\u0001" // key invalid in XML
@@ -255,8 +255,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2022)
   fun shouldGetObjectListing(testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     s3Client.putObject(PutObjectRequest(bucketName, UPLOAD_FILE_NAME, uploadFile))
     val objectListingResult = s3Client.listObjects(bucketName, UPLOAD_FILE_NAME)
@@ -270,8 +269,7 @@ internal class ListObjectV1IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2022)
   fun shouldUploadAndListV2Objects(testInfo: TestInfo) {
-    val bucketName = bucketName(testInfo)
-    s3Client.createBucket(bucketName)
+    val bucketName = givenBucketV1(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     s3Client.putObject(
       PutObjectRequest(

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.kt
@@ -15,12 +15,14 @@
  */
 package com.adobe.testing.s3mock.its
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ListObjectsRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 
 internal class ListObjectV1MaxKeysIT : S3TestBase() {
+  val s3Client: AmazonS3 = createS3ClientV1()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
  */
 package com.adobe.testing.s3mock.its
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ListObjectsRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 
 internal class ListObjectV1PaginationIT : S3TestBase() {
+  val s3Client: AmazonS3 = createS3ClientV1()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
@@ -21,6 +21,7 @@ import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm
 import software.amazon.awssdk.services.s3.model.EncodingType
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.s3.model.S3Object
 import java.io.File
 
 internal class ListObjectV2IT : S3TestBase() {
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   @S3VerifiedTodo

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectVersionsV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectVersionsV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm
 import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest
 import software.amazon.awssdk.services.s3.model.ObjectVersion
@@ -28,6 +29,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.io.File
 
 internal class ListObjectVersionsV2IT : S3TestBase() {
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   fun testPutObjects_listObjectVersions(testInfo: TestInfo) {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV1IT.kt
@@ -15,6 +15,7 @@
  */
 package com.adobe.testing.s3mock.its
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest
@@ -43,6 +44,8 @@ import java.util.UUID
  * Test the application using the AmazonS3 SDK V1.
  */
 internal class MultiPartUploadV1IT : S3TestBase() {
+  val s3Client: AmazonS3 = createS3ClientV1()
+
   /**
    * Tests if user metadata can be passed by multipart upload.
    */

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV1IT.kt
@@ -15,6 +15,7 @@
  */
 package com.adobe.testing.s3mock.its
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.GetObjectTaggingRequest
 import com.amazonaws.services.s3.model.ObjectTagging
 import com.amazonaws.services.s3.model.PutObjectRequest
@@ -29,6 +30,7 @@ import java.io.File
  * Test the application using the AmazonS3 SDK V1.
  */
 internal class ObjectTaggingV1IT : S3TestBase() {
+  val s3Client: AmazonS3 = createS3ClientV1()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.s3.model.Tag
 import software.amazon.awssdk.services.s3.model.Tagging
 
 internal class ObjectTaggingV2IT : S3TestBase() {
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.adobe.testing.s3mock.its
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.UploadPartRequest
@@ -36,8 +37,6 @@ import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.message.BasicHeader
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.springframework.http.MediaType
@@ -53,17 +52,8 @@ import java.util.stream.Collectors
  * resp. where it's not possible to verify e.g. status codes.
  */
 internal class PlainHttpIT : S3TestBase() {
-  private lateinit var httpClient: CloseableHttpClient
-
-  @BeforeEach
-  fun setupHttpClient() {
-    httpClient = HttpClients.createDefault()
-  }
-
-  @AfterEach
-  fun shutdownHttpClient() {
-    httpClient.close()
-  }
+  private val httpClient: CloseableHttpClient = HttpClients.createDefault()
+  private val s3Client: AmazonS3 = createS3ClientV1()
 
   @Test
   @S3VerifiedFailure(year = 2022,

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUriV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUriV2IT.kt
@@ -28,11 +28,10 @@ import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.message.BasicHeader
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload
@@ -42,6 +41,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.UploadPartRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.AbortMultipartUploadPresignRequest
 import software.amazon.awssdk.services.s3.presigner.model.CompleteMultipartUploadPresignRequest
 import software.amazon.awssdk.services.s3.presigner.model.CreateMultipartUploadPresignRequest
@@ -54,17 +54,9 @@ import java.nio.file.Path
 import java.time.Duration
 
 internal class PresignedUriV2IT : S3TestBase() {
-  private lateinit var httpClient: CloseableHttpClient
-
-  @BeforeEach
-  fun setupHttpClient() {
-    httpClient = HttpClients.createDefault()
-  }
-
-  @AfterEach
-  fun shutdownHttpClient() {
-    httpClient.close()
-  }
+  private val httpClient: CloseableHttpClient = HttpClients.createDefault()
+  private val s3ClientV2: S3Client = createS3ClientV2()
+  private val s3Presigner: S3Presigner = createS3Presigner()
 
   @Test
   fun testPresignedUri_getObject(testInfo: TestInfo) {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/RetentionV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/RetentionV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2022 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRetentionRequest
 import software.amazon.awssdk.services.s3.model.ObjectLockRetention
@@ -35,6 +36,7 @@ import java.time.temporal.ChronoUnit.DAYS
 import java.time.temporal.ChronoUnit.MILLIS
 
 internal class RetentionV2IT : S3TestBase() {
+  private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
   @S3VerifiedSuccess(year = 2022)

--- a/server/src/main/resources/application-debug.properties
+++ b/server/src/main/resources/application-debug.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017-2022 Adobe.
+#  Copyright 2017-2024 Adobe.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #
 
 # Enable debug logging for requests to better debug S3Mock
+#logging.level.root=debug
 logging.level.org.springframework.web=DEBUG
 spring.mvc.log-request-details=true
 

--- a/server/src/main/resources/application-trace.properties
+++ b/server/src/main/resources/application-trace.properties
@@ -1,0 +1,18 @@
+#
+#  Copyright 2017-2024 Adobe.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+logging.level.root=trace
+logging.level.org.springframework.web=trace


### PR DESCRIPTION
## Description
Updating to Spring Boot 3.2 updated Jetty to v12. By default, Jetty will now refuse RFC-3986 non-compliant URIs, which  leads to S3Mock refusing object keys that are valid according to [S3 API docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html).
Enable "legacy" compliance mode to allow those kinds of object keys.

## Related Issue
$1686

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
