### PR TITLE
Refactor deletion of all files on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,13 +138,17 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Features and fixes
   * Allow overriding headers in head object
   * Implement If-(Un)modified-Since handling (fixes #829)
+  * Close all InputStreams and OutputStreams
 * Refactorings
   * Use Tomcat instead of Jetty as the application container (fixes #2136)
   * "FROM" in Dockerfile did not match "as"
+  * Delete files on shutdown using a `DisposableBean` instead of `File#deleteOnExit()`
 * Version updates (deliverable dependencies)
-  * none
+  * Bump spring-boot.version from 3.3.5 to 3.4.1
 * Version updates (build dependencies)
   * Bump github/codeql-action from 3.27.6 to 3.27.9
+  * Bump actions/upload-artifact from 4.4.3 to 4.5.0
+  * Bump actions/setup-java from 4.5.0 to 4.6.0
   * Bump com.puppycrawl.tools:checkstyle from 10.20.2 to 10.21.0
   * Jackson 2.18.2 to 2.17.2 (remove override, use Spring-Boot supplied version)
 

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ServiceBase.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ServiceBase.java
@@ -58,8 +58,8 @@ abstract class ServiceBase {
   public Pair<Path, String> toTempFile(InputStream inputStream, HttpHeaders httpHeaders) {
     try {
       var tempFile = Files.createTempFile("ObjectService", "toTempFile");
-      try (OutputStream os = Files.newOutputStream(tempFile)) {
-        InputStream wrappedStream = wrapStream(inputStream, httpHeaders);
+      try (var os = Files.newOutputStream(tempFile);
+           var wrappedStream = wrapStream(inputStream, httpHeaders)) {
         wrappedStream.transferTo(os);
         ChecksumAlgorithm algorithmFromSdk = checksumAlgorithmFromSdk(httpHeaders);
         if (algorithmFromSdk != null

--- a/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/BucketStore.java
@@ -51,16 +51,13 @@ public class BucketStore {
    */
   private final Map<String, Object> lockStore = new ConcurrentHashMap<>();
   private final File rootFolder;
-  private final boolean retainFilesOnExit;
   private final DateTimeFormatter s3ObjectDateFormat;
   private final ObjectMapper objectMapper;
 
   public BucketStore(File rootFolder,
-      boolean retainFilesOnExit,
       DateTimeFormatter s3ObjectDateFormat,
       ObjectMapper objectMapper) {
     this.rootFolder = rootFolder;
-    this.retainFilesOnExit = retainFilesOnExit;
     this.s3ObjectDateFormat = s3ObjectDateFormat;
     this.objectMapper = objectMapper;
   }
@@ -309,9 +306,6 @@ public class BucketStore {
   private void writeToDisk(BucketMetadata bucketMetadata) {
     try {
       var metaFile = getMetaFilePath(bucketMetadata.name()).toFile();
-      if (!retainFilesOnExit) {
-        metaFile.deleteOnExit();
-      }
       synchronized (lockStore.get(bucketMetadata.name())) {
         objectMapper.writeValue(metaFile, bucketMetadata);
       }
@@ -328,9 +322,6 @@ public class BucketStore {
     try {
       var bucketFolder = getBucketFolderPath(bucketName).toFile();
       FileUtils.forceMkdir(bucketFolder);
-      if (!retainFilesOnExit) {
-        bucketFolder.deleteOnExit();
-      }
       return bucketFolder;
     } catch (final IOException e) {
       throw new IllegalStateException("Can't create bucket directory!", e);

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
@@ -50,7 +50,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.StreamSupport;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang3.stream.Streams;
 import org.slf4j.Logger;
@@ -249,29 +248,33 @@ public class MultipartStore extends StoreBase {
             )
             .toList();
     Path tempFile = null;
-    try (var inputStream = toInputStream(partsPaths)) {
+    try {
       tempFile = Files.createTempFile("completeMultipartUpload", "");
-      inputStream.transferTo(Files.newOutputStream(tempFile));
-      var checksumFor = checksumFor(partsPaths, uploadInfo);
-      var etag = hexDigestMultipart(partsPaths);
-      objectStore.storeS3ObjectMetadata(bucket,
-          id,
-          key,
-          uploadInfo.contentType(),
-          uploadInfo.storeHeaders(),
-          tempFile,
-          uploadInfo.userMetadata(),
-          encryptionHeaders,
-          etag,
-          Collections.emptyList(), //TODO: no tags for multi part uploads?
-          uploadInfo.checksumAlgorithm(),
-          checksumFor,
-          uploadInfo.upload().owner(),
-          uploadInfo.storageClass()
-      );
-      FileUtils.deleteDirectory(partFolder.toFile());
-      return new CompleteMultipartUploadResult(location, uploadInfo.bucket(),
-          key, etag, uploadInfo, checksumFor);
+
+      try (var is = toInputStream(partsPaths);
+           var os = newOutputStream(tempFile)) {
+        is.transferTo(os);
+        var checksumFor = checksumFor(partsPaths, uploadInfo);
+        var etag = hexDigestMultipart(partsPaths);
+        objectStore.storeS3ObjectMetadata(bucket,
+            id,
+            key,
+            uploadInfo.contentType(),
+            uploadInfo.storeHeaders(),
+            tempFile,
+            uploadInfo.userMetadata(),
+            encryptionHeaders,
+            etag,
+            Collections.emptyList(), //TODO: no tags for multi part uploads?
+            uploadInfo.checksumAlgorithm(),
+            checksumFor,
+            uploadInfo.upload().owner(),
+            uploadInfo.storageClass()
+        );
+        FileUtils.deleteDirectory(partFolder.toFile());
+        return new CompleteMultipartUploadResult(location, uploadInfo.bucket(),
+            key, etag, uploadInfo, checksumFor);
+      }
     } catch (IOException e) {
       throw new IllegalStateException(String.format(
           "Error finishing multipart upload bucket=%s, key=%s, id=%s, uploadId=%s",
@@ -381,13 +384,13 @@ public class MultipartStore extends StoreBase {
         var targetStream = newOutputStream(partFile.toPath())) {
       var skip = sourceStream.skip(from);
       if (skip == from) {
-        IOUtils.copy(BoundedInputStream
+        try (var bis = BoundedInputStream
             .builder()
             .setInputStream(sourceStream)
             .setMaxCount(len)
-            .get(),
-            targetStream
-        );
+            .get()) {
+          bis.transferTo(targetStream);
+        }
       } else {
         throw new IllegalStateException("Could not skip exact byte range");
       }

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreBase.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreBase.java
@@ -34,13 +34,10 @@ abstract class StoreBase {
    *
    * @return the newly created File.
    */
-  File inputPathToFile(Path inputPath, Path filePath, boolean retainFilesOnExit) {
+  File inputPathToFile(Path inputPath, Path filePath) {
     var targetFile = filePath.toFile();
     try {
-      if (targetFile.createNewFile() && (!retainFilesOnExit)) {
-        targetFile.deleteOnExit();
-      }
-
+      targetFile.createNewFile();
       try (var is = newInputStream(inputPath);
            var os = newOutputStream(targetFile.toPath())) {
         is.transferTo(os);

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreCleaner.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreCleaner.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2017-2024 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.store;
+
+import static org.apache.commons.io.FileUtils.cleanDirectory;
+import static org.apache.commons.io.FileUtils.deleteDirectory;
+import static org.apache.commons.io.FileUtils.isSymlink;
+
+import java.io.File;
+import org.springframework.beans.factory.DisposableBean;
+
+public class StoreCleaner implements DisposableBean {
+
+  private final File rootFolder;
+  private final boolean retainFilesOnExit;
+
+  public StoreCleaner(File rootFolder, boolean retainFilesOnExit) {
+    this.rootFolder = rootFolder;
+    this.retainFilesOnExit = retainFilesOnExit;
+  }
+
+  @Override
+  public void destroy() throws Exception {
+    if (!retainFilesOnExit && rootFolder.exists()) {
+      cleanDirectory(rootFolder);
+    }
+  }
+}

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreConfiguration.java
@@ -46,8 +46,7 @@ public class StoreConfiguration {
   @Bean
   ObjectStore objectStore(StoreProperties properties, List<String> bucketNames,
                           BucketStore bucketStore, ObjectMapper objectMapper) {
-    var objectStore = new ObjectStore(properties.retainFilesOnExit(),
-        S3_OBJECT_DATE_FORMAT, objectMapper);
+    var objectStore = new ObjectStore(S3_OBJECT_DATE_FORMAT, objectMapper);
     for (var bucketName : bucketNames) {
       var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
       if (bucketMetadata != null) {
@@ -60,8 +59,7 @@ public class StoreConfiguration {
   @Bean
   BucketStore bucketStore(StoreProperties properties, File rootFolder, List<String> bucketNames,
                           ObjectMapper objectMapper) {
-    var bucketStore = new BucketStore(rootFolder, properties.retainFilesOnExit(),
-        S3_OBJECT_DATE_FORMAT, objectMapper);
+    var bucketStore = new BucketStore(rootFolder, S3_OBJECT_DATE_FORMAT, objectMapper);
     //load existing buckets first
     bucketStore.loadBuckets(bucketNames);
 
@@ -112,7 +110,7 @@ public class StoreConfiguration {
   MultipartStore multipartStore(StoreProperties properties,
       ObjectStore objectStore,
       ObjectMapper objectMapper) {
-    return new MultipartStore(properties.retainFilesOnExit(), objectStore, objectMapper);
+    return new MultipartStore(objectStore, objectMapper);
   }
 
   @Bean
@@ -151,11 +149,11 @@ public class StoreConfiguration {
             root.getAbsolutePath(), properties.retainFilesOnExit());
       }
     }
-
-    if (!properties.retainFilesOnExit()) {
-      root.deleteOnExit();
-    }
-
     return root;
+  }
+
+  @Bean
+  StoreCleaner storeCleaner(File rootFolder, StoreProperties storeProperties) {
+    return new StoreCleaner(rootFolder, storeProperties.retainFilesOnExit());
   }
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/util/DigestUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/DigestUtil.java
@@ -72,7 +72,7 @@ public final class DigestUtil {
    * @param algorithm algorithm to use
    * @return the checksum
    */
-  public static String checksumFor(InputStream is, Algorithm algorithm) {
+  private static String checksumFor(InputStream is, Algorithm algorithm) {
     return BinaryUtils.toBase64(checksum(is, algorithm));
   }
 
@@ -83,7 +83,7 @@ public final class DigestUtil {
    * @param algorithm algorithm to use
    * @return the checksum
    */
-  public static byte[] checksum(InputStream is, Algorithm algorithm) {
+  private static byte[] checksum(InputStream is, Algorithm algorithm) {
     SdkChecksum sdkChecksum = SdkChecksum.forAlgorithm(algorithm);
     try {
       byte[] buffer = new byte[4096];
@@ -230,7 +230,7 @@ public final class DigestUtil {
    *
    * @return String Base64 MD5 digest.
    */
-  public static String base64Digest(String salt, InputStream inputStream) {
+  private static String base64Digest(String salt, InputStream inputStream) {
     return Base64.encodeBase64String(md5(salt, inputStream));
   }
 

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/ObjectControllerTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/ObjectControllerTest.kt
@@ -620,7 +620,7 @@ internal class ObjectControllerTest : BaseControllerTest() {
       return S3ObjectMetadata(
         UUID.randomUUID(),
         id,
-        "1234",
+        Path.of(UPLOAD_FILE_NAME).toFile().length().toString(),
         "1234",
         digest,
         "text/plain",

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/ObjectControllerTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/ObjectControllerTest.kt
@@ -319,14 +319,14 @@ internal class ObjectControllerTest : BaseControllerTest() {
       .thenReturn(expectedS3ObjectMetadata)
 
     val headers = HttpHeaders().apply {
-      this.accept = listOf(MediaType.APPLICATION_XML)
+      this.accept = listOf(MediaType.ALL)
       this.contentType = MediaType.TEXT_PLAIN
     }
     val response = restTemplate.exchange(
       "/test-bucket/$key",
       HttpMethod.GET,
       HttpEntity<Any>(headers),
-      Void::class.java
+      ByteArray::class.java
     )
 
     assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
@@ -623,7 +623,7 @@ internal class ObjectControllerTest : BaseControllerTest() {
         "1234",
         "1234",
         digest,
-        null,
+        "text/plain",
         1L,
         Path.of(UPLOAD_FILE_NAME),
         null,

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/store/StoresWithExistingFileRootTest.kt
@@ -101,18 +101,12 @@ internal class StoresWithExistingFileRootTest : StoreTestBase() {
       properties: StoreProperties, rootFolder: File?,
       objectMapper: ObjectMapper?
     ): BucketStore {
-      return BucketStore(
-        rootFolder, properties.retainFilesOnExit,
-        StoreConfiguration.S3_OBJECT_DATE_FORMAT, objectMapper
-      )
+      return BucketStore(rootFolder, StoreConfiguration.S3_OBJECT_DATE_FORMAT, objectMapper)
     }
 
     @Bean
     open fun testObjectStore(properties: StoreProperties, objectMapper: ObjectMapper?): ObjectStore {
-      return ObjectStore(
-        properties.retainFilesOnExit,
-        StoreConfiguration.S3_OBJECT_DATE_FORMAT, objectMapper
-      )
+      return ObjectStore(StoreConfiguration.S3_OBJECT_DATE_FORMAT, objectMapper)
     }
 
     @Bean


### PR DESCRIPTION
## Description
Refactor deletion at exit to use a `DisposableBean` instead of `File#deleteOnExit()`.
Also: close all InputStreams and OutputStreams.

## Related Issue
#2143

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
