### PR TITLE
Do not store "aws-chunked" encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * [PLANNED - 5.x - RELEASE TBD](#planned---5x---release-tbd)
   * [Planned changes](#planned-changes)
 * [CURRENT - 4.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---4x---this-version-is-under-active-development)
-  * [4.1.1 - PLANNED](#411---planned)
+  * [4.2.0 - PLANNED](#420---planned)
+  * [4.1.1](#411)
   * [4.1.0](#410)
   * [4.0.0](#400)
 * [DEPRECATED - 3.x](#deprecated---3x)
@@ -137,17 +138,29 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 
 **The current major version 4 will receive new features, dependency updates and bug fixes on a continuous basis.**
 
-## 4.1.1 - PLANNED
+## 4.2.0 - PLANNED
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
-  * Content-Encoding: aws-chunked should not be stored (fixes #2218)
+  * Support checksum algorithm CRC64NVME (fixes #2334)
 * Refactorings
   * TBD
 * Version updates (deliverable dependencies)
   * TBD
 * Version updates (build dependencies)
   * TBD
+
+## 4.1.1
+Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * Content-Encoding: aws-chunked should not be stored (fixes #2218)
+* Refactorings
+  * none
+* Version updates (deliverable dependencies)
+  * none
+* Version updates (build dependencies)
+  * none
 
 ## 4.1.0
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -227,7 +227,6 @@ internal abstract class S3TestBase {
   @AfterEach
   fun cleanupStores() {
     for (bucket in _s3Client.listBuckets().buckets()) {
-      if(bucket.name() == "testputandgetretention-545488000") {return}
       //Empty all buckets
       deleteMultipartUploads(bucket)
       deleteObjectsInBucket(bucket, isObjectLockEnabled(bucket))

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ServiceBase.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ServiceBase.java
@@ -24,8 +24,8 @@ import static com.adobe.testing.s3mock.S3Exception.BAD_DIGEST;
 import static com.adobe.testing.s3mock.S3Exception.BAD_REQUEST_CONTENT;
 import static com.adobe.testing.s3mock.util.AwsHttpHeaders.X_AMZ_DECODED_CONTENT_LENGTH;
 import static com.adobe.testing.s3mock.util.HeaderUtil.checksumAlgorithmFromSdk;
-import static com.adobe.testing.s3mock.util.HeaderUtil.isChunked;
-import static com.adobe.testing.s3mock.util.HeaderUtil.isChunkedAndV4Signed;
+import static com.adobe.testing.s3mock.util.HeaderUtil.isChunkedEncoding;
+import static com.adobe.testing.s3mock.util.HeaderUtil.isV4Signed;
 
 import com.adobe.testing.s3mock.dto.ChecksumAlgorithm;
 import com.adobe.testing.s3mock.util.AbstractAwsInputStream;
@@ -93,9 +93,9 @@ abstract class ServiceBase {
   private InputStream wrapStream(InputStream dataStream, HttpHeaders headers) {
     var lengthHeader = headers.getFirst(X_AMZ_DECODED_CONTENT_LENGTH);
     var length = lengthHeader == null ? -1 : Long.parseLong(lengthHeader);
-    if (isChunkedAndV4Signed(headers)) {
+    if (isV4Signed(headers)) {
       return new AwsChunkedDecodingChecksumInputStream(dataStream, length);
-    } else if (isChunked(headers)) {
+    } else if (isChunkedEncoding(headers)) {
       return new AwsUnsignedChunkedDecodingChecksumInputStream(dataStream, length);
     } else {
       return dataStream;


### PR DESCRIPTION
## Description
AWS docs specify that this encoding is not persisted or returned if it's the only value sent in the "Content-Encoding" header.

## Related Issue
Fixes #2218

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
