### PR TITLE
Verify checksums on upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
     * [Planned changes](#planned-changes)
 * [CURRENT - 3.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---3x---this-version-is-under-active-development)
   * [3.8.0 - PLANNED](#380---planned)
-  * [3.7.1 - PLANNED](#371---planned)
+  * [3.7.3 - PLANNED](#373---planned)
+  * [3.7.2](#372)
+  * [3.7.1](#371)
   * [3.7.0](#370)
   * [3.6.0](#360)
   * [3.5.2](#352)
@@ -132,15 +134,18 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Version updates
   * TBD
 
-## 3.7.2 - PLANNED
+## 3.7.3 - PLANNED
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
-  * Calculate and validate checksums on upload
-* Refactorings
-  * TBD
-* Version updates
-  * TBD
+  * Support large, chunked, unsigned, asynchronous uploads (fixes #1818)
+
+## 3.7.2
+3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Calculate and validate checksums on upload (fixes #1827)
+    * UploadPart API now also returns checksums, if available.
 
 ## 3.7.1
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
@@ -39,28 +39,30 @@ internal class AclIT : S3TestBase() {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, sourceKey)
 
-    val putAclResponse = s3ClientV2.putObjectAcl(
+    s3ClientV2.putObjectAcl(
       PutObjectAclRequest
         .builder()
         .bucket(bucketName)
         .key(sourceKey)
         .acl(ObjectCannedACL.PRIVATE)
         .build()
-    )
-    assertThat(putAclResponse.sdkHttpResponse().isSuccessful).isTrue()
+    ).also {
+      assertThat(it.sdkHttpResponse().isSuccessful).isTrue()
+    }
 
-    val getAclResponse = s3ClientV2.getObjectAcl(
+    s3ClientV2.getObjectAcl(
       GetObjectAclRequest
         .builder()
         .bucket(bucketName)
         .key(sourceKey)
         .build()
-    )
-    assertThat(getAclResponse.sdkHttpResponse().isSuccessful).isTrue()
-    assertThat(getAclResponse.owner().id()).isEqualTo(DEFAULT_OWNER.id)
-    assertThat(getAclResponse.owner().displayName()).isEqualTo(DEFAULT_OWNER.displayName)
-    assertThat(getAclResponse.grants().size).isEqualTo(1)
-    assertThat(getAclResponse.grants()[0].permission()).isEqualTo(FULL_CONTROL)
+    ).also {
+      assertThat(it.sdkHttpResponse().isSuccessful).isTrue()
+      assertThat(it.owner().id()).isEqualTo(DEFAULT_OWNER.id)
+      assertThat(it.owner().displayName()).isEqualTo(DEFAULT_OWNER.displayName)
+      assertThat(it.grants().size).isEqualTo(1)
+      assertThat(it.grants()[0].permission()).isEqualTo(FULL_CONTROL)
+    }
   }
 
   @Test
@@ -78,21 +80,22 @@ internal class AclIT : S3TestBase() {
         .build()
     )
 
-    val owner = acl.owner()
-    assertThat(owner.id()).isEqualTo(DEFAULT_OWNER.id)
-    assertThat(owner.displayName()).isEqualTo(DEFAULT_OWNER.displayName)
+    acl.owner().also { owner ->
+      assertThat(owner.id()).isEqualTo(DEFAULT_OWNER.id)
+      assertThat(owner.displayName()).isEqualTo(DEFAULT_OWNER.displayName)
+    }
 
-    val grants = acl.grants()
-    assertThat(grants).hasSize(1)
-
+    val grants = acl.grants().also {
+      assertThat(it).hasSize(1)
+    }
     val grant = grants[0]
     assertThat(grant.permission()).isEqualTo(FULL_CONTROL)
-
-    val grantee = grant.grantee()
-    assertThat(grantee).isNotNull
-    assertThat(grantee.id()).isEqualTo(DEFAULT_OWNER.id)
-    assertThat(grantee.displayName()).isEqualTo(DEFAULT_OWNER.displayName)
-    assertThat(grantee.type()).isEqualTo(CANONICAL_USER)
+    grant.grantee().also {
+      assertThat(it).isNotNull
+      assertThat(it.id()).isEqualTo(DEFAULT_OWNER.id)
+      assertThat(it.displayName()).isEqualTo(DEFAULT_OWNER.displayName)
+      assertThat(it.type()).isEqualTo(CANONICAL_USER)
+    }
   }
 
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEndcodingITV2.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEndcodingITV2.kt
@@ -62,22 +62,25 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val putChecksum = putObjectResponse.checksumSHA256()
-    assertThat(putChecksum).isNotBlank
-    assertThat(putChecksum).isEqualTo(expectedChecksum)
+    putObjectResponse.checksumSHA256().also {
+      assertThat(it).isNotBlank
+      assertThat(it).isEqualTo(expectedChecksum)
+    }
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucket)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    assertThat(getObjectResponse.response().eTag()).isEqualTo(expectedEtag)
-    assertThat(getObjectResponse.response().contentLength()).isEqualTo(uploadFile.length())
+    ).also { getObjectResponse ->
+      assertThat(getObjectResponse.response().eTag()).isEqualTo(expectedEtag)
+      assertThat(getObjectResponse.response().contentLength()).isEqualTo(uploadFile.length())
 
-    val getChecksum = getObjectResponse.response().checksumSHA256()
-    assertThat(getChecksum).isNotBlank
-    assertThat(getChecksum).isEqualTo(expectedChecksum)
+      getObjectResponse.response().checksumSHA256().also {
+        assertThat(it).isNotBlank
+        assertThat(it).isEqualTo(expectedChecksum)
+      }
+    }
   }
 
   /**
@@ -104,13 +107,14 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val getObjectResponse = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucket)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    assertThat(getObjectResponse.response().eTag()).isEqualTo(expectedEtag)
-    assertThat(getObjectResponse.response().contentLength()).isEqualTo(uploadFile.length())
+    ).also {
+      assertThat(it.response().eTag()).isEqualTo(expectedEtag)
+      assertThat(it.response().contentLength()).isEqualTo(uploadFile.length())
+    }
   }
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV1IT.kt
@@ -55,9 +55,10 @@ internal class BucketV1IT : S3TestBase() {
     val createdBucket = buckets[0]
     assertThat(createdBucket.creationDate).isAfterOrEqualTo(creationDate)
 
-    val bucketOwner = createdBucket.owner
-    assertThat(bucketOwner.displayName).isEqualTo("s3-mock-file-store")
-    assertThat(bucketOwner.id).isEqualTo("79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be")
+    createdBucket.owner.also {
+      assertThat(it.displayName).isEqualTo("s3-mock-file-store")
+      assertThat(it.id).isEqualTo("79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be")
+    }
   }
 
   @Test
@@ -81,8 +82,9 @@ internal class BucketV1IT : S3TestBase() {
     s3Client.headBucket(HeadBucketRequest(bucketName))
     s3Client.deleteBucket(bucketName)
 
-    val doesBucketExist = s3Client.doesBucketExistV2(bucketName)
-    assertThat(doesBucketExist).isFalse
+    s3Client.doesBucketExistV2(bucketName).also {
+      assertThat(it).isFalse
+    }
   }
 
   @Test
@@ -104,8 +106,9 @@ internal class BucketV1IT : S3TestBase() {
     val bucketName = bucketName(testInfo)
     s3Client.createBucket(bucketName)
 
-    val doesBucketExist = s3Client.doesBucketExistV2(bucketName)
-    assertThat(doesBucketExist).isTrue
+    s3Client.doesBucketExistV2(bucketName).also {
+      assertThat(it).isTrue
+    }
   }
 
   @Test

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
@@ -64,9 +64,10 @@ internal class BucketV2IT : S3TestBase() {
     s3ClientV2.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build())
     val bucketDeleted = s3ClientV2.waiter()
       .waitUntilBucketNotExists(HeadBucketRequest.builder().bucket(bucketName).build())
-    val bucketDeletedResponse = bucketDeleted.matched().exception().get()
-    assertThat(bucketDeletedResponse).isNotNull
-    assertThat(bucketDeletedResponse).isInstanceOf(NoSuchBucketException::class.java)
+    bucketDeleted.matched().exception().get().also {
+      assertThat(it).isNotNull
+      assertThat(it).isInstanceOf(NoSuchBucketException::class.java)
+    }
   }
 
   @Test
@@ -86,8 +87,9 @@ internal class BucketV2IT : S3TestBase() {
 
     val bucketCreated = s3ClientV2.waiter()
       .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
-    val bucketCreatedResponse = bucketCreated.matched().response().get()
-    assertThat(bucketCreatedResponse).isNotNull
+    bucketCreated.matched().response().get().also {
+      assertThat(it).isNotNull
+    }
 
     assertThatThrownBy {
       s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
@@ -103,9 +105,10 @@ internal class BucketV2IT : S3TestBase() {
     val bucketDeleted = s3ClientV2.waiter()
       .waitUntilBucketNotExists(HeadBucketRequest.builder().bucket(bucketName).build())
 
-    val bucketDeletedResponse = bucketDeleted.matched().exception().get()
-    assertThat(bucketDeletedResponse).isNotNull
-    assertThat(bucketDeletedResponse).isInstanceOf(NoSuchBucketException::class.java)
+    bucketDeleted.matched().exception().get().also {
+      assertThat(it).isNotNull
+      assertThat(it).isInstanceOf(NoSuchBucketException::class.java)
+    }
   }
 
   @Test
@@ -116,15 +119,17 @@ internal class BucketV2IT : S3TestBase() {
 
     val bucketCreated = s3ClientV2.waiter()
       .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
-    val bucketCreatedResponse = bucketCreated.matched().response().get()
-    assertThat(bucketCreatedResponse).isNotNull
+    bucketCreated.matched().response().get().also {
+      assertThat(it).isNotNull
+    }
 
     s3ClientV2.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build())
     val bucketDeleted = s3ClientV2.waiter()
       .waitUntilBucketNotExists(HeadBucketRequest.builder().bucket(bucketName).build())
-    val bucketDeletedResponse = bucketDeleted.matched().exception().get()
-    assertThat(bucketDeletedResponse).isNotNull
-    assertThat(bucketDeletedResponse).isInstanceOf(NoSuchBucketException::class.java)
+    bucketDeleted.matched().exception().get().also {
+      assertThat(it).isNotNull
+      assertThat(it).isInstanceOf(NoSuchBucketException::class.java)
+    }
 
     assertThatThrownBy {
       s3ClientV2.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build())
@@ -169,8 +174,9 @@ internal class BucketV2IT : S3TestBase() {
 
     val bucketCreated = s3ClientV2.waiter()
       .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
-    val bucketCreatedResponse = bucketCreated.matched().response()!!.get()
-    assertThat(bucketCreatedResponse).isNotNull
+    bucketCreated.matched().response()!!.get().also {
+      assertThat(it).isNotNull
+    }
 
     val configuration = BucketLifecycleConfiguration
       .builder()
@@ -206,20 +212,21 @@ internal class BucketV2IT : S3TestBase() {
         .build()
     )
 
-    val configurationResponse = s3ClientV2.getBucketLifecycleConfiguration(
+    s3ClientV2.getBucketLifecycleConfiguration(
       GetBucketLifecycleConfigurationRequest
         .builder()
         .bucket(bucketName)
         .build()
-    )
+    ).also {
+      assertThat(it.rules()[0]).isEqualTo(configuration.rules()[0])
+    }
 
-    assertThat(configurationResponse.rules()[0]).isEqualTo(configuration.rules()[0])
-
-    val deleteBucketLifecycle = s3ClientV2.deleteBucketLifecycle(
+    s3ClientV2.deleteBucketLifecycle(
       DeleteBucketLifecycleRequest.builder().bucket(bucketName).build()
-    )
+    ).also {
+      assertThat(it.sdkHttpResponse().statusCode()).isEqualTo(204)
+    }
 
-    assertThat(deleteBucketLifecycle.sdkHttpResponse().statusCode()).isEqualTo(204)
 
     // give AWS time to actually delete the lifecycleConfiguration, otherwise the following call
     // will not fail as expected...

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ConcurrencyIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ConcurrencyIT.kt
@@ -61,31 +61,35 @@ internal class ConcurrencyIT : S3TestBase() {
   inner class Runner(val bucketName: String, val key: String) : Callable<Boolean> {
     override fun call(): Boolean {
       LATCH.countDown()
-      val putObjectResponse = s3ClientV2.putObject(
+      s3ClientV2.putObject(
         PutObjectRequest
           .builder()
           .bucket(bucketName)
           .key(key)
           .build(), RequestBody.empty()
-      )
-      assertThat(putObjectResponse.eTag()).isNotBlank
-      val getObjectResponse = s3ClientV2.getObject(
+      ).also {
+        assertThat(it.eTag()).isNotBlank
+      }
+
+      s3ClientV2.getObject(
         GetObjectRequest
           .builder()
           .bucket(bucketName)
           .key(key)
           .build()
-      )
-      assertThat(getObjectResponse.response().eTag()).isNotBlank
+      ).also {
+        assertThat(it.response().eTag()).isNotBlank
+      }
 
-      val deleteObjectResponse = s3ClientV2.deleteObject(
+      s3ClientV2.deleteObject(
         DeleteObjectRequest
           .builder()
           .bucket(bucketName)
           .key(key)
           .build()
-      )
-      assertThat(deleteObjectResponse.deleteMarker()).isTrue
+      ).also {
+        assertThat(it.deleteMarker()).isTrue
+      }
       DONE.incrementAndGet()
       return true
     }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
@@ -190,15 +190,13 @@ internal class CopyObjectV2IT : S3TestBase() {
       .build(),
       RequestBody.fromFile(uploadFile)
     )
-    val headObject = s3ClientV2.headObject(
+    val sourceLastModified = s3ClientV2.headObject(
       HeadObjectRequest
         .builder()
         .bucket(bucketName)
         .key(sourceKey)
         .build()
-    )
-
-    val sourceLastModified = headObject.lastModified()
+    ).lastModified()
 
     await("wait until source object is 5 seconds old").until {
       sourceLastModified.plusSeconds(5).isBefore(Instant.now())

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CorsV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CorsV2IT.kt
@@ -47,10 +47,11 @@ internal class CorsV2IT : S3TestBase() {
     val optionsRequest = HttpOptions("/${bucketName}/testObjectName").apply {
       this.addHeader("Origin", "http://localhost/")
     }
-    val optionsResponse: HttpResponse = httpclient.execute(HttpHost(
+    httpclient.execute(HttpHost(
       host, httpPort
-    ), optionsRequest)
-    assertThat(optionsResponse.getFirstHeader("Allow").value).contains("PUT")
+    ), optionsRequest).also {
+      assertThat(it.getFirstHeader("Allow").value).contains("PUT")
+    }
 
     val byteArray = UUID.randomUUID().toString().toByteArray()
     val expectedEtag = "\"${DigestUtil.hexDigest(byteArray)}\""

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
@@ -269,6 +269,28 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
+  @Test
+  @S3VerifiedTodo
+  fun testPutObject_wrongChecksum(testInfo: TestInfo) {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedChecksum = "wrongChecksum"
+    val checksumAlgorithm = ChecksumAlgorithm.SHA1
+    val bucketName = givenBucketV2(testInfo)
+
+    assertThatThrownBy {
+      s3ClientV2.putObject(
+        PutObjectRequest
+          .builder()
+          .checksum(expectedChecksum, checksumAlgorithm)
+          .bucket(bucketName).key(UPLOAD_FILE_NAME)
+          .build(),
+        RequestBody.fromFile(uploadFile)
+      )
+    }
+      .isInstanceOf(S3Exception::class.java)
+      .hasMessageContaining("The Content-MD5 or checksum value that you specified did not match what the server received.")
+  }
+
   /**
    * Safe characters:
    * https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
@@ -96,14 +96,14 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
 
     val key = UPLOAD_FILE_NAME
 
-    val putObjectResponse = s3ClientV2.putObject(
+    val eTag = s3ClientV2.putObject(
       PutObjectRequest.builder()
         .bucket(bucketName)
         .key(key)
         .storageClass(storageClass)
         .build(),
       RequestBody.fromFile(uploadFile)
-    )
+    ).eTag()
 
     s3ClientV2.headObject(
       HeadObjectRequest.builder()
@@ -111,7 +111,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .build()
     ).also {
-      assertThat(it.eTag()).isEqualTo(putObjectResponse.eTag())
+      assertThat(it.eTag()).isEqualTo(eTag)
     }
 
     s3ClientV2.getObject(
@@ -120,7 +120,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .build()
     ).use {
-      assertThat(it.response().eTag()).isEqualTo(putObjectResponse.eTag())
+      assertThat(it.response().eTag()).isEqualTo(eTag)
     }
   }
 
@@ -132,9 +132,10 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val expectedEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
 
     val (_, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag()
-    assertThat(eTag).isNotBlank
-    assertThat(eTag).isEqualTo(expectedEtag)
+    putObjectResponse.eTag().also {
+      assertThat(it).isNotBlank
+      assertThat(it).isEqualTo(expectedEtag)
+    }
   }
 
   @Test
@@ -144,17 +145,15 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), Algorithm.SHA1)
     val bucketName = givenBucketV2(testInfo)
 
-    val putObjectResponse = s3ClientV2.putObject(
+    val eTag = s3ClientV2.putObject(
       PutObjectRequest.builder()
         .bucket(bucketName).key(UPLOAD_FILE_NAME)
         .checksumAlgorithm(ChecksumAlgorithm.SHA1)
         .build(),
       RequestBody.fromFile(uploadFile)
-    )
+    ).eTag()
 
-    val eTag = putObjectResponse.eTag()
-
-    val objectAttributes = s3ClientV2.getObjectAttributes(
+    s3ClientV2.getObjectAttributes(
       GetObjectAttributesRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -164,12 +163,12 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
           ObjectAttributes.E_TAG,
           ObjectAttributes.CHECKSUM)
         .build()
-    )
-
-    assertThat(objectAttributes.eTag()).isEqualTo(eTag)
-    assertThat(objectAttributes.storageClass()).isEqualTo(StorageClass.STANDARD)
-    assertThat(objectAttributes.objectSize()).isEqualTo(File(UPLOAD_FILE_NAME).length())
-    assertThat(objectAttributes.checksum().checksumSHA1()).isEqualTo(expectedChecksum)
+    ).also {
+      assertThat(it.eTag()).isEqualTo(eTag)
+      assertThat(it.storageClass()).isEqualTo(StorageClass.STANDARD)
+      assertThat(it.objectSize()).isEqualTo(File(UPLOAD_FILE_NAME).length())
+      assertThat(it.checksum().checksumSHA1()).isEqualTo(expectedChecksum)
+    }
   }
 
   @S3VerifiedTodo
@@ -301,15 +300,15 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucketV2(testInfo)
 
-    val key = "someKey!-_.*'()" //safe characters as per S3 API
+    val key = "someKey${charsSafeKey()}"
 
-    val putObjectResponse = s3ClientV2.putObject(
+    val eTag = s3ClientV2.putObject(
       PutObjectRequest.builder()
         .bucket(bucketName)
         .key(key)
         .build(),
       RequestBody.fromFile(uploadFile)
-    )
+    ).eTag()
 
     s3ClientV2.headObject(
       HeadObjectRequest.builder()
@@ -317,7 +316,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .build()
     ).also {
-      assertThat(it.eTag()).isEqualTo(putObjectResponse.eTag())
+      assertThat(it.eTag()).isEqualTo(eTag)
     }
 
     s3ClientV2.getObject(
@@ -326,7 +325,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .build()
     ).use {
-      assertThat(putObjectResponse.eTag()).isEqualTo(it.response().eTag())
+      assertThat(eTag).isEqualTo(it.response().eTag())
     }
   }
 
@@ -340,15 +339,15 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucketV2(testInfo)
 
-    val key = "someKey&$@=;/:+ ,?" //safe characters as per S3 API
+    val key = "someKey${charsSpecialKey()}"
 
-    val putObjectResponse = s3ClientV2.putObject(
+    val eTag = s3ClientV2.putObject(
       PutObjectRequest.builder()
         .bucket(bucketName)
         .key(key)
         .build(),
       RequestBody.fromFile(uploadFile)
-    )
+    ).eTag()
 
     s3ClientV2.headObject(
       HeadObjectRequest.builder()
@@ -356,7 +355,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .build()
     ).also {
-      assertThat(it.eTag()).isEqualTo(putObjectResponse.eTag())
+      assertThat(it.eTag()).isEqualTo(eTag)
     }
 
     s3ClientV2.getObject(
@@ -365,7 +364,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .key(key)
         .build()
     ).use {
-      assertThat(putObjectResponse.eTag()).isEqualTo(it.response().eTag())
+      assertThat(eTag).isEqualTo(it.response().eTag())
     }
   }
 
@@ -417,30 +416,30 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .build(),
       RequestBody.fromFile(uploadFile))
 
-    val getObjectResponseResponse = getObjectV2(bucket, UPLOAD_FILE_NAME)
+    getObjectV2(bucket, UPLOAD_FILE_NAME).also {
+      assertThat(it.response().contentDisposition()).isEqualTo(contentDisposition)
+      assertThat(it.response().contentEncoding()).isEqualTo(encoding)
+      // time in second precision, see
+      // https://www.rfc-editor.org/rfc/rfc7234#section-5.3
+      // https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
+      assertThat(it.response().expires()).isEqualTo(expires.truncatedTo(ChronoUnit.SECONDS))
+      assertThat(it.response().contentLanguage()).isEqualTo(contentLanguage)
+      assertThat(it.response().cacheControl()).isEqualTo(cacheControl)
+    }
 
-    assertThat(getObjectResponseResponse.response().contentDisposition())
-      .isEqualTo(contentDisposition)
-    assertThat(getObjectResponseResponse.response().contentEncoding())
-      .isEqualTo(encoding)
-    // time in second precision, see
-    // https://www.rfc-editor.org/rfc/rfc7234#section-5.3
-    // https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
-    assertThat(getObjectResponseResponse.response().expires()).isEqualTo(expires.truncatedTo(ChronoUnit.SECONDS))
-    assertThat(getObjectResponseResponse.response().contentLanguage()).isEqualTo(contentLanguage)
-    assertThat(getObjectResponseResponse.response().cacheControl()).isEqualTo(cacheControl)
 
-    val headObjectResponse = s3ClientV2.headObject(
+    s3ClientV2.headObject(
       HeadObjectRequest.builder()
         .bucket(bucket)
         .key(UPLOAD_FILE_NAME)
         .build()
-    )
-    assertThat(headObjectResponse.contentDisposition()).isEqualTo(contentDisposition)
-    assertThat(headObjectResponse.contentEncoding()).isEqualTo(encoding)
-    assertThat(headObjectResponse.expires()).isEqualTo(expires.truncatedTo(ChronoUnit.SECONDS))
-    assertThat(headObjectResponse.contentLanguage()).isEqualTo(contentLanguage)
-    assertThat(headObjectResponse.cacheControl()).isEqualTo(cacheControl)
+    ).also {
+      assertThat(it.contentDisposition()).isEqualTo(contentDisposition)
+      assertThat(it.contentEncoding()).isEqualTo(encoding)
+      assertThat(it.expires()).isEqualTo(expires.truncatedTo(ChronoUnit.SECONDS))
+      assertThat(it.contentLanguage()).isEqualTo(contentLanguage)
+      assertThat(it.cacheControl()).isEqualTo(cacheControl)
+    }
   }
 
   @Test
@@ -451,8 +450,10 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val matchingEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
 
     val (bucketName, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag()
-    assertThat(eTag).isEqualTo(matchingEtag)
+    val eTag = putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(matchingEtag)
+    }
+
     s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
@@ -511,17 +512,19 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val nonMatchingEtag = "\"$randomName\""
 
     val (bucketName, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag()
-    assertThat(eTag).isEqualTo(expectedEtag)
+    val eTag = putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
 
-    val headObjectResponse = s3ClientV2.headObject(
+    s3ClientV2.headObject(
       HeadObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .ifNoneMatch(nonMatchingEtag)
         .build()
-    )
-    assertThat(headObjectResponse.eTag()).isEqualTo(eTag)
+    ).also {
+      assertThat(it.eTag()).isEqualTo(eTag)
+    }
   }
 
   @Test
@@ -534,8 +537,9 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val nonMatchingEtag = "\"*\""
 
     val (bucketName, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag()
-    assertThat(eTag).isEqualTo(expectedEtag)
+    putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
 
     assertThatThrownBy {
       s3ClientV2.headObject(
@@ -552,15 +556,15 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2022)
   fun testHeadObject_failureWithMatchEtag(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
-    val uploadFileIs: InputStream = FileInputStream(uploadFile)
-    val expectedEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
+    val expectedEtag = FileInputStream(File(UPLOAD_FILE_NAME))
+      .let {"\"${DigestUtil.hexDigest(it)}\""}
 
     val nonMatchingEtag = "\"$randomName\""
 
     val (bucketName, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag()
-    assertThat(eTag).isEqualTo(expectedEtag)
+    putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
 
     assertThatThrownBy {
       s3ClientV2.headObject(
@@ -583,17 +587,18 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val smallRequestStartBytes = 1L
     val smallRequestEndBytes = 2L
 
-    val smallObject = s3ClientV2.getObject(
+    s3ClientV2.getObject(
       GetObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
         .ifMatch(eTag)
         .range("bytes=$smallRequestStartBytes-$smallRequestEndBytes")
         .build()
-    )
-    assertThat(smallObject.response().contentLength()).isEqualTo(smallRequestEndBytes)
-    assertThat(smallObject.response().contentRange())
-      .isEqualTo("bytes $smallRequestStartBytes-$smallRequestEndBytes/${uploadFile.length()}")
+    ).also {
+      assertThat(it.response().contentLength()).isEqualTo(smallRequestEndBytes)
+      assertThat(it.response().contentRange())
+        .isEqualTo("bytes $smallRequestStartBytes-$smallRequestEndBytes/${uploadFile.length()}")
+    }
 
     val largeRequestStartBytes = 0L
     val largeRequestEndBytes = 1000L
@@ -665,7 +670,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     val sseCustomerKey = "someCustomerKey"
     val sseCustomerKeyMD5 = "someCustomerKeyMD5"
     val ssekmsEncryptionContext = "someEncryptionContext"
-    val putObject = s3ClientV2.putObject(
+    s3ClientV2.putObject(
       PutObjectRequest.builder()
         .bucket(bucketName)
         .key(UPLOAD_FILE_NAME)
@@ -677,12 +682,13 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
         .serverSideEncryption(ServerSideEncryption.AWS_KMS)
         .build(),
       RequestBody.fromFile(uploadFile)
-    )
+    ).also {
+      assertThat(it.ssekmsKeyId()).isEqualTo(TEST_ENC_KEY_ID)
+      assertThat(it.sseCustomerAlgorithm()).isEqualTo(sseCustomerAlgorithm)
+      assertThat(it.sseCustomerKeyMD5()).isEqualTo(sseCustomerKeyMD5)
+      assertThat(it.serverSideEncryption()).isEqualTo(ServerSideEncryption.AWS_KMS)
+    }
 
-    assertThat(putObject.ssekmsKeyId()).isEqualTo(TEST_ENC_KEY_ID)
-    assertThat(putObject.sseCustomerAlgorithm()).isEqualTo(sseCustomerAlgorithm)
-    assertThat(putObject.sseCustomerKeyMD5()).isEqualTo(sseCustomerKeyMD5)
-    assertThat(putObject.serverSideEncryption()).isEqualTo(ServerSideEncryption.AWS_KMS)
 
     s3ClientV2.getObject(
       GetObjectRequest.builder()

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
@@ -106,13 +106,14 @@ internal class LegalHoldV2IT : S3TestBase() {
       .build()
     )
 
-    val objectLegalHold = s3ClientV2.getObjectLegalHold(
+    s3ClientV2.getObjectLegalHold(
       GetObjectLegalHoldRequest
         .builder()
         .bucket(bucketName)
         .key(sourceKey)
         .build()
-    )
-    assertThat(objectLegalHold.legalHold().status()).isEqualTo(ObjectLockLegalHoldStatus.ON)
+    ).also {
+      assertThat(it.legalHold().status()).isEqualTo(ObjectLockLegalHoldStatus.ON)
+    }
   }
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1IT.kt
@@ -176,10 +176,12 @@ internal class ListObjectV1IT : S3TestBase() {
     val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
     s3Client.putObject(PutObjectRequest(bucketName, key, uploadFile))
 
-    val listing = s3Client.listObjects(bucketName, prefix)
-    val summaries = listing.objectSummaries
-    assertThat(summaries).hasSize(1)
-    assertThat(summaries[0].key).isEqualTo(key)
+    s3Client.listObjects(bucketName, prefix).also { listing ->
+      listing.objectSummaries.also {
+        assertThat(it).hasSize(1)
+        assertThat(it[0].key).isEqualTo(key)
+      }
+    }
   }
 
   /**
@@ -205,9 +207,10 @@ internal class ListObjectV1IT : S3TestBase() {
     }
     val listing = s3Client.listObjectsV2(request)
 
-    val summaries = listing.objectSummaries
-    assertThat(summaries).hasSize(1)
-    assertThat(summaries[0].key).isEqualTo(key)
+    listing.objectSummaries.also {
+      assertThat(it).hasSize(1)
+      assertThat(it[0].key).isEqualTo(key)
+    }
   }
 
 
@@ -232,10 +235,12 @@ internal class ListObjectV1IT : S3TestBase() {
       this.encodingType = "url"
     }
 
-    val listing = s3Client.listObjects(lor)
-    val summaries = listing.objectSummaries
-    assertThat(summaries).hasSize(1)
-    assertThat(summaries[0].key).isEqualTo("shouldHonorEncodingType/%01")
+    s3Client.listObjects(lor).also { listing ->
+      listing.objectSummaries.also {
+        assertThat(it).hasSize(1)
+        assertThat(it[0].key).isEqualTo("shouldHonorEncodingType/%01")
+      }
+    }
   }
 
   /**
@@ -255,10 +260,12 @@ internal class ListObjectV1IT : S3TestBase() {
       this.encodingType = "url"
     }
 
-    val listing = s3Client.listObjectsV2(request)
-    val summaries = listing.objectSummaries
-    assertThat(summaries).hasSize(1)
-    assertThat(summaries[0].key).isEqualTo("shouldHonorEncodingType/\u0001")
+    s3Client.listObjectsV2(request).also { listing ->
+      listing.objectSummaries.also {
+        assertThat(it).hasSize(1)
+        assertThat(it[0].key).isEqualTo("shouldHonorEncodingType/\u0001")
+      }
+    }
   }
 
   @Test
@@ -268,9 +275,10 @@ internal class ListObjectV1IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     s3Client.putObject(PutObjectRequest(bucketName, UPLOAD_FILE_NAME, uploadFile))
 
-    val objectListingResult = s3Client.listObjects(bucketName, UPLOAD_FILE_NAME)
-    assertThat(objectListingResult.objectSummaries).hasSizeGreaterThan(0)
-    assertThat(objectListingResult.objectSummaries[0].key).isEqualTo(UPLOAD_FILE_NAME)
+    s3Client.listObjects(bucketName, UPLOAD_FILE_NAME).also {
+      assertThat(it.objectSummaries).hasSizeGreaterThan(0)
+      assertThat(it.objectSummaries[0].key).isEqualTo(UPLOAD_FILE_NAME)
+    }
   }
 
   /**

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1MaxKeysIT.kt
@@ -30,9 +30,10 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
     val bucketName = givenBucketWithTwoObjects(testInfo)
     val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(1)
 
-    val objectListing = s3Client.listObjects(request)
-    assertThat(objectListing.objectSummaries).hasSize(1)
-    assertThat(objectListing.maxKeys).isEqualTo(1)
+    s3Client.listObjects(request).also {
+      assertThat(it.objectSummaries).hasSize(1)
+      assertThat(it.maxKeys).isEqualTo(1)
+    }
   }
 
   @Test
@@ -41,9 +42,10 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
     val bucketName = givenBucketWithTwoObjects(testInfo)
     val request = ListObjectsRequest().withBucketName(bucketName)
 
-    val objectListing = s3Client.listObjects(request)
-    assertThat(objectListing.objectSummaries).hasSize(2)
-    assertThat(objectListing.maxKeys).isEqualTo(1000)
+    s3Client.listObjects(request).also {
+      assertThat(it.objectSummaries).hasSize(2)
+      assertThat(it.maxKeys).isEqualTo(1000)
+    }
   }
 
   @Test
@@ -52,9 +54,10 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
     val bucketName = givenBucketWithTwoObjects(testInfo)
     val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(2)
 
-    val objectListing = s3Client.listObjects(request)
-    assertThat(objectListing.objectSummaries).hasSize(2)
-    assertThat(objectListing.maxKeys).isEqualTo(2)
+    s3Client.listObjects(request).also {
+      assertThat(it.objectSummaries).hasSize(2)
+      assertThat(it.maxKeys).isEqualTo(2)
+    }
   }
 
   @Test
@@ -63,9 +66,10 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
     val bucketName = givenBucketWithTwoObjects(testInfo)
     val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(3)
 
-    val objectListing = s3Client.listObjects(request)
-    assertThat(objectListing.objectSummaries).hasSize(2)
-    assertThat(objectListing.maxKeys).isEqualTo(3)
+    s3Client.listObjects(request).also {
+      assertThat(it.objectSummaries).hasSize(2)
+      assertThat(it.maxKeys).isEqualTo(3)
+    }
   }
 
   @Test
@@ -74,9 +78,10 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
     val bucketName = givenBucketWithTwoObjects(testInfo)
     val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(0)
 
-    val objectListing = s3Client.listObjects(request)
-    assertThat(objectListing.objectSummaries).hasSize(0)
-    assertThat(objectListing.maxKeys).isEqualTo(0)
+    s3Client.listObjects(request).also {
+      assertThat(it.objectSummaries).hasSize(0)
+      assertThat(it.maxKeys).isEqualTo(0)
+    }
   }
 
   @Test
@@ -84,11 +89,11 @@ internal class ListObjectV1MaxKeysIT : S3TestBase() {
   fun returnsAllObjectsIfMaxKeysIsNegative(testInfo: TestInfo) {
     val bucketName = givenBucketWithTwoObjects(testInfo)
     val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(-1)
-    val objectListing = s3Client.listObjects(request)
-
-    // Apparently, the Amazon SDK rejects negative max keys, and by default it's 1000
-    assertThat(objectListing.objectSummaries).hasSize(2)
-    assertThat(objectListing.maxKeys).isEqualTo(1000)
+    s3Client.listObjects(request).also {
+      // Apparently, the Amazon SDK rejects negative max keys, and by default it's 1000
+      assertThat(it.objectSummaries).hasSize(2)
+      assertThat(it.maxKeys).isEqualTo(1000)
+    }
   }
 
   private fun givenBucketWithTwoObjects(testInfo: TestInfo): String {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV1PaginationIT.kt
@@ -30,16 +30,18 @@ internal class ListObjectV1PaginationIT : S3TestBase() {
     val bucketName = givenBucketWithTwoObjects(testInfo)
     val request = ListObjectsRequest().withBucketName(bucketName).withMaxKeys(1)
 
-    val objectListing = s3Client.listObjects(request)
-    assertThat(objectListing.objectSummaries).hasSize(1)
-    assertThat(objectListing.maxKeys).isEqualTo(1)
-    assertThat(objectListing.nextMarker).isEqualTo("a")
-    assertThat(objectListing.isTruncated).isTrue
+    val objectListing = s3Client.listObjects(request).also {
+      assertThat(it.objectSummaries).hasSize(1)
+      assertThat(it.maxKeys).isEqualTo(1)
+      assertThat(it.nextMarker).isEqualTo("a")
+      assertThat(it.isTruncated).isTrue
+    }
 
     val continueRequest = ListObjectsRequest().withBucketName(bucketName).withMarker(objectListing.nextMarker)
-    val continueObjectListing = s3Client.listObjects(continueRequest)
-    assertThat(continueObjectListing.objectSummaries.size).isEqualTo(1)
-    assertThat(continueObjectListing.objectSummaries[0].key).isEqualTo("b")
+    s3Client.listObjects(continueRequest).also {
+      assertThat(it.objectSummaries.size).isEqualTo(1)
+      assertThat(it.objectSummaries[0].key).isEqualTo("b")
+    }
   }
 
   private fun givenBucketWithTwoObjects(testInfo: TestInfo): String {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
@@ -55,19 +55,19 @@ internal class ListObjectV2IT : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val listObjectsV2Response = s3ClientV2.listObjectsV2(
+    s3ClientV2.listObjectsV2(
       ListObjectsV2Request.builder()
         .bucket(bucketName)
         .build()
-    )
-
-    assertThat(listObjectsV2Response.contents())
-      .hasSize(2)
-      .extracting(S3Object::checksumAlgorithm)
-      .containsOnly(
-        Tuple(arrayListOf(ChecksumAlgorithm.SHA256)),
-        Tuple(arrayListOf(ChecksumAlgorithm.SHA256))
-      )
+    ).also {
+      assertThat(it.contents())
+        .hasSize(2)
+        .extracting(S3Object::checksumAlgorithm)
+        .containsOnly(
+          Tuple(arrayListOf(ChecksumAlgorithm.SHA256)),
+          Tuple(arrayListOf(ChecksumAlgorithm.SHA256))
+        )
+    }
   }
 
   @Test
@@ -92,19 +92,19 @@ internal class ListObjectV2IT : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val listObjectsResponse = s3ClientV2.listObjects(
+    s3ClientV2.listObjects(
       ListObjectsRequest.builder()
         .bucket(bucketName)
         .build()
-    )
-
-    assertThat(listObjectsResponse.contents())
-      .hasSize(2)
-      .extracting(S3Object::checksumAlgorithm)
-      .containsOnly(
-        Tuple(arrayListOf(ChecksumAlgorithm.SHA256)),
-        Tuple(arrayListOf(ChecksumAlgorithm.SHA256))
-      )
+    ).also {
+      assertThat(it.contents())
+        .hasSize(2)
+        .extracting(S3Object::checksumAlgorithm)
+        .containsOnly(
+          Tuple(arrayListOf(ChecksumAlgorithm.SHA256)),
+          Tuple(arrayListOf(ChecksumAlgorithm.SHA256))
+        )
+    }
   }
 
   /**
@@ -128,17 +128,19 @@ internal class ListObjectV2IT : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val listing = s3ClientV2.listObjectsV2(
+    s3ClientV2.listObjectsV2(
       ListObjectsV2Request
         .builder()
         .bucket(bucketName)
         .prefix(prefix)
         .encodingType(EncodingType.URL)
         .build()
-    )
-    val summaries = listing.contents()
-    assertThat(summaries).hasSize(1)
-    assertThat(summaries[0].key()).isEqualTo(key)
+    ).also { listing ->
+      listing.contents().also {
+        assertThat(it).hasSize(1)
+        assertThat(it[0].key()).isEqualTo(key)
+      }
+    }
   }
 
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectVersionsV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectVersionsV2IT.kt
@@ -52,18 +52,18 @@ internal class ListObjectVersionsV2IT : S3TestBase() {
       RequestBody.fromFile(uploadFile)
     )
 
-    val listObjectVersionsResponse = s3ClientV2.listObjectVersions(
+    s3ClientV2.listObjectVersions(
       ListObjectVersionsRequest.builder()
         .bucket(bucketName)
         .build()
-    )
-
-    assertThat(listObjectVersionsResponse.versions())
-      .hasSize(2)
-      .extracting(ObjectVersion::checksumAlgorithm)
-      .containsOnly(
-        Tuple(arrayListOf(ChecksumAlgorithm.SHA256)),
-        Tuple(arrayListOf(ChecksumAlgorithm.SHA256))
-      )
+    ).also {
+      assertThat(it.versions())
+        .hasSize(2)
+        .extracting(ObjectVersion::checksumAlgorithm)
+        .containsOnly(
+          Tuple(arrayListOf(ChecksumAlgorithm.SHA256)),
+          Tuple(arrayListOf(ChecksumAlgorithm.SHA256))
+        )
+    }
   }
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV1IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ObjectTaggingV1IT.kt
@@ -44,10 +44,11 @@ internal class ObjectTaggingV1IT : S3TestBase() {
     s3Client.setObjectTagging(setObjectTaggingRequest)
     val getObjectTaggingRequest = GetObjectTaggingRequest(bucketName, s3Object.key)
 
-    val getObjectTaggingResult = s3Client.getObjectTagging(getObjectTaggingRequest)
-    // There should be 'foo:bar' here
-    assertThat(getObjectTaggingResult.tagSet).hasSize(1)
-    assertThat(getObjectTaggingResult.tagSet).contains(tag)
+    s3Client.getObjectTagging(getObjectTaggingRequest).also {
+      // There should be 'foo:bar' here
+      assertThat(it.tagSet).hasSize(1)
+      assertThat(it.tagSet).contains(tag)
+    }
   }
 
   @Test
@@ -65,10 +66,11 @@ internal class ObjectTaggingV1IT : S3TestBase() {
     val s3Object = s3Client.getObject(bucketName, uploadFile.name)
     val getObjectTaggingRequest = GetObjectTaggingRequest(bucketName, s3Object.key)
 
-    val getObjectTaggingResult = s3Client.getObjectTagging(getObjectTaggingRequest)
-    // There should be 'foo:bar' here
-    assertThat(getObjectTaggingResult.tagSet).hasSize(1)
-    assertThat(getObjectTaggingResult.tagSet[0].value).isEqualTo("bar")
+    s3Client.getObjectTagging(getObjectTaggingRequest).also {
+      // There should be 'foo:bar' here
+      assertThat(it.tagSet).hasSize(1)
+      assertThat(it.tagSet[0].value).isEqualTo("bar")
+    }
   }
 
   /**
@@ -91,9 +93,10 @@ internal class ObjectTaggingV1IT : S3TestBase() {
     val s3Object = s3Client.getObject(bucketName, uploadFile.name)
     val getObjectTaggingRequest = GetObjectTaggingRequest(bucketName, s3Object.key)
 
-    val getObjectTaggingResult = s3Client.getObjectTagging(getObjectTaggingRequest)
-    assertThat(getObjectTaggingResult.tagSet).hasSize(2)
-    assertThat(getObjectTaggingResult.tagSet).contains(tag1, tag2)
+    s3Client.getObjectTagging(getObjectTaggingRequest).also {
+      assertThat(it.tagSet).hasSize(2)
+      assertThat(it.tagSet).contains(tag1, tag2)
+    }
   }
 
 
@@ -104,8 +107,9 @@ internal class ObjectTaggingV1IT : S3TestBase() {
     val s3Object = s3Client.getObject(bucketName, UPLOAD_FILE_NAME)
     val getObjectTaggingRequest = GetObjectTaggingRequest(bucketName, s3Object.key)
 
-    val getObjectTaggingResult = s3Client.getObjectTagging(getObjectTaggingRequest)
-    // There shouldn't be any tags here
-    assertThat(getObjectTaggingResult.tagSet).isEmpty()
+    s3Client.getObjectTagging(getObjectTaggingRequest).also {
+      // There shouldn't be any tags here
+      assertThat(it.tagSet).isEmpty()
+    }
   }
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUriV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUriV2IT.kt
@@ -115,16 +115,16 @@ internal class PresignedUriV2IT : S3TestBase() {
     val presignedUrlString = presignedPutObjectRequest.url().toString()
     assertThat(presignedUrlString).isNotBlank()
 
-    val putObject = HttpPut(presignedUrlString).apply {
+    HttpPut(presignedUrlString).apply {
       this.entity = FileEntity(File(UPLOAD_FILE_NAME))
-    }
-
-    httpClient.execute(
-      HttpHost(
-        host, httpPort
-      ), putObject
-    ).use {
-      assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+    }.also {
+      httpClient.execute(
+        HttpHost(
+          host, httpPort
+        ), it
+      ).use {
+        assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+      }
     }
 
     s3ClientV2.getObject(GetObjectRequest
@@ -161,7 +161,7 @@ internal class PresignedUriV2IT : S3TestBase() {
     val presignedUrlString = presignCreateMultipartUpload.url().toString()
     assertThat(presignedUrlString).isNotBlank()
 
-    val postObject = HttpPost(presignedUrlString).apply {
+    HttpPost(presignedUrlString).apply {
       this.entity = StringEntity(
         """<?xml version="1.0" encoding="UTF-8"?>
     <InitiateMultipartUploadResult>
@@ -169,25 +169,27 @@ internal class PresignedUriV2IT : S3TestBase() {
       <Key>fileName</Key>
       <UploadId>uploadId</UploadId>
     </InitiateMultipartUploadResult>
-    """)
-    }
-    httpClient.execute(
-      HttpHost(
-        host, httpPort
-      ), postObject
-    ).use {
-      assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+    """
+      )
+    }.also {
+      httpClient.execute(
+        HttpHost(
+          host, httpPort
+        ), it
+      ).use {
+        assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+      }
     }
 
-    val listMultipartUploads = s3ClientV2.listMultipartUploads(
+    s3ClientV2.listMultipartUploads(
       ListMultipartUploadsRequest
         .builder()
         .bucket(bucketName)
         .keyMarker(key)
         .build()
-    )
-
-    assertThat(listMultipartUploads.uploads()).hasSize(1)
+    ).also {
+      assertThat(it.uploads()).hasSize(1)
+    }
   }
 
   @Test
@@ -234,24 +236,25 @@ internal class PresignedUriV2IT : S3TestBase() {
     val presignedUrlString = presignAbortMultipartUpload.url().toString()
     assertThat(presignedUrlString).isNotBlank()
 
-    val httpDelete = HttpDelete(presignedUrlString)
-    httpClient.execute(
-      HttpHost(
-        host, httpPort
-      ), httpDelete
-    ).use {
-      assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_NO_CONTENT)
+    HttpDelete(presignedUrlString).also {
+      httpClient.execute(
+        HttpHost(
+          host, httpPort
+        ), it
+      ).use {
+        assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_NO_CONTENT)
+      }
     }
 
-    val listMultipartUploads = s3ClientV2.listMultipartUploads(
+    s3ClientV2.listMultipartUploads(
       ListMultipartUploadsRequest
         .builder()
         .bucket(bucketName)
         .keyMarker(key)
         .build()
-    )
-
-    assertThat(listMultipartUploads.uploads()).isEmpty()
+    ).also {
+      assertThat(it.uploads()).isEmpty()
+    }
   }
 
   @Test
@@ -298,7 +301,7 @@ internal class PresignedUriV2IT : S3TestBase() {
     val presignedUrlString = presignCompleteMultipartUpload.url().toString()
     assertThat(presignedUrlString).isNotBlank()
 
-    val httpPost = HttpPost(presignedUrlString).apply {
+    HttpPost(presignedUrlString).apply {
       this.setHeader(BasicHeader("Content-Type", "application/xml"))
       this.entity = StringEntity(
         """<CompleteMultipartUpload>
@@ -308,24 +311,25 @@ internal class PresignedUriV2IT : S3TestBase() {
         </Part>
       </CompleteMultipartUpload>
       """)
-    }
-    httpClient.execute(
-      HttpHost(
-        host, httpPort
-      ), httpPost
-    ).use {
-      assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+    }.also {
+      httpClient.execute(
+        HttpHost(
+          host, httpPort
+        ), it
+      ).use {
+        assertThat(it.statusLine.statusCode).isEqualTo(HttpStatus.SC_OK)
+      }
     }
 
-    val listMultipartUploads = s3ClientV2.listMultipartUploads(
+    s3ClientV2.listMultipartUploads(
       ListMultipartUploadsRequest
         .builder()
         .bucket(bucketName)
         .keyMarker(key)
         .build()
-    )
-
-    assertThat(listMultipartUploads.uploads()).isEmpty()
+    ).also {
+      assertThat(it.uploads()).isEmpty()
+    }
   }
 
 
@@ -394,15 +398,15 @@ internal class PresignedUriV2IT : S3TestBase() {
       s3ClientV2.completeMultipartUpload(completeMultipartUploadRequest)
     }
 
-    val listMultipartUploads = s3ClientV2.listMultipartUploads(
+    s3ClientV2.listMultipartUploads(
       ListMultipartUploadsRequest
         .builder()
         .bucket(bucketName)
         .keyMarker(key)
         .build()
-    )
-
-    assertThat(listMultipartUploads.uploads()).isEmpty()
+    ).also {
+      assertThat(it.uploads()).isEmpty()
+    }
   }
 
 }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/RetentionV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/RetentionV2IT.kt
@@ -119,19 +119,20 @@ internal class RetentionV2IT : S3TestBase() {
         .build()
     )
 
-    val retention = s3ClientV2.getObjectRetention(
+    s3ClientV2.getObjectRetention(
       GetObjectRetentionRequest
         .builder()
         .bucket(bucketName)
         .key(sourceKey)
         .build()
-    )
-    assertThat(retention.retention().mode()).isEqualTo(ObjectLockRetentionMode.COMPLIANCE)
-    //the returned date has MILLIS resolution, the local instant is in NANOS.
-    assertThat(retention.retention().retainUntilDate())
-      .isCloseTo(
-        retainUntilDate, within(1, MILLIS)
-      )
+    ).also {
+      assertThat(it.retention().mode()).isEqualTo(ObjectLockRetentionMode.COMPLIANCE)
+      //the returned date has MILLIS resolution, the local instant is in NANOS.
+      assertThat(it.retention().retainUntilDate())
+        .isCloseTo(
+          retainUntilDate, within(1, MILLIS)
+        )
+    }
   }
 
   @Test

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -73,6 +73,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception
 import software.amazon.awssdk.services.s3.model.S3Object
 import software.amazon.awssdk.services.s3.model.S3Response
 import software.amazon.awssdk.services.s3.model.StorageClass
+import software.amazon.awssdk.services.s3.model.UploadPartResponse
 import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.transfer.s3.S3TransferManager
@@ -567,6 +568,7 @@ internal abstract class S3TestBase {
         is GetObjectResponse -> this.checksumSHA1()
         is PutObjectResponse -> this.checksumSHA1()
         is HeadObjectResponse -> this.checksumSHA1()
+        is UploadPartResponse -> this.checksumSHA1()
         else -> throw RuntimeException("Unexpected response type ${this::class.java}")
       }
     }
@@ -576,6 +578,7 @@ internal abstract class S3TestBase {
         is GetObjectResponse -> this.checksumSHA256()
         is PutObjectResponse -> this.checksumSHA256()
         is HeadObjectResponse -> this.checksumSHA256()
+        is UploadPartResponse -> this.checksumSHA256()
         else -> throw RuntimeException("Unexpected response type ${this::class.java}")
       }
     }
@@ -585,6 +588,7 @@ internal abstract class S3TestBase {
         is GetObjectResponse -> this.checksumCRC32()
         is PutObjectResponse -> this.checksumCRC32()
         is HeadObjectResponse -> this.checksumCRC32()
+        is UploadPartResponse -> this.checksumCRC32()
         else -> throw RuntimeException("Unexpected response type ${this::class.java}")
       }
     }
@@ -594,6 +598,7 @@ internal abstract class S3TestBase {
         is GetObjectResponse -> this.checksumCRC32C()
         is PutObjectResponse -> this.checksumCRC32C()
         is HeadObjectResponse -> this.checksumCRC32C()
+        is UploadPartResponse -> this.checksumCRC32C()
         else -> throw RuntimeException("Unexpected response type ${this::class.java}")
       }
     }

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -87,6 +87,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -615,7 +616,11 @@ public class ObjectController {
       checksumAlgorithm = algorithmFromHeader;
     }
     bucketService.verifyBucketExists(bucketName);
-    objectService.verifyMd5(tempFileAndChecksum.getLeft(), contentMd5);
+    Path tempFile = tempFileAndChecksum.getLeft();
+    objectService.verifyMd5(tempFile, contentMd5);
+    if (checksum != null) {
+      objectService.verifyChecksum(tempFile, checksum, checksumAlgorithm);
+    }
 
     //TODO: need to extract owner from headers
     var owner = Owner.DEFAULT_OWNER;
@@ -624,7 +629,7 @@ public class ObjectController {
             key.key(),
             mediaTypeFrom(contentType).toString(),
             storeHeadersFrom(httpHeaders),
-            tempFileAndChecksum.getLeft(),
+            tempFile,
             userMetadataFrom(httpHeaders),
             encryptionHeadersFrom(httpHeaders),
             tags,
@@ -633,7 +638,7 @@ public class ObjectController {
             owner,
             storageClass);
 
-    FileUtils.deleteQuietly(tempFileAndChecksum.getLeft().toFile());
+    FileUtils.deleteQuietly(tempFile.toFile());
 
     //return version id
     return ResponseEntity

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -282,7 +282,7 @@ public class ObjectService {
     }
   }
 
-  void validateChecksum(Path path, String checksum, ChecksumAlgorithm checksumAlgorithm) {
+  public void verifyChecksum(Path path, String checksum, ChecksumAlgorithm checksumAlgorithm) {
     String checksumFor = DigestUtil.checksumFor(path, checksumAlgorithm.toAlgorithm());
     if (!checksum.equals(checksumFor)) {
       throw BAD_DIGEST;

--- a/server/src/main/java/com/adobe/testing/s3mock/util/HeaderUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/HeaderUtil.java
@@ -175,10 +175,16 @@ public final class HeaderUtil {
 
 
   public static Map<String, String> checksumHeaderFrom(S3ObjectMetadata s3ObjectMetadata) {
-    Map<String, String> headers = new HashMap<>();
     ChecksumAlgorithm checksumAlgorithm = s3ObjectMetadata.checksumAlgorithm();
-    if (checksumAlgorithm != null) {
-      headers.put(mapChecksumToHeader(checksumAlgorithm), s3ObjectMetadata.checksum());
+    String checksum = s3ObjectMetadata.checksum();
+    return checksumHeaderFrom(checksum, checksumAlgorithm);
+  }
+
+  public static Map<String, String> checksumHeaderFrom(String checksum,
+      ChecksumAlgorithm checksumAlgorithm) {
+    Map<String, String> headers = new HashMap<>();
+    if (checksumAlgorithm != null && checksum != null) {
+      headers.put(mapChecksumToHeader(checksumAlgorithm), checksum);
     }
     return headers;
   }


### PR DESCRIPTION
## Description
This works for regular uploads and parts now.
UploadPart API now returns the checksum.

## Related Issue
Fixes #1827

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
