### PR TITLE
Use Tomcat instead of Jetty

### DIFF
--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
@@ -100,7 +100,7 @@ internal class PlainHttpIT : S3TestBase() {
   fun putHeadObject_withUserMetadata(testInfo: TestInfo) {
     val targetBucket = givenBucketV2(testInfo)
     val byteArray = UUID.randomUUID().toString().toByteArray()
-    val amzMetaHeaderKey = "X-Amz-Meta-My-Key"
+    val amzMetaHeaderKey = "x-amz-meta-my-key"
     val amzMetaHeaderValue = "MY_DATA"
     val putObject = HttpPut("/$targetBucket/testObjectName").apply {
       this.entity = ByteArrayEntity(byteArray)

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <!-- Run Docker build by default -->
     <skipDocker>false</skipDocker>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
-    <spring-boot.version>3.3.3</spring-boot.version>
+    <spring-boot.version>3.3.5</spring-boot.version>
     <testcontainers.version>1.20.1</testcontainers.version>
     <testng.version>7.10.2</testng.version>
     <xmlunit-assertj3.version>2.10.0</xmlunit-assertj3.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -110,11 +110,6 @@
       <artifactId>spring-boot-devtools</artifactId>
       <optional>true</optional>
     </dependency>
-    <!-- Use Jetty instead of tomcat -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jetty</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -123,12 +118,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-tomcat</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -283,7 +283,7 @@ public class S3MockApplication {
    */
   @Deprecated(since = "2.12.2", forRemoval = true)
   public int getHttpPort() {
-    return config.getHttpServerConnector().getLocalPort();
+    return config.getHttpConnector().getLocalPort();
   }
 
   /**

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package com.adobe.testing.s3mock;
 
 import static java.util.Collections.emptyMap;

--- a/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3MockApplication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2023 Adobe.
+ *  Copyright 2017-2024 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package com.adobe.testing.s3mock;
 
 import static java.util.Collections.emptyMap;

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017-2022 Adobe.
+#  Copyright 2017-2024 Adobe.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
 #
 
 # server.ssl.* are moved to S3MockApplication#start so users can override them
-# The values in application.properties can't be overriden by SpringApplicationBuilder#properties
+# The values in application.properties can't be overridden by SpringApplicationBuilder#properties
 
 logging.level.org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver=ERROR
-logging.level.org.eclipse.jetty.util.ssl.SslContextFactory.config=ERROR
 
 # deactivate JMX to save resources and startup time
 spring.jmx.enabled=false


### PR DESCRIPTION
## Description
The AWS CRT-based S3 client does not work with Jetty 12.0.13+ (probably due to changed behaviour with 100-continue requests). With Tomcat, the CRT client works fine.

## Related Issue
#2136

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
