### PR TITLE
IT correctness, refactoring, remove V1 SDK

### DIFF
--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEndcodingITV2.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEndcodingITV2.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.checksums.Algorithm
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm
-import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -54,11 +52,11 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
     val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), Algorithm.SHA256)
 
     val putObjectResponse = s3ClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucket)
-        .key(UPLOAD_FILE_NAME)
-        .checksumAlgorithm(ChecksumAlgorithm.SHA256)
-        .build(),
+      {
+        it.bucket(bucket)
+        it.key(UPLOAD_FILE_NAME)
+        it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
@@ -67,12 +65,10 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
       assertThat(it).isEqualTo(expectedChecksum)
     }
 
-    s3ClientV2.getObject(
-      GetObjectRequest.builder()
-        .bucket(bucket)
-        .key(UPLOAD_FILE_NAME)
-        .build()
-    ).also { getObjectResponse ->
+    s3ClientV2.getObject {
+      it.bucket(bucket)
+      it.key(UPLOAD_FILE_NAME)
+    }.also { getObjectResponse ->
       assertThat(getObjectResponse.response().eTag()).isEqualTo(expectedEtag)
       assertThat(getObjectResponse.response().contentLength()).isEqualTo(uploadFile.length())
 
@@ -100,19 +96,17 @@ internal class AwsChunkedEndcodingITV2 : S3TestBase() {
     val expectedEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
 
     s3ClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucket)
-        .key(UPLOAD_FILE_NAME)
-        .build(),
+      {
+        it.bucket(bucket)
+        it.key(UPLOAD_FILE_NAME)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
-    s3ClientV2.getObject(
-      GetObjectRequest.builder()
-        .bucket(bucket)
-        .key(UPLOAD_FILE_NAME)
-        .build()
-    ).also {
+    s3ClientV2.getObject {
+      it.bucket(bucket)
+      it.key(UPLOAD_FILE_NAME)
+    }.also {
       assertThat(it.response().eTag()).isEqualTo(expectedEtag)
       assertThat(it.response().contentLength()).isEqualTo(uploadFile.length())
     }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/BucketV2IT.kt
@@ -28,19 +28,15 @@ import software.amazon.awssdk.services.s3.model.AbortIncompleteMultipartUpload
 import software.amazon.awssdk.services.s3.model.BucketLifecycleConfiguration
 import software.amazon.awssdk.services.s3.model.BucketVersioningStatus
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
-import software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleRequest
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
 import software.amazon.awssdk.services.s3.model.ExpirationStatus
 import software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationRequest
-import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest
-import software.amazon.awssdk.services.s3.model.HeadBucketRequest
 import software.amazon.awssdk.services.s3.model.LifecycleExpiration
 import software.amazon.awssdk.services.s3.model.LifecycleRule
 import software.amazon.awssdk.services.s3.model.LifecycleRuleFilter
 import software.amazon.awssdk.services.s3.model.MFADelete
 import software.amazon.awssdk.services.s3.model.MFADeleteStatus
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException
-import software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationRequest
 import java.util.concurrent.TimeUnit
 
 /**
@@ -51,22 +47,20 @@ internal class BucketV2IT : S3TestBase() {
   private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun createAndDeleteBucket(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
     s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
 
-    val bucketCreated = s3ClientV2.waiter()
-      .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    val bucketCreated = s3ClientV2.waiter().waitUntilBucketExists { it.bucket(bucketName) }
     val bucketCreatedResponse = bucketCreated.matched().response().get()
     assertThat(bucketCreatedResponse).isNotNull
 
     //does not throw exception if bucket exists.
-    s3ClientV2.headBucket(HeadBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.headBucket { it.bucket(bucketName) }
 
-    s3ClientV2.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build())
-    val bucketDeleted = s3ClientV2.waiter()
-      .waitUntilBucketNotExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.deleteBucket { it.bucket(bucketName) }
+    val bucketDeleted = s3ClientV2.waiter().waitUntilBucketNotExists { it.bucket(bucketName) }
     bucketDeleted.matched().exception().get().also {
       assertThat(it).isNotNull
       assertThat(it).isInstanceOf(NoSuchBucketException::class.java)
@@ -74,16 +68,16 @@ internal class BucketV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun getBucketLocation(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
-    val bucketLocation = s3ClientV2.getBucketLocation(GetBucketLocationRequest.builder().bucket(bucketName).build())
+    val bucketLocation = s3ClientV2.getBucketLocation { it.bucket(bucketName) }
 
     assertThat(bucketLocation.locationConstraint().toString()).isEqualTo("eu-west-1")
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun getDefaultBucketVersioning(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
 
@@ -96,7 +90,7 @@ internal class BucketV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun putAndGetBucketVersioning(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
     s3ClientV2.putBucketVersioning {
@@ -114,7 +108,7 @@ internal class BucketV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun putAndGetBucketVersioning_suspended(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
     s3ClientV2.putBucketVersioning {
@@ -166,19 +160,18 @@ internal class BucketV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun duplicateBucketCreation(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
-    s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.createBucket { it.bucket(bucketName) }
 
-    val bucketCreated = s3ClientV2.waiter()
-      .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    val bucketCreated = s3ClientV2.waiter().waitUntilBucketExists { it.bucket(bucketName) }
     bucketCreated.matched().response().get().also {
       assertThat(it).isNotNull
     }
 
     assertThatThrownBy {
-      s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+      s3ClientV2.createBucket { it.bucket(bucketName) }
     }
       .isInstanceOf(AwsServiceException::class.java)
       .hasMessageContaining("Service: S3, Status Code: 409")
@@ -187,9 +180,8 @@ internal class BucketV2IT : S3TestBase() {
       .extracting(AwsErrorDetails::errorCode)
       .isEqualTo("BucketAlreadyOwnedByYou")
 
-    s3ClientV2.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build())
-    val bucketDeleted = s3ClientV2.waiter()
-      .waitUntilBucketNotExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.deleteBucket { it.bucket(bucketName) }
+    val bucketDeleted = s3ClientV2.waiter().waitUntilBucketNotExists { it.bucket(bucketName) }
 
     bucketDeleted.matched().exception().get().also {
       assertThat(it).isNotNull
@@ -198,20 +190,18 @@ internal class BucketV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun duplicateBucketDeletion(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
-    s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.createBucket { it.bucket(bucketName) }
 
-    val bucketCreated = s3ClientV2.waiter()
-      .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    val bucketCreated = s3ClientV2.waiter().waitUntilBucketExists { it.bucket(bucketName) }
     bucketCreated.matched().response().get().also {
       assertThat(it).isNotNull
     }
 
-    s3ClientV2.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build())
-    val bucketDeleted = s3ClientV2.waiter()
-      .waitUntilBucketNotExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.deleteBucket { it.bucket(bucketName) }
+    val bucketDeleted = s3ClientV2.waiter().waitUntilBucketNotExists { it.bucket(bucketName) }
     bucketDeleted.matched().exception().get().also {
       assertThat(it).isNotNull
       assertThat(it).isInstanceOf(NoSuchBucketException::class.java)
@@ -229,20 +219,17 @@ internal class BucketV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun getBucketLifecycle_notFound(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
-    s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.createBucket { it.bucket(bucketName) }
 
-    val bucketCreated = s3ClientV2.waiter()
-      .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    val bucketCreated = s3ClientV2.waiter().waitUntilBucketExists { it.bucket(bucketName) }
     val bucketCreatedResponse = bucketCreated.matched().response()!!.get()
     assertThat(bucketCreatedResponse).isNotNull
 
     assertThatThrownBy {
-      s3ClientV2.getBucketLifecycleConfiguration(
-        GetBucketLifecycleConfigurationRequest.builder().bucket(bucketName).build()
-      )
+      s3ClientV2.getBucketLifecycleConfiguration { it.bucket(bucketName) }
     }
       .isInstanceOf(AwsServiceException::class.java)
       .hasMessageContaining("Service: S3, Status Code: 404")
@@ -253,13 +240,12 @@ internal class BucketV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun putGetDeleteBucketLifecycle(testInfo: TestInfo) {
     val bucketName = bucketName(testInfo)
-    s3ClientV2.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+    s3ClientV2.createBucket { it.bucket(bucketName) }
 
-    val bucketCreated = s3ClientV2.waiter()
-      .waitUntilBucketExists(HeadBucketRequest.builder().bucket(bucketName).build())
+    val bucketCreated = s3ClientV2.waiter().waitUntilBucketExists { it.bucket(bucketName) }
     bucketCreated.matched().response()!!.get().also {
       assertThat(it).isNotNull
     }
@@ -288,28 +274,16 @@ internal class BucketV2IT : S3TestBase() {
       )
       .build()
 
-    s3ClientV2.putBucketLifecycleConfiguration(
-      PutBucketLifecycleConfigurationRequest
-        .builder()
-        .bucket(bucketName)
-        .lifecycleConfiguration(
-          configuration
-        )
-        .build()
-    )
+    s3ClientV2.putBucketLifecycleConfiguration {
+      it.bucket(bucketName)
+      it.lifecycleConfiguration(configuration)
+    }
 
-    s3ClientV2.getBucketLifecycleConfiguration(
-      GetBucketLifecycleConfigurationRequest
-        .builder()
-        .bucket(bucketName)
-        .build()
-    ).also {
+    s3ClientV2.getBucketLifecycleConfiguration { it.bucket(bucketName) }.also {
       assertThat(it.rules()[0]).isEqualTo(configuration.rules()[0])
     }
 
-    s3ClientV2.deleteBucketLifecycle(
-      DeleteBucketLifecycleRequest.builder().bucket(bucketName).build()
-    ).also {
+    s3ClientV2.deleteBucketLifecycle { it.bucket(bucketName) }.also {
       assertThat(it.sdkHttpResponse().statusCode()).isEqualTo(204)
     }
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ConcurrencyIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ConcurrencyIT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,9 +21,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
-import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -37,8 +34,10 @@ internal class ConcurrencyIT : S3TestBase() {
    * the same bucket.
    */
   @Test
-  @S3VerifiedFailure(year = 2022,
-    reason = "No need to test S3 concurrency.")
+  @S3VerifiedFailure(
+    year = 2022,
+    reason = "No need to test S3 concurrency."
+  )
   fun concurrentBucketPutGetAndDeletes(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
     val runners = mutableListOf<Runner>()
@@ -62,32 +61,25 @@ internal class ConcurrencyIT : S3TestBase() {
     override fun call(): Boolean {
       LATCH.countDown()
       s3ClientV2.putObject(
-        PutObjectRequest
-          .builder()
-          .bucket(bucketName)
-          .key(key)
-          .build(), RequestBody.empty()
+        {
+          it.bucket(bucketName)
+          it.key(key)
+        }, RequestBody.empty()
       ).also {
         assertThat(it.eTag()).isNotBlank
       }
 
-      s3ClientV2.getObject(
-        GetObjectRequest
-          .builder()
-          .bucket(bucketName)
-          .key(key)
-          .build()
-      ).also {
+      s3ClientV2.getObject {
+        it.bucket(bucketName)
+        it.key(key)
+      }.also {
         assertThat(it.response().eTag()).isNotBlank
       }
 
-      s3ClientV2.deleteObject(
-        DeleteObjectRequest
-          .builder()
-          .bucket(bucketName)
-          .key(key)
-          .build()
-      ).also {
+      s3ClientV2.deleteObject {
+        it.bucket(bucketName)
+        it.key(key)
+      }.also {
         assertThat(it.deleteMarker()).isTrue
       }
       DONE.incrementAndGet()

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   private val s3ClientV2: S3Client = createS3ClientV2()
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObject(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObjectV2(testInfo, sourceKey)
@@ -72,7 +72,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObject_successMatch(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObjectV2(testInfo, sourceKey)
@@ -101,7 +101,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObject_successNoneMatch(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObjectV2(testInfo, sourceKey)
@@ -129,7 +129,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObject_failureMatch(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, sourceKey)
@@ -153,7 +153,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObject_failureNoneMatch(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObjectV2(testInfo, sourceKey)
@@ -177,7 +177,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObjectToSameBucketAndKey(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
@@ -238,7 +238,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObjectToSameBucketAndKey_throws(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
@@ -279,7 +279,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObjectWithNewMetadata(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObjectV2(testInfo, sourceKey)
@@ -312,7 +312,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObject_storageClass(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val uploadFile = File(UPLOAD_FILE_NAME)
@@ -351,7 +351,7 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun testCopyObject_overwriteStoreHeader(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val uploadFile = File(UPLOAD_FILE_NAME)
@@ -390,7 +390,8 @@ internal class CopyObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedFailure(year = 2025,
+    reason = "Requests specifying Server Side Encryption with Customer provided keys must provide a valid encryption algorithm")
   fun testCopyObject_encrypted(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val uploadFile = File(UPLOAD_FILE_NAME)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CrtAsyncV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CrtAsyncV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,17 +25,8 @@ import org.springframework.web.util.UriUtils
 import software.amazon.awssdk.core.async.AsyncRequestBody
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
 import software.amazon.awssdk.services.s3.S3AsyncClient
-import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest
-import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload
-import software.amazon.awssdk.services.s3.model.CompletedPart
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest
-import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
-import software.amazon.awssdk.services.s3.model.UploadPartRequest
 import software.amazon.awssdk.transfer.s3.S3TransferManager
 import software.amazon.awssdk.transfer.s3.model.DownloadRequest
-import software.amazon.awssdk.transfer.s3.model.UploadRequest
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
@@ -56,17 +47,15 @@ internal class CrtAsyncV2IT : S3TestBase() {
 
     val bucketName = randomName
     autoS3CrtAsyncClientV2
-      .createBucket(CreateBucketRequest
-        .builder()
-        .bucket(bucketName)
-        .build()
-      ).join()
+      .createBucket {
+        it.bucket(bucketName)
+      }.join()
 
     val putObjectResponse = autoS3CrtAsyncClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+      },
       AsyncRequestBody.fromFile(uploadFile)
     ).join()
 
@@ -82,24 +71,23 @@ internal class CrtAsyncV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = randomName
     autoS3CrtAsyncClientV2
-      .createBucket(CreateBucketRequest
-        .builder()
-        .bucket(bucketName)
-        .build()
-      ).join()
+      .createBucket {
+        it.bucket(bucketName)
+      }.join()
 
     val eTag = autoS3CrtAsyncClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucketName).key(UPLOAD_FILE_NAME).build(),
+      {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+      },
       AsyncRequestBody.fromFile(uploadFile)
     ).join().eTag()
 
     autoS3CrtAsyncClientV2.getObject(
-      GetObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+      },
       AsyncResponseTransformer.toBytes()
     ).join().also {
       assertThat(it.response().eTag()).isEqualTo(eTag)
@@ -114,10 +102,11 @@ internal class CrtAsyncV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val objectMetadata = mapOf(Pair("key", "value"))
     val createMultipartUploadResponseCompletableFuture = autoS3CrtAsyncClientV2
-      .createMultipartUpload(
-        CreateMultipartUploadRequest.builder().bucket(bucketName).key(UPLOAD_FILE_NAME)
-          .metadata(objectMetadata).build()
-      )
+      .createMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.metadata(objectMetadata)
+      }
     val initiateMultipartUploadResult = createMultipartUploadResponseCompletableFuture.join()
     val uploadId = initiateMultipartUploadResult.uploadId()
     // upload part 1, >5MB
@@ -125,52 +114,39 @@ internal class CrtAsyncV2IT : S3TestBase() {
     val partETag = uploadPart(bucketName, UPLOAD_FILE_NAME, uploadId, 1, randomBytes)
     // upload part 2, <5MB
     val uploadPartResponse = autoS3CrtAsyncClientV2.uploadPart(
-      UploadPartRequest
-        .builder()
-        .bucket(initiateMultipartUploadResult.bucket())
-        .key(initiateMultipartUploadResult.key())
-        .uploadId(uploadId)
-        .partNumber(2)
-        .contentLength(uploadFile.length()).build(),
-      //.lastPart(true)
+      {
+        it.bucket(initiateMultipartUploadResult.bucket())
+        it.key(initiateMultipartUploadResult.key())
+        it.uploadId(uploadId)
+        it.partNumber(2)
+        it.contentLength(uploadFile.length())
+        //it.lastPart(true)
+      },
       AsyncRequestBody.fromFile(uploadFile),
     ).join()
 
-    val completeMultipartUploadResponse = autoS3CrtAsyncClientV2.completeMultipartUpload(
-      CompleteMultipartUploadRequest
-        .builder()
-        .bucket(initiateMultipartUploadResult.bucket())
-        .key(initiateMultipartUploadResult.key())
-        .uploadId(initiateMultipartUploadResult.uploadId())
-        .multipartUpload(
-          CompletedMultipartUpload
-            .builder()
-            .parts(
-              CompletedPart
-                .builder()
-                .eTag(partETag)
-                .partNumber(1)
-                .build(),
-              CompletedPart
-                .builder()
-                .eTag(uploadPartResponse.eTag())
-                .partNumber(2)
-                .build()
-            )
-            .build()
-        )
-        .build()
-    ).join()
+    val completeMultipartUploadResponse = autoS3CrtAsyncClientV2.completeMultipartUpload {
+      it.bucket(initiateMultipartUploadResult.bucket())
+      it.key(initiateMultipartUploadResult.key())
+      it.uploadId(initiateMultipartUploadResult.uploadId())
+      it.multipartUpload {
+        it.parts(
+          {
+            it.eTag(partETag)
+            it.partNumber(1)
+          },
+          {
+            it.eTag(uploadPartResponse.eTag())
+            it.partNumber(2)
+          })
+      }
+    }.join()
 
     // Verify only 1st and 3rd counts
-    val getObjectResponse = autoS3CrtAsyncClientV2.getObject(
-      GetObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build(),
-      AsyncResponseTransformer.toBytes()
-    ).join()
+    val getObjectResponse = autoS3CrtAsyncClientV2.getObject({
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+    }, AsyncResponseTransformer.toBytes()).join()
 
     val uploadFileBytes = readStreamIntoByteArray(uploadFile.inputStream())
     (DigestUtils.md5(randomBytes) + DigestUtils.md5(uploadFileBytes)).also {
@@ -199,12 +175,13 @@ internal class CrtAsyncV2IT : S3TestBase() {
   ): String {
     return autoS3CrtAsyncClientV2
       .uploadPart(
-        UploadPartRequest.builder()
-          .bucket(bucketName)
-          .key(key)
-          .uploadId(uploadId)
-          .partNumber(partNumber)
-          .contentLength(randomBytes.size.toLong()).build(),
+        {
+          it.bucket(bucketName)
+          it.key(key)
+          it.uploadId(uploadId)
+          it.partNumber(partNumber)
+          it.contentLength(randomBytes.size.toLong())
+        },
         AsyncRequestBody.fromBytes(randomBytes)
       ).join()
       .eTag()
@@ -217,11 +194,10 @@ internal class CrtAsyncV2IT : S3TestBase() {
 
     val body = AsyncRequestBody.forBlockingInputStream(null)
     val putObjectResponseFuture = autoS3CrtAsyncClientV2.putObject(
-      PutObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+      },
       body
     )
 
@@ -231,11 +207,10 @@ internal class CrtAsyncV2IT : S3TestBase() {
     putObjectResponseFuture.join()
 
     val getObjectResponse = autoS3CrtAsyncClientV2.getObject(
-      GetObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+      },
       AsyncResponseTransformer.toBytes()
     ).join()
 
@@ -255,19 +230,13 @@ internal class CrtAsyncV2IT : S3TestBase() {
 
     val body = AsyncRequestBody.forBlockingInputStream(null)
     val upload = transferManagerV2
-      .upload(
-        UploadRequest
-          .builder()
-          .requestBody(body)
-          .putObjectRequest(
-            PutObjectRequest
-              .builder()
-              .bucket(bucketName)
-              .key(UPLOAD_FILE_NAME)
-              .build()
-          )
-          .build()
-      )
+      .upload {
+        it.requestBody(body)
+        it.putObjectRequest {
+          it.bucket(bucketName)
+          it.key(UPLOAD_FILE_NAME)
+        }
+      }
 
     val randomBytes = randomBytes()
     body.writeInputStream(ByteArrayInputStream(randomBytes))
@@ -278,13 +247,10 @@ internal class CrtAsyncV2IT : S3TestBase() {
       .download(
         DownloadRequest
           .builder()
-          .getObjectRequest(
-            GetObjectRequest
-              .builder()
-              .bucket(bucketName)
-              .key(UPLOAD_FILE_NAME)
-              .build()
-          )
+          .getObjectRequest {
+            it.bucket(bucketName)
+            it.key(UPLOAD_FILE_NAME)
+          }
           .responseTransformer(AsyncResponseTransformer.toBytes())
           .build()
       ).completionFuture().join().result()

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ErrorResponsesV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,20 +21,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest
-import software.amazon.awssdk.services.s3.model.Delete
-import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
-import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest
-import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
-import software.amazon.awssdk.services.s3.model.ObjectIdentifier
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
-import software.amazon.awssdk.services.s3.model.UploadPartRequest
 import java.io.File
 
 internal class ErrorResponsesV2IT : S3TestBase() {
@@ -45,9 +34,13 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun getObject_noSuchKey(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
-    val req = GetObjectRequest.builder().bucket(bucketName).key(NON_EXISTING_KEY).build()
 
-    assertThatThrownBy { s3ClientV2.getObject(req) }.isInstanceOf(
+    assertThatThrownBy {
+      s3ClientV2.getObject {
+        it.bucket(bucketName)
+        it.key(NON_EXISTING_KEY)
+      }
+    }.isInstanceOf(
       NoSuchKeyException::class.java
     ).hasMessageContaining(NO_SUCH_KEY)
   }
@@ -56,9 +49,13 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun getObject_noSuchKey_startingSlash(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
-    val req = GetObjectRequest.builder().bucket(bucketName).key("/$NON_EXISTING_KEY").build()
 
-    assertThatThrownBy { s3ClientV2.getObject(req) }.isInstanceOf(
+    assertThatThrownBy {
+      s3ClientV2.getObject {
+        it.bucket(bucketName)
+        it.key("/$NON_EXISTING_KEY")
+      }
+    }.isInstanceOf(
       NoSuchKeyException::class.java
     ).hasMessageContaining(NO_SUCH_KEY)
   }
@@ -70,11 +67,10 @@ internal class ErrorResponsesV2IT : S3TestBase() {
 
     assertThatThrownBy {
       s3ClientV2.putObject(
-        PutObjectRequest
-          .builder()
-          .bucket(randomName)
-          .key(UPLOAD_FILE_NAME)
-          .build(),
+        {
+          it.bucket(randomName)
+          it.key(UPLOAD_FILE_NAME)
+        },
         RequestBody.fromFile(uploadFile)
       )
     }
@@ -90,15 +86,14 @@ internal class ErrorResponsesV2IT : S3TestBase() {
     val destinationBucketName = randomName
     val destinationKey = "copyOf/$sourceKey"
 
-    assertThatThrownBy { s3ClientV2.copyObject(
-      software.amazon.awssdk.services.s3.model.CopyObjectRequest
-        .builder()
-        .sourceBucket(bucketName)
-        .sourceKey(sourceKey)
-        .destinationBucket(destinationBucketName)
-        .destinationKey(destinationKey)
-        .build()
-    ) }
+    assertThatThrownBy {
+      s3ClientV2.copyObject {
+        it.sourceBucket(bucketName)
+        it.sourceKey(sourceKey)
+        it.destinationBucket(destinationBucketName)
+        it.destinationKey(destinationKey)
+      }
+    }
       .isInstanceOf(NoSuchBucketException::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
   }
@@ -107,13 +102,10 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun deleteObject_noSuchBucket() {
     assertThatThrownBy {
-      s3ClientV2.deleteObject(
-        DeleteObjectRequest
-          .builder()
-          .bucket(randomName)
-          .key(NON_EXISTING_KEY)
-          .build()
-      )
+      s3ClientV2.deleteObject {
+        it.bucket(randomName)
+        it.key(NON_EXISTING_KEY)
+      }
     }
       .isInstanceOf(NoSuchBucketException::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
@@ -124,33 +116,24 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   fun deleteObject_nonExistent_OK(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
 
-    s3ClientV2.deleteObject(
-      DeleteObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(NON_EXISTING_KEY)
-        .build()
-    )
+    s3ClientV2.deleteObject {
+      it.bucket(bucketName)
+      it.key(NON_EXISTING_KEY)
+    }
   }
 
   @Test
   @S3VerifiedSuccess(year = 2024)
   fun deleteObjects_noSuchBucket() {
     assertThatThrownBy {
-      s3ClientV2.deleteObjects(
-        DeleteObjectsRequest
-          .builder()
-          .bucket(randomName)
-          .delete(
-            Delete
-              .builder()
-              .objects(ObjectIdentifier
-                .builder()
-                .key(NON_EXISTING_KEY)
-                .build()
-              ).build()
-          ).build()
-      )
+      s3ClientV2.deleteObjects {
+        it.bucket(randomName)
+        it.delete {
+          it.objects({
+            it.key(NON_EXISTING_KEY)
+          })
+        }
+      }
     }
       .isInstanceOf(NoSuchBucketException::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
@@ -160,12 +143,9 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun deleteBucket_noSuchBucket() {
     assertThatThrownBy {
-      s3ClientV2.deleteBucket(
-        DeleteBucketRequest
-          .builder()
-          .bucket(randomName)
-          .build()
-      )
+      s3ClientV2.deleteBucket {
+        it.bucket(randomName)
+      }
     }
       .isInstanceOf(NoSuchBucketException::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
@@ -175,13 +155,10 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun multipartUploads_noSuchBucket() {
     assertThatThrownBy {
-      s3ClientV2.createMultipartUpload(
-        CreateMultipartUploadRequest
-          .builder()
-          .bucket(randomName)
-          .key(UPLOAD_FILE_NAME)
-          .build()
-      )
+      s3ClientV2.createMultipartUpload {
+        it.bucket(randomName)
+        it.key(UPLOAD_FILE_NAME)
+      }
     }
       .isInstanceOf(NoSuchBucketException::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
@@ -191,12 +168,9 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun listMultipartUploads_noSuchBucket() {
     assertThatThrownBy {
-      s3ClientV2.listMultipartUploads(
-        ListMultipartUploadsRequest
-          .builder()
-          .bucket(randomName)
-          .build()
-      )
+      s3ClientV2.listMultipartUploads {
+        it.bucket(randomName)
+      }
     }
       .isInstanceOf(NoSuchBucketException::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
@@ -206,14 +180,11 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun abortMultipartUpload_noSuchBucket() {
     assertThatThrownBy {
-      s3ClientV2.abortMultipartUpload(
-        AbortMultipartUploadRequest
-          .builder()
-          .bucket(randomName)
-          .key(UPLOAD_FILE_NAME)
-          .uploadId("uploadId")
-          .build()
-        )
+      s3ClientV2.abortMultipartUpload {
+        it.bucket(randomName)
+        it.key(UPLOAD_FILE_NAME)
+        it.uploadId("uploadId")
+      }
     }
       .isInstanceOf(NoSuchBucketException::class.java)
       .hasMessageContaining(NO_SUCH_BUCKET)
@@ -222,37 +193,30 @@ internal class ErrorResponsesV2IT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2024)
   fun uploadMultipart_invalidPartNumber(testInfo: TestInfo) {
-    val bucketName = givenBucketV1(testInfo)
+    val bucketName = givenBucketV2(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val initiateMultipartUploadResult = s3ClientV2
-      .createMultipartUpload(
-        CreateMultipartUploadRequest
-          .builder()
-          .bucket(bucketName)
-          .key(UPLOAD_FILE_NAME)
-          .build()
-      )
+      .createMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+      }
     val uploadId = initiateMultipartUploadResult.uploadId()
 
     assertThat(
-      s3ClientV2.listMultipartUploads(
-        ListMultipartUploadsRequest
-          .builder()
-          .bucket(bucketName)
-          .build()
-      ).uploads()
+      s3ClientV2.listMultipartUploads {
+        it.bucket(bucketName)
+      }.uploads()
     ).isNotEmpty
 
     val invalidPartNumber = 0
     assertThatThrownBy {
       s3ClientV2.uploadPart(
-        UploadPartRequest
-          .builder()
-          .bucket(initiateMultipartUploadResult.bucket())
-          .key(initiateMultipartUploadResult.key())
-          .uploadId(uploadId)
-          .partNumber(invalidPartNumber)
-          .build(),
+        {
+          it.bucket(initiateMultipartUploadResult.bucket())
+          it.key(initiateMultipartUploadResult.key())
+          it.uploadId(uploadId)
+          it.partNumber(invalidPartNumber)
+        },
         RequestBody.fromFile(uploadFile)
       )
     }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
 import kotlin.math.min
 
 internal class GetPutDeleteObjectV2IT : S3TestBase() {
@@ -63,7 +64,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
    *
    * https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
    */
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["charsSafe", "charsSpecial", "charsToAvoid"])
   fun testPutHeadGetObject_keyNames_safe(key: String, testInfo: TestInfo) {
@@ -95,7 +96,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["storageClasses"])
   fun testPutObject_storageClass(storageClass: StorageClass, testInfo: TestInfo) {
@@ -138,7 +139,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["testFileNames"])
   fun testPutObject_etagCreation_sync(testFileName: String, testInfo: TestInfo) {
@@ -167,7 +168,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["testFileNames"])
   fun testPutObject_etagCreation_async(testFileName: String) {
@@ -201,7 +202,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPutObject_getObjectAttributes(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), Algorithm.SHA1)
@@ -235,7 +236,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testPutObject_checksumAlgorithm_http(checksumAlgorithm: ChecksumAlgorithm) {
@@ -248,7 +249,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testPutObject_checksumAlgorithm_https(checksumAlgorithm: ChecksumAlgorithm) {
@@ -305,7 +306,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testPutObject_checksumAlgorithm_async_http(checksumAlgorithm: ChecksumAlgorithm) {
@@ -325,7 +326,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     testChecksumAlgorithm_async(TEST_IMAGE_LARGE, checksumAlgorithm, autoS3CrtAsyncClientV2Http)
   }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testPutObject_checksumAlgorithm_async_https(checksumAlgorithm: ChecksumAlgorithm) {
@@ -402,7 +403,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
       else -> error("Unknown checksum algorithm")
     }
 
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testPutObject_checksum(checksumAlgorithm: ChecksumAlgorithm, testInfo: TestInfo) {
@@ -449,7 +450,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPutObject_wrongChecksum(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = "wrongChecksum"
@@ -476,7 +477,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
    * https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
    */
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPutObject_safeCharacters(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucketV2(testInfo)
@@ -515,7 +516,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
    * https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
    */
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPutObject_specialHandlingCharacters(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucketV2(testInfo)
@@ -550,7 +551,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPutGetDeleteObject_twoBuckets(testInfo: TestInfo) {
     val bucket1 = givenRandomBucketV2()
     val bucket2 = givenRandomBucketV2()
@@ -571,7 +572,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPutGetHeadObject_storeHeaders(testInfo: TestInfo) {
     val bucket = givenRandomBucketV2()
     val uploadFile = File(UPLOAD_FILE_NAME)
@@ -624,7 +625,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_successWithMatchingEtag(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val matchingEtag = FileInputStream(uploadFile).let {
@@ -648,7 +649,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_successWithSameLength(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val matchingEtag = FileInputStream(uploadFile).let {
@@ -668,7 +669,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_successWithMatchingWildcardEtag(testInfo: TestInfo) {
     val (bucketName, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
     val eTag = putObjectResponse.eTag()
@@ -686,7 +687,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testHeadObject_successWithNonMatchEtag(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
@@ -712,7 +713,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testHeadObject_failureWithNonMatchWildcardEtag(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
@@ -739,7 +740,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testHeadObject_failureWithMatchEtag(testInfo: TestInfo) {
     val expectedEtag = FileInputStream(File(UPLOAD_FILE_NAME)).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -765,7 +766,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_successWithMatchingIfModified(testInfo: TestInfo) {
     val now = Instant.now().minusSeconds(60)
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
@@ -782,10 +783,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_failureWithNonMatchingIfModified(testInfo: TestInfo) {
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
-    val now = Instant.now().plusSeconds(60)
+    TimeUnit.SECONDS.sleep(10L)
+    val now = Instant.now()
 
     assertThatThrownBy {
       s3ClientV2.getObject(
@@ -796,11 +798,11 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
           .build()
       )
     }.isInstanceOf(S3Exception::class.java)
-      .hasMessageContaining("Service: S3, Status Code: 412")
+      .hasMessageContaining("Service: S3, Status Code: 304")
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_successWithMatchingIfUnmodified(testInfo: TestInfo) {
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
     val now = Instant.now().plusSeconds(60)
@@ -816,9 +818,8 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
     }
   }
 
-
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_failureWithNonMatchingIfUnmodified(testInfo: TestInfo) {
     val now = Instant.now().minusSeconds(60)
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
@@ -836,7 +837,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_rangeDownloads(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val (bucketName, putObjectResponse) = givenBucketAndObjectV2(testInfo, UPLOAD_FILE_NAME)
@@ -876,7 +877,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_rangeDownloads_finalBytes_prefixOffset(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
     val key = givenObjectV2WithRandomBytes(bucketName)
@@ -895,7 +896,7 @@ internal class GetPutDeleteObjectV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testGetObject_rangeDownloads_finalBytes_suffixOffset(testInfo: TestInfo) {
     val bucketName = givenBucketV2(testInfo)
     val key = givenObjectV2WithRandomBytes(bucketName)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/KotlinSDKIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/KotlinSDKIT.kt
@@ -31,7 +31,8 @@ internal class KotlinSDKIT: S3TestBase() {
   private val s3Client = createS3ClientKotlin()
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedFailure(year = 2025,
+    reason = "The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.")
   fun createAndDeleteBucket(testInfo: TestInfo) : Unit = runBlocking {
     val bucketName = bucketName(testInfo)
     s3Client.createBucket(CreateBucketRequest { bucket = bucketName })

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,12 +22,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest
-import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest
-import software.amazon.awssdk.services.s3.model.ObjectLockLegalHold
 import software.amazon.awssdk.services.s3.model.ObjectLockLegalHoldStatus
-import software.amazon.awssdk.services.s3.model.PutObjectLegalHoldRequest
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
 import java.io.File
 
@@ -39,19 +34,16 @@ internal class LegalHoldV2IT : S3TestBase() {
   @S3VerifiedSuccess(year = 2024)
   fun testGetLegalHoldNoBucketLockConfiguration(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
-    val (bucketName, _) = givenBucketAndObjectV1(testInfo, sourceKey)
+    val (bucketName, _) = givenBucketAndObjectV2(testInfo, sourceKey)
 
     assertThatThrownBy {
-      s3ClientV2.getObjectLegalHold(
-        GetObjectLegalHoldRequest
-          .builder()
-          .bucket(bucketName)
-          .key(sourceKey)
-          .build()
-      )
+      s3ClientV2.getObjectLegalHold {
+        it.bucket(bucketName)
+        it.key(sourceKey)
+      }
     }.isInstanceOf(S3Exception::class.java)
-     .hasMessageContaining("Bucket is missing Object Lock Configuration")
-     .hasMessageContaining("Service: S3, Status Code: 400")
+      .hasMessageContaining("Bucket is missing Object Lock Configuration")
+      .hasMessageContaining("Service: S3, Status Code: 400")
   }
 
   @Test
@@ -60,32 +52,26 @@ internal class LegalHoldV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val bucketName = bucketName(testInfo)
-    s3ClientV2.createBucket(CreateBucketRequest
-      .builder()
-      .bucket(bucketName)
-      .objectLockEnabledForBucket(true)
-      .build()
-    )
+    s3ClientV2.createBucket {
+      it.bucket(bucketName)
+      it.objectLockEnabledForBucket(true)
+    }
     s3ClientV2.putObject(
-      PutObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(sourceKey)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key(sourceKey)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
     assertThatThrownBy {
-      s3ClientV2.getObjectLegalHold(
-        GetObjectLegalHoldRequest
-          .builder()
-          .bucket(bucketName)
-          .key(sourceKey)
-          .build()
-      )
+      s3ClientV2.getObjectLegalHold {
+        it.bucket(bucketName)
+        it.key(sourceKey)
+      }
     }.isInstanceOf(S3Exception::class.java)
-     .hasMessageContaining("The specified object does not have a ObjectLock configuration")
-     .hasMessageContaining("Service: S3, Status Code: 404")
+      .hasMessageContaining("The specified object does not have a ObjectLock configuration")
+      .hasMessageContaining("Service: S3, Status Code: 404")
   }
 
   @Test
@@ -94,62 +80,45 @@ internal class LegalHoldV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val bucketName = bucketName(testInfo)
-    s3ClientV2.createBucket(CreateBucketRequest
-      .builder()
-      .bucket(bucketName)
-      .objectLockEnabledForBucket(true)
-      .build()
-    )
+    s3ClientV2.createBucket {
+      it.bucket(bucketName)
+      it.objectLockEnabledForBucket(true)
+    }
     s3ClientV2.putObject(
-      PutObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(sourceKey)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key(sourceKey)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
-    s3ClientV2.putObjectLegalHold(PutObjectLegalHoldRequest
-      .builder()
-      .bucket(bucketName)
-      .key(sourceKey)
-      .legalHold(ObjectLockLegalHold
-        .builder()
-        .status(ObjectLockLegalHoldStatus.ON)
-        .build()
-      )
-      .build()
-    )
+    s3ClientV2.putObjectLegalHold {
+      it.bucket(bucketName)
+      it.key(sourceKey)
+      it.legalHold {
+        it.status(ObjectLockLegalHoldStatus.ON)
+      }
+    }
 
-    s3ClientV2.getObjectLegalHold(
-      GetObjectLegalHoldRequest
-        .builder()
-        .bucket(bucketName)
-        .key(sourceKey)
-        .build()
-    ).also {
+    s3ClientV2.getObjectLegalHold {
+      it.bucket(bucketName)
+      it.key(sourceKey)
+    }.also {
       assertThat(it.legalHold().status()).isEqualTo(ObjectLockLegalHoldStatus.ON)
     }
 
-    s3ClientV2.putObjectLegalHold(PutObjectLegalHoldRequest
-      .builder()
-      .bucket(bucketName)
-      .key(sourceKey)
-      .legalHold(ObjectLockLegalHold
-        .builder()
-        .status(ObjectLockLegalHoldStatus.OFF)
-        .build()
-      )
-      .build()
-    )
+    s3ClientV2.putObjectLegalHold {
+      it.bucket(bucketName)
+      it.key(sourceKey)
+      it.legalHold {
+        it.status(ObjectLockLegalHoldStatus.OFF)
+      }
+    }
 
-    s3ClientV2.getObjectLegalHold(
-      GetObjectLegalHoldRequest
-        .builder()
-        .bucket(bucketName)
-        .key(sourceKey)
-        .build()
-    ).also {
+    s3ClientV2.getObjectLegalHold {
+      it.bucket(bucketName)
+      it.key(sourceKey)
+    }.also {
       assertThat(it.legalHold().status()).isEqualTo(ObjectLockLegalHoldStatus.OFF)
     }
   }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,9 +24,6 @@ import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm
 import software.amazon.awssdk.services.s3.model.EncodingType
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Object
 import java.io.File
 
@@ -40,26 +37,25 @@ internal class ListObjectV2IT : S3TestBase() {
     val bucketName = givenBucketV2(testInfo)
 
     s3ClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucketName).key("$UPLOAD_FILE_NAME-1")
-        .checksumAlgorithm(ChecksumAlgorithm.SHA256)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key("$UPLOAD_FILE_NAME-1")
+        it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
     s3ClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucketName).key("$UPLOAD_FILE_NAME-2")
-        .checksumAlgorithm(ChecksumAlgorithm.SHA256)
-        .build(),
+      {
+        it.bucket(bucketName).key("$UPLOAD_FILE_NAME-2")
+        it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
-    s3ClientV2.listObjectsV2(
-      ListObjectsV2Request.builder()
-        .bucket(bucketName)
-        .build()
-    ).also {
+    s3ClientV2.listObjectsV2 {
+      it.bucket(bucketName)
+    }.also {
       assertThat(it.contents())
         .hasSize(2)
         .extracting(S3Object::checksumAlgorithm)
@@ -77,26 +73,24 @@ internal class ListObjectV2IT : S3TestBase() {
     val bucketName = givenBucketV2(testInfo)
 
     s3ClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucketName).key("$UPLOAD_FILE_NAME-1")
-        .checksumAlgorithm(ChecksumAlgorithm.SHA256)
-        .build(),
+      {
+        it.bucket(bucketName).key("$UPLOAD_FILE_NAME-1")
+        it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
     s3ClientV2.putObject(
-      PutObjectRequest.builder()
-        .bucket(bucketName).key("$UPLOAD_FILE_NAME-2")
-        .checksumAlgorithm(ChecksumAlgorithm.SHA256)
-        .build(),
+      {
+        it.bucket(bucketName).key("$UPLOAD_FILE_NAME-2")
+        it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
-    s3ClientV2.listObjects(
-      ListObjectsRequest.builder()
-        .bucket(bucketName)
-        .build()
-    ).also {
+    s3ClientV2.listObjects {
+      it.bucket(bucketName)
+    }.also {
       assertThat(it.contents())
         .hasSize(2)
         .extracting(S3Object::checksumAlgorithm)
@@ -120,22 +114,19 @@ internal class ListObjectV2IT : S3TestBase() {
     val weirdStuff = charsSafe()
     val prefix = "shouldListWithCorrectObjectNames/"
     val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
-    s3ClientV2.putObject(PutObjectRequest
-      .builder()
-      .bucket(bucketName)
-      .key(key)
-      .build(),
+    s3ClientV2.putObject(
+      {
+        it.bucket(bucketName)
+        it.key(key)
+      },
       RequestBody.fromFile(uploadFile)
     )
 
-    s3ClientV2.listObjectsV2(
-      ListObjectsV2Request
-        .builder()
-        .bucket(bucketName)
-        .prefix(prefix)
-        .encodingType(EncodingType.URL)
-        .build()
-    ).also { listing ->
+    s3ClientV2.listObjectsV2 {
+      it.bucket(bucketName)
+      it.prefix(prefix)
+      it.encodingType(EncodingType.URL)
+    }.also { listing ->
       listing.contents().also {
         assertThat(it).hasSize(1)
         assertThat(it[0].key()).isEqualTo(key)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultiPartUploadV2IT.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload
 import software.amazon.awssdk.services.s3.model.CompletedPart
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest
 import software.amazon.awssdk.services.s3.model.ListPartsRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
@@ -51,13 +50,12 @@ import software.amazon.awssdk.services.s3.model.S3Exception
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest
 import software.amazon.awssdk.services.s3.model.UploadPartRequest
 import software.amazon.awssdk.transfer.s3.S3TransferManager
-import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest
-import software.amazon.awssdk.transfer.s3.model.UploadFileRequest
 import software.amazon.awssdk.utils.http.SdkHttpUtils
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files.newOutputStream
 import java.time.Instant
 import java.util.UUID
 
@@ -75,41 +73,34 @@ internal class MultiPartUploadV2IT : S3TestBase() {
     val bucketName = givenBucketV2(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     s3CrtAsyncClientV2.putObject(
-      PutObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(uploadFile.name)
-        .checksumAlgorithm(ChecksumAlgorithm.CRC32)
-        .build(),
+      {
+        it.bucket(bucketName)
+        it.key(uploadFile.name)
+        it.checksumAlgorithm(ChecksumAlgorithm.CRC32)
+      },
       AsyncRequestBody.fromFile(uploadFile)
     ).join().also {
       assertThat(it.checksumCRC32()).isEqualTo(DigestUtil.checksumFor(uploadFile.toPath(), CRC32))
     }
 
-    s3AsyncClientV2.waiter()
-      .waitUntilObjectExists(
-        HeadObjectRequest
-          .builder()
-          .bucket(bucketName)
-          .key(uploadFile.name)
-          .build()
-      )
-
-    s3ClientV2.getObject(
-      GetObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(uploadFile.name)
-        .build()
-    ).use {
-      val uploadDigest = hexDigest(uploadFile)
-      val newTemporaryFile = Files.newTemporaryFile()
-      it.transferTo(java.nio.file.Files.newOutputStream(newTemporaryFile.toPath()))
-      assertThat(newTemporaryFile).hasSize(uploadFile.length())
-      assertThat(newTemporaryFile).hasSameBinaryContentAs(uploadFile)
-      val downloadedDigest = hexDigest(newTemporaryFile)
-      assertThat(uploadDigest).isEqualTo(downloadedDigest)
+    s3AsyncClientV2.waiter().waitUntilObjectExists {
+      it.bucket(bucketName)
+      it.key(uploadFile.name)
     }
+
+    val uploadDigest = hexDigest(uploadFile)
+    val downloadedDigest = s3ClientV2.getObject {
+      it.bucket(bucketName)
+      it.key(uploadFile.name)
+    }.use { response ->
+      Files.newTemporaryFile().let {
+        response.transferTo(newOutputStream(it.toPath()))
+        assertThat(it).hasSize(uploadFile.length())
+        assertThat(it).hasSameBinaryContentAs(uploadFile)
+        hexDigest(it)
+      }
+    }
+    assertThat(uploadDigest).isEqualTo(downloadedDigest)
   }
 
   @Test
@@ -118,44 +109,29 @@ internal class MultiPartUploadV2IT : S3TestBase() {
     val bucketName = givenBucketV2(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     transferManagerV2
-      .uploadFile(
-        UploadFileRequest
-          .builder()
-          .putObjectRequest(
-            PutObjectRequest
-              .builder()
-              .bucket(bucketName)
-              .key(UPLOAD_FILE_NAME)
-              .build()
-          )
-          .source(uploadFile)
-          .build()
-      ).completionFuture().join()
+      .uploadFile {
+        it.putObjectRequest {
+          it.bucket(bucketName)
+          it.key(UPLOAD_FILE_NAME)
+        }
+        it.source(uploadFile)
+      }.completionFuture().join()
 
-    s3ClientV2.getObject(
-      GetObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build()
-    ).use {
+    s3ClientV2.getObject {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+    }.use {
       assertThat(it.response().contentLength()).isEqualTo(uploadFile.length())
     }
 
     val downloadFile = Files.newTemporaryFile()
-    transferManagerV2.downloadFile(
-      DownloadFileRequest
-        .builder()
-        .getObjectRequest(
-          GetObjectRequest
-            .builder()
-            .bucket(bucketName)
-            .key(UPLOAD_FILE_NAME)
-            .build()
-        )
-        .destination(downloadFile)
-        .build()
-    ).also { download ->
+    transferManagerV2.downloadFile {
+      it.getObjectRequest {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+      }
+      it.destination(downloadFile)
+    }.also { download ->
       download.completionFuture().join().response().also {
         assertThat(it.contentLength()).isEqualTo(uploadFile.length())
       }
@@ -174,51 +150,41 @@ internal class MultiPartUploadV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val objectMetadata = mapOf(Pair("key", "value"))
     val initiateMultipartUploadResult = s3ClientV2
-      .createMultipartUpload(
-        CreateMultipartUploadRequest.builder().bucket(bucketName).key(UPLOAD_FILE_NAME)
-          .metadata(objectMetadata).build()
-      )
+      .createMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.metadata(objectMetadata)
+      }
     val uploadId = initiateMultipartUploadResult.uploadId()
     val uploadPartResult = s3ClientV2.uploadPart(
-      UploadPartRequest
-        .builder()
-        .bucket(initiateMultipartUploadResult.bucket())
-        .key(initiateMultipartUploadResult.key())
-        .uploadId(uploadId)
-        .partNumber(1)
-        .contentLength(uploadFile.length()).build(),
-      //.lastPart(true)
+      {
+        it.bucket(initiateMultipartUploadResult.bucket())
+        it.key(initiateMultipartUploadResult.key())
+        it.uploadId(uploadId)
+        it.partNumber(1)
+        it.contentLength(uploadFile.length())
+        //it.lastPart(true)
+      },
       RequestBody.fromFile(uploadFile),
     )
 
-    s3ClientV2.completeMultipartUpload(
-      CompleteMultipartUploadRequest
-        .builder()
-        .bucket(initiateMultipartUploadResult.bucket())
-        .key(initiateMultipartUploadResult.key())
-        .uploadId(initiateMultipartUploadResult.uploadId())
-        .multipartUpload(
-          CompletedMultipartUpload
-            .builder()
-            .parts(
-              CompletedPart
-                .builder()
-                .eTag(uploadPartResult.eTag())
-                .partNumber(1)
-                .build()
-            )
-            .build()
+    s3ClientV2.completeMultipartUpload {
+      it.bucket(initiateMultipartUploadResult.bucket())
+      it.key(initiateMultipartUploadResult.key())
+      it.uploadId(initiateMultipartUploadResult.uploadId())
+      it.multipartUpload {
+        it.parts({
+          it.eTag(uploadPartResult.eTag())
+          it.partNumber(1)
+        }
         )
-        .build()
-    )
+      }
+    }
 
-    s3ClientV2.getObject(
-      GetObjectRequest
-        .builder()
-        .bucket(initiateMultipartUploadResult.bucket())
-        .key(initiateMultipartUploadResult.key())
-        .build()
-    ).use {
+    s3ClientV2.getObject {
+      it.bucket(initiateMultipartUploadResult.bucket())
+      it.key(initiateMultipartUploadResult.key())
+    }.use {
       assertThat(it.response().metadata()).isEqualTo(objectMetadata)
     }
   }
@@ -232,72 +198,57 @@ internal class MultiPartUploadV2IT : S3TestBase() {
     val bucketName = givenBucketV2(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
     val objectMetadata = mapOf(Pair("key", "value"))
-    val initiateMultipartUploadResult = s3ClientV2
-      .createMultipartUpload(
-        CreateMultipartUploadRequest
-          .builder()
-          .bucket(bucketName)
-          .key(UPLOAD_FILE_NAME)
-          .metadata(objectMetadata)
-          .build()
-      )
+    val initiateMultipartUploadResult = s3ClientV2.createMultipartUpload {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+      it.metadata(objectMetadata)
+    }
     val uploadId = initiateMultipartUploadResult.uploadId()
     // upload part 1, >5MB
     val randomBytes = randomBytes()
     val etag1 = uploadPart(bucketName, UPLOAD_FILE_NAME, uploadId, 1, randomBytes)
     // upload part 2, <5MB
     val etag2 = s3ClientV2.uploadPart(
-      UploadPartRequest
-        .builder()
-        .bucket(initiateMultipartUploadResult.bucket())
-        .key(initiateMultipartUploadResult.key())
-        .uploadId(uploadId)
-        .partNumber(2)
-        .contentLength(uploadFile.length()).build(),
-      //.lastPart(true)
+      {
+        it.bucket(initiateMultipartUploadResult.bucket())
+        it.key(initiateMultipartUploadResult.key())
+        it.uploadId(uploadId)
+        it.partNumber(2)
+        it.contentLength(uploadFile.length())
+        //it.lastPart(true)
+      },
       RequestBody.fromFile(uploadFile),
     ).eTag()
 
-    val completeMultipartUpload = s3ClientV2.completeMultipartUpload(
-      CompleteMultipartUploadRequest
-        .builder()
-        .bucket(initiateMultipartUploadResult.bucket())
-        .key(initiateMultipartUploadResult.key())
-        .uploadId(initiateMultipartUploadResult.uploadId())
-        .multipartUpload(
-          CompletedMultipartUpload
-            .builder()
-            .parts(
-              CompletedPart
-                .builder()
-                .eTag(etag1)
-                .partNumber(1)
-                .build(),
-              CompletedPart
-                .builder()
-                .eTag(etag2)
-                .partNumber(2)
-                .build()
-            )
-            .build()
+    val completeMultipartUpload = s3ClientV2.completeMultipartUpload {
+      it.bucket(initiateMultipartUploadResult.bucket())
+      it.key(initiateMultipartUploadResult.key())
+      it.uploadId(initiateMultipartUploadResult.uploadId())
+      it.multipartUpload {
+        it.parts(
+          {
+            it.eTag(etag1)
+            it.partNumber(1)
+          },
+          {
+            it.eTag(etag2)
+            it.partNumber(2)
+          }
         )
-        .build()
-    )
+      }
+    }
 
     val uploadFileBytes = readStreamIntoByteArray(uploadFile.inputStream())
 
-      (DigestUtils.md5(randomBytes) + DigestUtils.md5(uploadFileBytes)).also {
+    (DigestUtils.md5(randomBytes) + DigestUtils.md5(uploadFileBytes)).also {
       // verify special etag
       assertThat(completeMultipartUpload.eTag()).isEqualTo("\"${DigestUtils.md5Hex(it)}-2\"")
     }
 
-    s3ClientV2.getObject(
-      GetObjectRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build()
-    ).use {
+    s3ClientV2.getObject {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+    }.use {
       // verify content size
       assertThat(it.response().contentLength()).isEqualTo(randomBytes.size.toLong() + uploadFileBytes.size.toLong())
       // verify contents
@@ -432,12 +383,13 @@ internal class MultiPartUploadV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), checksumAlgorithm.toAlgorithm())
     val initiateMultipartUploadResult = s3ClientV2
-      .createMultipartUpload(CreateMultipartUploadRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .checksumAlgorithm(checksumAlgorithm)
-        .build()
+      .createMultipartUpload(
+        CreateMultipartUploadRequest
+          .builder()
+          .bucket(bucketName)
+          .key(UPLOAD_FILE_NAME)
+          .checksumAlgorithm(checksumAlgorithm)
+          .build()
       )
     val uploadId = initiateMultipartUploadResult.uploadId()
 
@@ -475,12 +427,13 @@ internal class MultiPartUploadV2IT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), checksumAlgorithm.toAlgorithm())
     val initiateMultipartUploadResult = s3ClientV2
-      .createMultipartUpload(CreateMultipartUploadRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .checksumAlgorithm(checksumAlgorithm)
-        .build()
+      .createMultipartUpload(
+        CreateMultipartUploadRequest
+          .builder()
+          .bucket(bucketName)
+          .key(UPLOAD_FILE_NAME)
+          .checksumAlgorithm(checksumAlgorithm)
+          .build()
       )
     val uploadId = initiateMultipartUploadResult.uploadId()
 
@@ -514,11 +467,12 @@ internal class MultiPartUploadV2IT : S3TestBase() {
     val expectedChecksum = "wrongChecksum"
     val checksumAlgorithm = ChecksumAlgorithm.SHA1
     val initiateMultipartUploadResult = s3ClientV2
-      .createMultipartUpload(CreateMultipartUploadRequest
-        .builder()
-        .bucket(bucketName)
-        .key(UPLOAD_FILE_NAME)
-        .build()
+      .createMultipartUpload(
+        CreateMultipartUploadRequest
+          .builder()
+          .bucket(bucketName)
+          .key(UPLOAD_FILE_NAME)
+          .build()
       )
     val uploadId = initiateMultipartUploadResult.uploadId()
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUrlV2IT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUrlV2IT.kt
@@ -45,7 +45,7 @@ internal class PresignedUrlV2IT : S3TestBase() {
   private val s3Presigner: S3Presigner = createS3Presigner()
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPresignedUrl_getObject(testInfo: TestInfo) {
     val key = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, key)
@@ -73,7 +73,7 @@ internal class PresignedUrlV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedTodo
+  @S3VerifiedSuccess(year = 2025)
   fun testPresignedUrl_getObject_range(testInfo: TestInfo) {
     val key = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObjectV2(testInfo, key)
@@ -101,13 +101,13 @@ internal class PresignedUrlV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPresignedUrl_putObject(testInfo: TestInfo) {
     val key = UPLOAD_FILE_NAME
     val bucketName = givenBucketV2(testInfo)
 
-    val presignedUrlString = s3Presigner.presignGetObject {
-      it.getObjectRequest{
+    val presignedUrlString = s3Presigner.presignPutObject {
+      it.putObjectRequest {
         it.bucket(bucketName)
         it.key(key)
       }
@@ -137,7 +137,7 @@ internal class PresignedUrlV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedFailure(year = 2024, reason = "S3 returns no multipart uploads.")
+  @S3VerifiedSuccess(year = 2025)
   fun testPresignedUrl_createMultipartUpload(testInfo: TestInfo) {
     val key = UPLOAD_FILE_NAME
     val bucketName = givenBucketV2(testInfo)
@@ -166,15 +166,14 @@ internal class PresignedUrlV2IT : S3TestBase() {
 
     s3ClientV2.listMultipartUploads {
       it.bucket(bucketName)
-      it.keyMarker(key)
-      it.uploadIdMarker(uploadId)
     }.also {
       assertThat(it.uploads()).hasSize(1)
+      assertThat(it.uploads()[0].uploadId()).isEqualTo(uploadId)
     }
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPresignedUrl_abortMultipartUpload(testInfo: TestInfo) {
     val key = UPLOAD_FILE_NAME
     val bucketName = givenBucketV2(testInfo)
@@ -224,7 +223,7 @@ internal class PresignedUrlV2IT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPresignedUrl_completeMultipartUpload(testInfo: TestInfo) {
     val key = UPLOAD_FILE_NAME
     val bucketName = givenBucketV2(testInfo)
@@ -286,7 +285,7 @@ internal class PresignedUrlV2IT : S3TestBase() {
 
 
   @Test
-  @S3VerifiedSuccess(year = 2024)
+  @S3VerifiedSuccess(year = 2025)
   fun testPresignedUrl_uploadPart(testInfo: TestInfo) {
     val key = UPLOAD_FILE_NAME
     val bucketName = givenBucketV2(testInfo)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -57,7 +57,6 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
 import software.amazon.awssdk.services.s3.model.EncodingType
 import software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse
 import software.amazon.awssdk.services.s3.model.GetObjectResponse
-import software.amazon.awssdk.services.s3.model.HeadBucketRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse
 import software.amazon.awssdk.services.s3.model.ObjectLockEnabled
 import software.amazon.awssdk.services.s3.model.ObjectLockLegalHoldStatus
@@ -388,11 +387,9 @@ internal abstract class S3TestBase {
     }
     val bucketDeleted = _s3ClientV2
       .waiter()
-      .waitUntilBucketNotExists(HeadBucketRequest
-        .builder()
-        .bucket(bucket.name())
-        .build()
-      )
+      .waitUntilBucketNotExists {
+        it.bucket(bucket.name())
+      }
     bucketDeleted.matched().exception().get().also {
       assertThat(it).isNotNull
     }
@@ -510,31 +507,20 @@ internal abstract class S3TestBase {
           // no-op
         }
 
-        override fun checkClientTrusted(
-          arg0: Array<X509Certificate>, arg1: String,
-          arg2: SSLEngine
+        override fun checkClientTrusted(arg0: Array<X509Certificate>, arg1: String, arg2: SSLEngine) {
+          // no-op
+        }
+
+        override fun checkClientTrusted(arg0: Array<X509Certificate>, arg1: String, arg2: Socket
         ) {
           // no-op
         }
 
-        override fun checkClientTrusted(
-          arg0: Array<X509Certificate>, arg1: String,
-          arg2: Socket
-        ) {
+        override fun checkServerTrusted(arg0: Array<X509Certificate>, arg1: String, arg2: SSLEngine) {
           // no-op
         }
 
-        override fun checkServerTrusted(
-          arg0: Array<X509Certificate>, arg1: String,
-          arg2: SSLEngine
-        ) {
-          // no-op
-        }
-
-        override fun checkServerTrusted(
-          arg0: Array<X509Certificate>, arg1: String,
-          arg2: Socket
-        ) {
+        override fun checkServerTrusted(arg0: Array<X509Certificate>, arg1: String, arg2: Socket) {
           // no-op
         }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -310,7 +310,7 @@ public class ObjectService extends ServiceBase {
       var setModifiedSince = ifModifiedSince != null && !ifModifiedSince.isEmpty();
       if (setModifiedSince) {
         if (ifModifiedSince.get(0).isAfter(lastModified)) {
-          throw PRECONDITION_FAILED;
+          throw NOT_MODIFIED;
         }
       }
 

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/service/ObjectServiceTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/service/ObjectServiceTest.kt
@@ -181,7 +181,7 @@ internal class ObjectServiceTest : ServiceTestBase() {
     val now = Instant.now().plusSeconds(10)
 
     assertThatThrownBy { iut.verifyObjectMatching(null, null, listOf(now), null, s3ObjectMetadata) }
-      .isEqualTo(S3Exception.PRECONDITION_FAILED)
+      .isEqualTo(S3Exception.NOT_MODIFIED)
   }
 
   @Test


### PR DESCRIPTION
Test all ITs against S3 again to see if there are differences in behaviour, fix S3Mock if necessary.
Migrate all SDK V1 tests to SDK V2.
Remove SDK V1 tests.
Use Lambdas where possible for functions accepting Consumer<Builder>. Kotlification.

## Description
<!--- Describe your changes -->

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
