### PR TITLE
Let CopyObject overwrite store headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,20 @@ Version 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Version updates (build dependencies)
   * TBD
 
+## 3.10.2
+3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  *  Let CopyObject overwrite store headers (fixes #2005)
+* Version updates (build dependencies)
+  * Bump org.apache.maven.plugins:maven-deploy-plugin from 3.1.2 to 3.1.3
+  * Bump org.apache.maven.plugins:maven-dependency-plugin from 3.7.1 to 3.8.0
+  * Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0
+  * Bump com.puppycrawl.tools:checkstyle from 10.17.0 to 10.18.1
+  * Bump actions/checkout from 4.1.7 to 4.2.0
+  * Bump github/codeql-action from 3.26.7 to 3.26.9
+  * Bump actions/setup-java from 4.3.0 to 4.4.0
+
 ## 3.10.1
 3.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 

--- a/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/ObjectController.java
@@ -696,9 +696,11 @@ public class ObjectController {
     var s3ObjectMetadata = objectService.verifyObjectExists(copySource.bucket(), copySource.key());
     objectService.verifyObjectMatchingForCopy(match, noneMatch, s3ObjectMetadata);
 
-    Map<String, String> metadata = Collections.emptyMap();
+    Map<String, String> userMetadata = Collections.emptyMap();
+    Map<String, String> storeHeaders = Collections.emptyMap();
     if (MetadataDirective.REPLACE == metadataDirective) {
-      metadata = userMetadataFrom(httpHeaders);
+      userMetadata = userMetadataFrom(httpHeaders);
+      storeHeaders = storeHeadersFrom(httpHeaders);
     }
 
     var copyObjectResult = objectService.copyS3Object(copySource.bucket(),
@@ -706,7 +708,8 @@ public class ObjectController {
         bucketName,
         key.key(),
         encryptionHeadersFrom(httpHeaders),
-        metadata,
+        storeHeaders,
+        userMetadata,
         storageClass);
 
     //return version id / copy source version id

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -80,6 +80,7 @@ public class ObjectService extends ServiceBase {
       String destinationBucketName,
       String destinationKey,
       Map<String, String> encryptionHeaders,
+      Map<String, String> storeHeaders,
       Map<String, String> userMetadata,
       StorageClass storageClass) {
     var sourceBucketMetadata = bucketStore.getBucketMetadata(sourceBucketName);
@@ -93,8 +94,9 @@ public class ObjectService extends ServiceBase {
     if (sourceKey.equals(destinationKey) && sourceBucketName.equals(destinationBucketName)) {
       return objectStore.pretendToCopyS3Object(sourceBucketMetadata,
           sourceId,
-          userMetadata,
           encryptionHeaders,
+          storeHeaders,
+          userMetadata,
           storageClass);
     }
 
@@ -103,7 +105,7 @@ public class ObjectService extends ServiceBase {
     try {
       return objectStore.copyS3Object(sourceBucketMetadata, sourceId,
           destinationBucketMetadata, destinationId, destinationKey,
-          encryptionHeaders, userMetadata, storageClass);
+          encryptionHeaders, storeHeaders, userMetadata, storageClass);
     } catch (Exception e) {
       //something went wrong with writing the destination file, clean up ID from BucketStore.
       bucketStore.removeFromBucket(destinationKey, destinationBucketName);

--- a/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/S3ObjectMetadata.java
@@ -35,6 +35,7 @@ import org.springframework.http.MediaType;
 
 /**
  * Represents an object in S3, used to serialize and deserialize all metadata locally.
+ * <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html">See API</a>
  */
 public record S3ObjectMetadata(
     UUID id,

--- a/server/src/main/resources/application-trace.properties
+++ b/server/src/main/resources/application-trace.properties
@@ -16,3 +16,4 @@
 
 logging.level.root=trace
 logging.level.org.springframework.web=trace
+spring.mvc.log-request-details=true

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/store/ObjectStoreTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/store/ObjectStoreTest.kt
@@ -250,7 +250,7 @@ internal class ObjectStoreTest : StoreTestBase() {
     objectStore.copyS3Object(
       metadataFrom(sourceBucketName), sourceId,
       metadataFrom(destinationBucketName),
-      destinationId, destinationObjectName, emptyMap(), NO_USER_METADATA, StorageClass.STANDARD_IA
+      destinationId, destinationObjectName, emptyMap(), emptyMap(), NO_USER_METADATA, StorageClass.STANDARD_IA
     )
 
     objectStore.getS3ObjectMetadata(metadataFrom(destinationBucketName), destinationId).also {
@@ -288,6 +288,7 @@ internal class ObjectStoreTest : StoreTestBase() {
       destinationId,
       destinationObjectName,
       encryptionHeaders(),
+      emptyMap(),
       NO_USER_METADATA,
       StorageClass.STANDARD_IA
     )


### PR DESCRIPTION
## Description
The headers we store as "storeHeaders" are part of the
"System-defined object metadata" which can be the only metadata
overwritten when copying objects.

See also https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#SysMetadata

## Related Issue
Fixes #2005

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
