### PR TITLE
Support crc64nvme checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,9 +146,10 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Refactorings
   * TBD
 * Version updates (deliverable dependencies)
-  * TBD
+  * Bump spring-boot.version from 3.4.4 to 3.4.5
+  * Bump testcontainers.version from 1.20.6 to 1.21.0
 * Version updates (build dependencies)
-  * TBD
+  * Bump github/codeql-action from 3.28.15 to 3.28.16
 
 ## 4.1.1
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AclIT.kt
@@ -108,7 +108,7 @@ internal class AclIT : S3TestBase() {
     val userName = "John Doe"
     val granteeId = "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2ef"
     val granteeName = "Jane Doe"
-    val granteeEmail = "jane@doe.com"
+    "jane@doe.com"
     s3Client.putObjectAcl {
       it.bucket(bucketName)
       it.key(sourceKey)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEncodingIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/AwsChunkedEncodingIT.kt
@@ -20,7 +20,7 @@ import com.adobe.testing.s3mock.util.DigestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
-import software.amazon.awssdk.core.checksums.Algorithm
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm
 import java.io.File
@@ -49,7 +49,7 @@ internal class AwsChunkedEncodingIT : S3TestBase() {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val uploadFileIs: InputStream = FileInputStream(uploadFile)
     val expectedEtag = "\"${DigestUtil.hexDigest(uploadFileIs)}\""
-    val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), Algorithm.SHA256)
+    val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), DefaultChecksumAlgorithm.SHA256)
 
     val putObjectResponse = s3Client.putObject(
       {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectsIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectsIT.kt
@@ -254,9 +254,6 @@ internal class ListObjectsIT : S3TestBase() {
   fun listV1(parameters: Param, testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
-    val weirdStuff = "\u0001" // key invalid in XML
-    val prefix = "shouldHonorEncodingTypeV2/"
-    val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
 
     for(key in ALL_OBJECTS) {
       s3Client.putObject(
@@ -308,9 +305,6 @@ internal class ListObjectsIT : S3TestBase() {
   fun listV2(parameters: Param, testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val uploadFile = File(UPLOAD_FILE_NAME)
-    val weirdStuff = "\u0001" // key invalid in XML
-    val prefix = "shouldHonorEncodingTypeV2/"
-    val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
 
     for(key in ALL_OBJECTS) {
       s3Client.putObject(

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
@@ -59,7 +59,6 @@ internal class PlainHttpIT : S3TestBase() {
     val putObject = HttpPut("$serviceEndpoint/$targetBucket/testObjectName").apply {
       this.entity = ByteArrayEntity(byteArray)
       this.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
-      this.params
     }
 
     httpClient.execute(putObject).use {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUrlIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PresignedUrlIT.kt
@@ -172,7 +172,7 @@ internal class PresignedUrlIT : S3TestBase() {
         assertThat(it.getFirstHeader(HttpHeaders.CACHE_CONTROL).value).isEqualTo("no-cache")
         assertThat(it.getFirstHeader("Content-Disposition").value).isEqualTo("attachment; filename=\"$key\"")
         assertThat(it.getFirstHeader(HttpHeaders.CONTENT_ENCODING).value).isEqualTo("encoding")
-        assertThat(it.getFirstHeader(HttpHeaders.CONTENT_TYPE).value).isEqualTo("application/json")
+        assertThat(it.getFirstHeader(CONTENT_TYPE).value).isEqualTo("application/json")
         assertThat(it.getFirstHeader(HttpHeaders.CONTENT_LANGUAGE).value).isEqualTo("en")
       }
     }

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/VersionsIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/VersionsIT.kt
@@ -21,7 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
-import software.amazon.awssdk.core.checksums.Algorithm
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.BucketVersioningStatus
@@ -68,7 +68,7 @@ internal class VersionsIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun testPutGetObject_withVersion(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
-    val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), Algorithm.SHA1)
+    val expectedChecksum = DigestUtil.checksumFor(uploadFile.toPath(), DefaultChecksumAlgorithm.SHA1)
     val bucketName = givenBucket(testInfo)
 
     s3Client.putBucketVersioning {

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,11 @@
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
+        <artifactId>checksums</artifactId>
+        <version>${aws-v2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3-transfer-manager</artifactId>
         <version>${aws-v2.version}</version>
       </dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -64,6 +64,10 @@
       <artifactId>s3</artifactId>
     </dependency>
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-crt-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/server/src/main/java/com/adobe/testing/s3mock/S3Exception.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/S3Exception.java
@@ -129,6 +129,9 @@ public class S3Exception extends RuntimeException {
   public static final S3Exception BAD_CHECKSUM_CRC32C =
       new S3Exception(BAD_REQUEST.value(), BAD_REQUEST_CODE,
           "Value for x-amz-checksum-crc32c header is invalid.");
+  public static final S3Exception BAD_CHECKSUM_CRC64NVME =
+      new S3Exception(BAD_REQUEST.value(), BAD_REQUEST_CODE,
+          "Value for x-amz-checksum-crc64nvme header is invalid.");
   private final int status;
   private final String code;
   private final String message;

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/Checksum.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/Checksum.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ public record Checksum(
     @JsonProperty("ChecksumSHA1")
     String checksumSHA1,
     @JsonProperty("ChecksumSHA256")
-    String checksumSHA256
+    String checksumSHA256,
+    @JsonProperty("ChecksumCRC64NVME")
+    String checksumCRC64NVME
 ) {
 
 }

--- a/server/src/main/java/com/adobe/testing/s3mock/dto/ChecksumAlgorithm.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/dto/ChecksumAlgorithm.java
@@ -18,7 +18,7 @@ package com.adobe.testing.s3mock.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import software.amazon.awssdk.core.checksums.Algorithm;
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
 
 public enum ChecksumAlgorithm {
   CRC32("CRC32"),
@@ -56,13 +56,13 @@ public enum ChecksumAlgorithm {
     };
   }
 
-  public Algorithm toAlgorithm() {
+  public software.amazon.awssdk.checksums.spi.ChecksumAlgorithm toChecksumAlgorithm() {
     return switch (this) {
-      case CRC32 -> Algorithm.CRC32;
-      case CRC32C -> Algorithm.CRC32C;
-      case CRC64NVME -> Algorithm.CRC64NVME;
-      case SHA1 -> Algorithm.SHA1;
-      case SHA256 -> Algorithm.SHA256;
+      case CRC32 -> DefaultChecksumAlgorithm.CRC32;
+      case CRC32C -> DefaultChecksumAlgorithm.CRC32C;
+      case CRC64NVME -> DefaultChecksumAlgorithm.CRC64NVME;
+      case SHA1 -> DefaultChecksumAlgorithm.SHA1;
+      case SHA256 -> DefaultChecksumAlgorithm.SHA256;
     };
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -372,7 +372,8 @@ public class ObjectService extends ServiceBase {
               checksumAlgorithm == ChecksumAlgorithm.CRC32 ? s3ObjectMetadata.checksum() : null,
               checksumAlgorithm == ChecksumAlgorithm.CRC32C ? s3ObjectMetadata.checksum() : null,
               checksumAlgorithm == ChecksumAlgorithm.SHA1 ? s3ObjectMetadata.checksum() : null,
-              checksumAlgorithm == ChecksumAlgorithm.SHA256 ? s3ObjectMetadata.checksum() : null
+              checksumAlgorithm == ChecksumAlgorithm.SHA256 ? s3ObjectMetadata.checksum() : null,
+              checksumAlgorithm == ChecksumAlgorithm.CRC64NVME ? s3ObjectMetadata.checksum() : null
       );
     }
     return null;

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ServiceBase.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ServiceBase.java
@@ -18,6 +18,7 @@ package com.adobe.testing.s3mock.service;
 
 import static com.adobe.testing.s3mock.S3Exception.BAD_CHECKSUM_CRC32;
 import static com.adobe.testing.s3mock.S3Exception.BAD_CHECKSUM_CRC32C;
+import static com.adobe.testing.s3mock.S3Exception.BAD_CHECKSUM_CRC64NVME;
 import static com.adobe.testing.s3mock.S3Exception.BAD_CHECKSUM_SHA1;
 import static com.adobe.testing.s3mock.S3Exception.BAD_CHECKSUM_SHA256;
 import static com.adobe.testing.s3mock.S3Exception.BAD_DIGEST;
@@ -46,13 +47,14 @@ abstract class ServiceBase {
   private static final Logger LOG = LoggerFactory.getLogger(ServiceBase.class);
 
   public void verifyChecksum(Path path, String checksum, ChecksumAlgorithm checksumAlgorithm) {
-    String checksumFor = DigestUtil.checksumFor(path, checksumAlgorithm.toAlgorithm());
+    String checksumFor = DigestUtil.checksumFor(path, checksumAlgorithm.toChecksumAlgorithm());
     if (!checksum.equals(checksumFor)) {
       switch (checksumAlgorithm) {
         case SHA1 -> throw BAD_CHECKSUM_SHA1;
         case SHA256 -> throw BAD_CHECKSUM_SHA256;
         case CRC32 -> throw BAD_CHECKSUM_CRC32;
         case CRC32C -> throw BAD_CHECKSUM_CRC32C;
+        case CRC64NVME -> throw BAD_CHECKSUM_CRC64NVME;
         default -> throw BAD_DIGEST;
       }
     }

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
@@ -288,7 +288,8 @@ public class MultipartStore extends StoreBase {
 
   private String checksumFor(List<Path> paths, MultipartUploadInfo uploadInfo) {
     if (uploadInfo.checksumAlgorithm() != null) {
-      return DigestUtil.checksumMultipart(paths, uploadInfo.checksumAlgorithm().toAlgorithm());
+      return DigestUtil.checksumMultipart(paths,
+          uploadInfo.checksumAlgorithm().toChecksumAlgorithm());
     }
     return null;
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/util/DigestUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/DigestUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import software.amazon.awssdk.core.checksums.Algorithm;
-import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.checksums.SdkChecksum;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.utils.BinaryUtils;
 
 /**
@@ -57,7 +57,7 @@ public final class DigestUtil {
    * @param algorithm algorithm to use
    * @return the checksum
    */
-  public static String checksumFor(Path path, Algorithm algorithm) {
+  public static String checksumFor(Path path, ChecksumAlgorithm algorithm) {
     try (InputStream is = Files.newInputStream(path)) {
       return checksumFor(is, algorithm);
     } catch (IOException e) {
@@ -72,7 +72,7 @@ public final class DigestUtil {
    * @param algorithm algorithm to use
    * @return the checksum
    */
-  private static String checksumFor(InputStream is, Algorithm algorithm) {
+  private static String checksumFor(InputStream is, ChecksumAlgorithm algorithm) {
     return BinaryUtils.toBase64(checksum(is, algorithm));
   }
 
@@ -83,7 +83,7 @@ public final class DigestUtil {
    * @param algorithm algorithm to use
    * @return the checksum
    */
-  private static byte[] checksum(InputStream is, Algorithm algorithm) {
+  private static byte[] checksum(InputStream is, ChecksumAlgorithm algorithm) {
     SdkChecksum sdkChecksum = SdkChecksum.forAlgorithm(algorithm);
     try {
       byte[] buffer = new byte[4096];
@@ -97,7 +97,7 @@ public final class DigestUtil {
     }
   }
 
-  private static byte[] checksum(List<Path> paths, Algorithm algorithm) {
+  private static byte[] checksum(List<Path> paths, ChecksumAlgorithm algorithm) {
     SdkChecksum sdkChecksum = SdkChecksum.forAlgorithm(algorithm);
     var allChecksums = new byte[0];
     for (var path : paths) {
@@ -144,7 +144,7 @@ public final class DigestUtil {
    * checksum.
    * <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">API</a>
    */
-  public static String checksumMultipart(List<Path> paths, Algorithm algorithm) {
+  public static String checksumMultipart(List<Path> paths, ChecksumAlgorithm algorithm) {
     return BinaryUtils.toBase64(checksum(paths, algorithm)) + "-" + paths.size();
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/util/HeaderUtil.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/util/HeaderUtil.java
@@ -232,6 +232,8 @@ public final class HeaderUtil {
       return ChecksumAlgorithm.CRC32;
     } else if (headers.containsKey(X_AMZ_CHECKSUM_CRC32C)) {
       return ChecksumAlgorithm.CRC32C;
+    } else if (headers.containsKey(X_AMZ_CHECKSUM_CRC64NVME)) {
+      return ChecksumAlgorithm.CRC64NVME;
     } else if (headers.containsKey(X_AMZ_CHECKSUM_ALGORITHM)) {
       var checksumAlgorithm = headers.getFirst(X_AMZ_CHECKSUM_ALGORITHM);
       return ChecksumAlgorithm.fromString(checksumAlgorithm);

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/ChecksumTestUtil.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/ChecksumTestUtil.kt
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2017-2025 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock
+
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm
+import software.amazon.awssdk.checksums.SdkChecksum
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm
+import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope
+import software.amazon.awssdk.http.auth.aws.internal.signer.RollingSigner
+import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.ChecksumTrailerProvider
+import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.ChunkedEncodedInputStream
+import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.SigV4ChunkExtensionProvider
+import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.SigV4TrailerProvider
+import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.TrailerProvider
+import software.amazon.awssdk.http.auth.aws.internal.signer.io.ChecksumInputStream
+import software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil
+import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerUtils
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Files
+import java.time.Instant
+import java.util.stream.Stream
+
+object ChecksumTestUtil {
+
+  fun prepareInputStream(
+      input: File,
+      signed: Boolean = true,
+      algorithm: ChecksumAlgorithm? = null,
+  ): Pair<InputStream, Long> {
+    val builder = ChunkedEncodedInputStream.builder()
+    builder.inputStream(Files.newInputStream(input.toPath()))
+    if (algorithm != null) {
+      setupChecksumTrailer(builder, algorithm)
+    }
+    if (signed) {
+      setupSignedTrailerAndExtension(builder)
+    }
+    val chunkedEncodingInputStream: InputStream = builder
+      .chunkSize(4000)
+      .build()
+
+    val decodedLength = input.length()
+
+    return chunkedEncodingInputStream to decodedLength
+  }
+
+  fun setupSignedTrailerAndExtension(builder: ChunkedEncodedInputStream.Builder) {
+    val seedSignature = "106e2a8a18243abcf37539882f36619c00e2dfc72633413f02d3b74544bfeb8e"
+    val credentialScope =
+        CredentialScope("us-east-1", "s3", Instant.parse("2013-05-24T00:00:00Z"))
+    val credentials =
+      AwsCredentialsIdentity.create("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    val signingKey = SignerUtils.deriveSigningKey(credentials, credentialScope)
+    val rollingSigner = RollingSigner(signingKey, seedSignature)
+    val sigV4ChunkExtensionProvider = SigV4ChunkExtensionProvider(rollingSigner, credentialScope)
+    val sigV4TrailerProvider = SigV4TrailerProvider(emptyList(), rollingSigner, credentialScope)
+
+    builder.addTrailer(sigV4TrailerProvider)
+    builder.addExtension(sigV4ChunkExtensionProvider)
+  }
+
+  fun setupChecksumTrailer(
+      builder: ChunkedEncodedInputStream.Builder,
+      checksumAlgorithm: ChecksumAlgorithm
+  ) {
+    val checksumHeaderName = ChecksumUtil.checksumHeaderName(checksumAlgorithm)
+    val sdkChecksum = ChecksumUtil.fromChecksumAlgorithm(checksumAlgorithm)
+    val checksumInputStream = ChecksumInputStream(
+        builder.inputStream(),
+        mutableSetOf<SdkChecksum?>(sdkChecksum)
+    )
+
+    val checksumTrailer: TrailerProvider = ChecksumTrailerProvider(sdkChecksum, checksumHeaderName)
+
+    builder.inputStream(checksumInputStream).addTrailer(checksumTrailer)
+  }
+
+  @JvmStatic
+  fun algorithms(): Stream<ChecksumAlgorithm> {
+    return listOf(
+      DefaultChecksumAlgorithm.SHA256,
+      DefaultChecksumAlgorithm.SHA1,
+      DefaultChecksumAlgorithm.CRC32,
+      DefaultChecksumAlgorithm.CRC32C,
+      DefaultChecksumAlgorithm.CRC64NVME
+    ).stream()
+  }
+}

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/ObjectControllerTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/ObjectControllerTest.kt
@@ -58,7 +58,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.util.UriComponentsBuilder
-import software.amazon.awssdk.core.checksums.Algorithm
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm
 import java.io.File
 import java.io.InputStream
 import java.nio.file.Files
@@ -104,7 +104,7 @@ internal class ObjectControllerTest : BaseControllerTest() {
       .thenReturn(
         Pair.of(
           tempFile,
-          DigestUtil.checksumFor(testFile.toPath(), Algorithm.CRC32)
+          DigestUtil.checksumFor(testFile.toPath(), DefaultChecksumAlgorithm.CRC32)
         )
       )
 
@@ -162,7 +162,7 @@ internal class ObjectControllerTest : BaseControllerTest() {
       .thenReturn(
         Pair.of(
           tempFile,
-          DigestUtil.checksumFor(testFile.toPath(), Algorithm.CRC32)
+          DigestUtil.checksumFor(testFile.toPath(), DefaultChecksumAlgorithm.CRC32)
         )
       )
 
@@ -226,7 +226,7 @@ internal class ObjectControllerTest : BaseControllerTest() {
       .thenReturn(
         Pair.of(
           tempFile,
-          DigestUtil.checksumFor(testFile.toPath(), Algorithm.CRC32)
+          DigestUtil.checksumFor(testFile.toPath(), DefaultChecksumAlgorithm.CRC32)
         )
       )
     whenever(

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/util/AwsChunkedDecodingChecksumInputStreamTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/util/AwsChunkedDecodingChecksumInputStreamTest.kt
@@ -15,164 +15,112 @@
  */
 package com.adobe.testing.s3mock.util
 
+import com.adobe.testing.s3mock.ChecksumTestUtil
 import com.adobe.testing.s3mock.dto.ChecksumAlgorithm
+import com.adobe.testing.s3mock.ChecksumTestUtil.prepareInputStream
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import software.amazon.awssdk.auth.signer.internal.chunkedencoding.AwsS3V4ChunkSigner
-import software.amazon.awssdk.auth.signer.internal.chunkedencoding.AwsSignedChunkedEncodingInputStream
-import software.amazon.awssdk.core.checksums.Algorithm
-import software.amazon.awssdk.core.checksums.SdkChecksum
-import software.amazon.awssdk.core.internal.chunked.AwsChunkedEncodingConfig
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm
 import java.io.File
 import java.io.IOException
-import java.io.InputStream
 import java.nio.file.Files
 import java.util.stream.Stream
 
 internal class AwsChunkedDecodingChecksumInputStreamTest {
   @Test
   @Throws(IOException::class)
-  fun testDecode_checksum(testInfo: TestInfo) {
+  fun `test decoding aws inputstream with fixed checksum`(testInfo: TestInfo) {
+    val sampleFile = TestUtil.getFileFromClasspath(testInfo, "sampleFile.txt")
+    val sampleFileLarge = TestUtil.getFileFromClasspath(testInfo, "sampleFile_large.txt")
     doTest(
-      testInfo, "sampleFile.txt", AwsHttpHeaders.X_AMZ_CHECKSUM_SHA256, Algorithm.SHA256,
-      "1VcEifAruhjVvjzul4sC0B1EmlUdzqvsp6BP0KSVdTE=", ChecksumAlgorithm.SHA256, 1
+      sampleFile,
+      1,
+      DefaultChecksumAlgorithm.SHA256,
+      "1VcEifAruhjVvjzul4sC0B1EmlUdzqvsp6BP0KSVdTE=",
+      ChecksumAlgorithm.SHA256,
     )
     doTest(
-      testInfo, "sampleFile_large.txt", AwsHttpHeaders.X_AMZ_CHECKSUM_SHA256, Algorithm.SHA256,
-      "Y8S4/uAGut7vjdFZQjLKZ7P28V9EPWb4BIoeniuM0mY=", ChecksumAlgorithm.SHA256, 16
+      sampleFileLarge,
+      16,
+      DefaultChecksumAlgorithm.SHA256,
+      "Y8S4/uAGut7vjdFZQjLKZ7P28V9EPWb4BIoeniuM0mY=",
+      ChecksumAlgorithm.SHA256
     )
-  }
-
-  @Test
-  @Throws(IOException::class)
-  fun testDecode_noChecksum(testInfo: TestInfo) {
-    doTest(testInfo, "sampleFile.txt", 1)
-    doTest(testInfo, "sampleFile_large.txt", 16)
-  }
-
-  @Throws(IOException::class)
-  fun doTest(testInfo: TestInfo, fileName: String, chunks: Int) {
-    doTest(testInfo, fileName, null, null, null, null, chunks)
-  }
-
-  @Throws(IOException::class)
-  fun doTest(
-    testInfo: TestInfo, fileName: String, header: String?, algorithm: Algorithm?,
-    checksum: String?, checksumAlgorithm: ChecksumAlgorithm?, chunks: Int
-  ) {
-    val sampleFile = TestUtil.getFileFromClasspath(testInfo, fileName)
-    val builder = AwsSignedChunkedEncodingInputStream
-      .builder()
-      .inputStream(Files.newInputStream(sampleFile.toPath()))
-    if (algorithm != null) {
-      builder.sdkChecksum(SdkChecksum.forAlgorithm(algorithm))
-    }
-    val chunkedEncodingInputStream: InputStream = builder
-      .checksumHeaderForTrailer(header) //force chunks in the inputstream
-      .awsChunkedEncodingConfig(AwsChunkedEncodingConfig.builder().chunkSize(4000).build())
-      .awsChunkSigner(
-        AwsS3V4ChunkSigner(
-          "signingKey".toByteArray(),
-          "dateTime",
-          "keyPath"
-        )
-      )
-      .build()
-
-    val decodedLength = sampleFile.length()
-    val iut = AwsChunkedDecodingChecksumInputStream(chunkedEncodingInputStream, decodedLength)
-    assertThat(iut).hasSameContentAs(Files.newInputStream(sampleFile.toPath()))
-    assertThat(iut.getAlgorithm()).isEqualTo(checksumAlgorithm)
-    assertThat(iut.getChecksum()).isEqualTo(checksum)
-    assertThat(iut.decodedLength).isEqualTo(decodedLength)
-    assertThat(iut.readDecodedLength).isEqualTo(decodedLength)
-    assertThat(iut.chunks).isEqualTo(chunks)
   }
 
   @ParameterizedTest
   @MethodSource("algorithms")
   @Throws(IOException::class)
-  fun testDecode_signed_checksum(algorithm: Algorithm, testInfo: TestInfo) {
+  fun `test decoding aws inputstream with calculated checksum`(
+    algorithm: software.amazon.awssdk.checksums.spi.ChecksumAlgorithm,
+    testInfo: TestInfo
+  ) {
     val checksumAlgorithm = ChecksumAlgorithm.fromString(algorithm.toString())
-    val header = HeaderUtil.mapChecksumToHeader(checksumAlgorithm)
-    doTestSigned(
-      TestUtil.getFileFromClasspath(testInfo, "sampleFile.txt"),
+    val sampleFile = TestUtil.getFileFromClasspath(testInfo, "sampleFile.txt")
+    val sampleFileLarge = TestUtil.getFileFromClasspath(testInfo, "sampleFile_large.txt")
+    val testImageSmall = TestUtil.getFileFromClasspath(testInfo, "test-image-small.png")
+    val testImage = TestUtil.getFileFromClasspath(testInfo, "test-image.png")
+
+    doTest(
+      sampleFile,
       1,
-      header,
-      SdkChecksum.forAlgorithm(algorithm),
-      DigestUtil.checksumFor(
-        TestUtil.getFileFromClasspath(testInfo, "sampleFile.txt").toPath(), algorithm
-      ),
+      algorithm,
+      DigestUtil.checksumFor(sampleFile.toPath(), algorithm),
       checksumAlgorithm
     )
-    doTestSigned(
-      TestUtil.getFileFromClasspath(testInfo, "sampleFile_large.txt"),
+    doTest(
+      sampleFileLarge,
       16,
-      header,
-      SdkChecksum.forAlgorithm(algorithm),
-      DigestUtil.checksumFor(
-        TestUtil.getFileFromClasspath(testInfo, "sampleFile_large.txt").toPath(), algorithm
-      ),
+      algorithm,
+      DigestUtil.checksumFor(sampleFileLarge.toPath(), algorithm),
       checksumAlgorithm
     )
-    doTestSigned(
-      TestUtil.getFileFromClasspath(testInfo, "test-image-small.png"),
+    doTest(
+      testImageSmall,
       9,
-      header,
-      SdkChecksum.forAlgorithm(algorithm),
-      DigestUtil.checksumFor(
-        TestUtil.getFileFromClasspath(testInfo, "test-image-small.png").toPath(), algorithm
-      ),
+      algorithm,
+      DigestUtil.checksumFor(testImageSmall.toPath(), algorithm),
       checksumAlgorithm
     )
-    doTestSigned(
-      TestUtil.getFileFromClasspath(testInfo, "test-image.png"),
+    doTest(
+      testImage,
       17,
-      header,
-      SdkChecksum.forAlgorithm(algorithm),
-      DigestUtil.checksumFor(
-        TestUtil.getFileFromClasspath(testInfo, "test-image.png").toPath(), algorithm
-      ),
+      algorithm,
+      DigestUtil.checksumFor(testImage.toPath(), algorithm),
       checksumAlgorithm
     )
   }
 
   @Test
   @Throws(IOException::class)
-  fun testDecode_signed_noChecksum(testInfo: TestInfo) {
-    doTestSigned(TestUtil.getFileFromClasspath(testInfo, "sampleFile.txt"), 1)
-    doTestSigned(TestUtil.getFileFromClasspath(testInfo, "sampleFile_large.txt"), 16)
-    doTestSigned(TestUtil.getFileFromClasspath(testInfo, "test-image-small.png"), 9)
-    doTestSigned(TestUtil.getFileFromClasspath(testInfo, "test-image.png"), 17)
+  fun `test decoding aws inputstream without checksum`(testInfo: TestInfo) {
+    val sampleFile = TestUtil.getFileFromClasspath(testInfo, "sampleFile.txt")
+    val sampleFileLarge = TestUtil.getFileFromClasspath(testInfo, "sampleFile_large.txt")
+    val testImageSmall = TestUtil.getFileFromClasspath(testInfo, "test-image-small.png")
+    val testImage = TestUtil.getFileFromClasspath(testInfo, "test-image.png")
+    doTest(sampleFile, 1)
+    doTest(sampleFileLarge, 16)
+    doTest(testImageSmall, 9)
+    doTest(testImage, 17)
   }
 
-  @JvmOverloads
   @Throws(IOException::class)
-  fun doTestSigned(
-    input: File, chunks: Int, header: String? = null, algorithm: SdkChecksum? = null,
-    checksum: String? = null, checksumAlgorithm: ChecksumAlgorithm? = null
+  private fun doTest(
+    input: File,
+    chunks: Int = 0,
+    algorithm: software.amazon.awssdk.checksums.spi.ChecksumAlgorithm? = null,
+    checksum: String? = null,
+    checksumAlgorithm: ChecksumAlgorithm? = null
   ) {
-    val chunkedEncodingInputStream: InputStream = AwsSignedChunkedEncodingInputStream
-      .builder()
-      .inputStream(Files.newInputStream(input.toPath()))
-      .sdkChecksum(algorithm)
-      .checksumHeaderForTrailer(header) //force chunks in the inputstream
-      .awsChunkedEncodingConfig(AwsChunkedEncodingConfig.builder().chunkSize(4000).build())
-      .awsChunkSigner(
-        AwsS3V4ChunkSigner(
-          "signingKey".toByteArray(),
-          "dateTime",
-          "keyPath"
-        )
-      )
-      .build()
-
-    val decodedLength = input.length()
+    val (chunkedEncodingInputStream, decodedLength) = prepareInputStream(
+      input,
+      true,
+      algorithm,
+    )
     val iut = AwsChunkedDecodingChecksumInputStream(chunkedEncodingInputStream, decodedLength)
-
     assertThat(iut).hasSameContentAs(Files.newInputStream(input.toPath()))
     assertThat(iut.getAlgorithm()).isEqualTo(checksumAlgorithm)
     assertThat(iut.getChecksum()).isEqualTo(checksum)
@@ -183,10 +131,8 @@ internal class AwsChunkedDecodingChecksumInputStreamTest {
 
   companion object {
     @JvmStatic
-    private fun algorithms(): Stream<Algorithm> {
-      //ignore new CRC64NVME for now, looks like AWS is moving checksums from core to a new checksums module, but not all
-      //types are currently compatible with the new types.
-      return Algorithm.entries.toList().stream().filter { it != Algorithm.CRC64NVME }
+    fun algorithms(): Stream<software.amazon.awssdk.checksums.spi.ChecksumAlgorithm> {
+      return ChecksumTestUtil.algorithms()
     }
   }
 }

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/util/DigestUtilTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/util/DigestUtilTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import org.apache.commons.codec.digest.DigestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
-import software.amazon.awssdk.core.checksums.Algorithm
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm
 import software.amazon.awssdk.utils.BinaryUtils
 
 internal class DigestUtilTest {
@@ -62,6 +62,6 @@ internal class DigestUtilTest {
       TestUtil.getTestFile(testInfo, "testFile2").toPath()
     )
 
-    assertThat(DigestUtil.checksumMultipart(files, Algorithm.SHA256)).isEqualTo(expected)
+    assertThat(DigestUtil.checksumMultipart(files, DefaultChecksumAlgorithm.SHA256)).isEqualTo(expected)
   }
 }


### PR DESCRIPTION
## Description
Support crc64nvme checksum, add tests.
Refactor S3Mock and tests to use new checksum related types from AWS SDK v2.

## Related Issue
#2334

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
