### PR TITLE
Let S3Mock accept * and "*" for conditional requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * [PLANNED - 5.x - RELEASE TBD](#planned---5x---release-tbd)
   * [Planned changes](#planned-changes)
 * [CURRENT - 4.x - THIS VERSION IS UNDER ACTIVE DEVELOPMENT](#current---4x---this-version-is-under-active-development)
-  * [4.3.0 - PLANNED](#430---planned)
+  * [4.4.0 - PLANNED](#440---planned)
+  * [4.3.0](#430)
   * [4.2.0](#420)
   * [4.1.1](#411)
   * [4.1.0](#410)
@@ -141,7 +142,7 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 
 **The current major version 4 will receive new features, dependency updates and bug fixes on a continuous basis.**
 
-## 4.3.0 - PLANNED
+## 4.4.0 - PLANNED
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
@@ -152,6 +153,22 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * none
 * Version updates (build dependencies)
   * none
+
+## 4.3.0
+Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * S3Mock accepts * for conditional requests on all APIs. (fixes #2371)
+  * Clarifications for S3Mock with custom SSL certificate usage in README.md
+  * Clarifications for S3Mock with provided SSL certificate usage in README.md
+* Refactorings
+  * none
+* Version updates (deliverable dependencies)
+  * Bump aws-v2.version from 2.31.38 to 2.31.42
+* Version updates (build dependencies)
+  * Bump aws.sdk.kotlin:s3-jvm from 1.4.80 to 1.4.83
+  * Bump kotlin.version from 2.1.20 to 2.1.21
+  * Bump actions/dependency-review-action from 4.7.0 to 4.7.1
 
 ## 4.2.0
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
@@ -179,11 +196,11 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
     * PutObject now supports conditional requests
 * Version updates (deliverable dependencies)
   * Bump aws-v2.version from 2.31.25 to 2.31.38
-  * Bump aws.sdk.kotlin:s3-jvm from 1.4.67 to 1.4.80
   * Bump aws.version from 1.12.782 to 1.12.783
   * Bump spring-boot.version from 3.4.4 to 3.4.5
   * Bump testcontainers.version from 1.20.6 to 1.21.0
 * Version updates (build dependencies)
+  * Bump aws.sdk.kotlin:s3-jvm from 1.4.67 to 1.4.80
   * Bump actions/dependency-review-action from 4.6.0 to 4.7.0
   * Bump github/codeql-action from 3.28.15 to 3.28.17
   * Bump com.puppycrawl.tools:checkstyle from 10.23.0 to 10.23.1
@@ -212,9 +229,9 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * Migrate all integration tests to AWS SDK v2, remove AWS SDK v1 tests from the integration-tests module
 * Version updates (deliverable dependencies)
   * Bump aws-v2.version from 2.31.17 to 2.31.25
-  * Bump aws.sdk.kotlin:s3-jvm from 1.4.59 to 1.4.67
   * Bump commons-io:commons-io from 2.18.0 to 2.19.0
 * Version updates (build dependencies)
+  * Bump aws.sdk.kotlin:s3-jvm from 1.4.59 to 1.4.67
   * Bump step-security/harden-runner from 2.11.1 to 2.12.0
   * Bump actions/setup-java from 4.7.0 to 4.7.1
 
@@ -239,13 +256,13 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * Jackson 2.18.2 to 2.17.2 (remove override, use Spring-Boot supplied version)
   * Bump aws-v2.version from 2.29.29 to 2.31.17
   * Bump aws.version from 1.12.779 to 1.12.780
-  * Bump aws.sdk.kotlin:s3-jvm from 1.4.41 to 1.4.59
   * Bump kotlin.version from 2.1.0 to 2.1.20
   * Bump testcontainers.version from 1.20.4 to 1.20.6
   * Bump org.testng:testng from 7.10.2 to 7.11.0
   * Bump aws.version from 1.12.780 to 1.12.782
   * Bump alpine from 3.21.0 to 3.21.3 in /docker
 * Version updates (build dependencies)
+  * Bump aws.sdk.kotlin:s3-jvm from 1.4.41 to 1.4.59
   * Bump org.apache.maven.plugins:maven-compiler-plugin from 3.13.0 to 3.14.0
   * Bump org.apache.maven.plugins:maven-clean-plugin from 3.4.0 to 3.4.1
   * Bump org.apache.maven.plugins:maven-install-plugin from 3.1.3 to 3.1.4

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-build-config</artifactId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-docker</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-integration-tests</artifactId>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ConcurrencyIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ConcurrencyIT.kt
@@ -72,7 +72,7 @@ internal class ConcurrencyIT : S3TestBase() {
       s3Client.getObject {
         it.bucket(bucketName)
         it.key(key)
-      }.also {
+      }.use {
         assertThat(it.response().eTag()).isNotBlank
       }
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/CopyObjectIT.kt
@@ -76,7 +76,6 @@ internal class CopyObjectIT : S3TestBase() {
   fun `copy object with key needing escaping succeeds and object can be retrieved`(testInfo: TestInfo) {
     val sourceKey = charsSpecialKey()
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val destinationBucketName = givenBucket()
     val destinationKey = "copyOf/$sourceKey"
 
@@ -84,7 +83,7 @@ internal class CopyObjectIT : S3TestBase() {
       {
         it.bucket(bucketName)
         it.key(sourceKey)
-      }, RequestBody.fromFile(uploadFile)
+      }, RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.copyObject {
@@ -138,7 +137,7 @@ internal class CopyObjectIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun `copy object with if-match=true and if-unmodified-since=false succeeds and object can be retrieved`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
-    val now = Instant.now().minus(60, SECONDS)
+    val now = Instant.now().minusSeconds(60)
     val (bucketName, putObjectResult) = givenBucketAndObject(testInfo, sourceKey)
     val destinationBucketName = givenBucket()
     val destinationKey = "copyOf/$sourceKey"
@@ -169,8 +168,7 @@ internal class CopyObjectIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun `copy object with if-modified-since=true succeeds and object can be retrieved`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
-    val now = Instant.now()
-    TimeUnit.SECONDS.sleep(5)
+    val now = Instant.now().minusSeconds(60)
     val (bucketName, putObjectResult) = givenBucketAndObject(testInfo, sourceKey)
     val destinationBucketName = givenBucket()
     val destinationKey = "copyOf/$sourceKey"
@@ -200,8 +198,7 @@ internal class CopyObjectIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun `copy object with if-modified-since=true and if-none-match=false fails`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
-    val now = Instant.now()
-    TimeUnit.SECONDS.sleep(5)
+    val now = Instant.now().minusSeconds(60)
     val (bucketName, putObjectResult) = givenBucketAndObject(testInfo, sourceKey)
     val destinationBucketName = givenBucket()
     val destinationKey = "copyOf/$sourceKey"
@@ -229,7 +226,7 @@ internal class CopyObjectIT : S3TestBase() {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResult) = givenBucketAndObject(testInfo, sourceKey)
     TimeUnit.SECONDS.sleep(5)
-    val now = Instant.now()
+    val now = Instant.now().plusSeconds(60)
     val destinationBucketName = givenBucket()
     val destinationKey = "copyOf/$sourceKey"
 
@@ -332,7 +329,6 @@ internal class CopyObjectIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun `copy object succeeds with same bucket and key with REPLACE and changing metadata`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val putObjectResult = s3Client.putObject(
       {
@@ -340,7 +336,7 @@ internal class CopyObjectIT : S3TestBase() {
         it.key(sourceKey)
         it.metadata(mapOf("test-key" to "test-value"))
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
     val sourceLastModified = s3Client.headObject {
       it.bucket(bucketName)
@@ -370,7 +366,7 @@ internal class CopyObjectIT : S3TestBase() {
       assertThat(copiedObjectMetadata["test-key"]).isNull()
 
       val length = response.contentLength()
-      assertThat(length).isEqualTo(uploadFile.length())
+      assertThat(length).isEqualTo(UPLOAD_FILE_LENGTH)
 
       val copiedDigest = DigestUtil.hexDigest(it)
       assertThat("\"$copiedDigest\"").isEqualTo(putObjectResult.eTag())
@@ -385,7 +381,6 @@ internal class CopyObjectIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun `copy object fails with same bucket and key without changing metadata`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
 
     s3Client.putObject(
@@ -394,7 +389,7 @@ internal class CopyObjectIT : S3TestBase() {
         it.key(sourceKey)
         it.metadata(mapOf("test-key" to "test-value"))
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     val sourceLastModified = s3Client.headObject {
@@ -421,9 +416,7 @@ internal class CopyObjectIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun `copy object succeeds with source metadata`(testInfo: TestInfo) {
-
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val destinationBucketName = givenBucket()
     val destinationKey = "copyOf/$sourceKey/withSourceUserMetadata"
@@ -436,7 +429,7 @@ internal class CopyObjectIT : S3TestBase() {
         it.key(sourceKey)
         it.metadata(metadata)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.copyObject {
@@ -489,7 +482,6 @@ internal class CopyObjectIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun `copy object succeeds with new storageclass`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucket(testInfo)
 
     s3Client.putObject(
@@ -498,7 +490,7 @@ internal class CopyObjectIT : S3TestBase() {
         it.key(sourceKey)
         it.storageClass(StorageClass.REDUCED_REDUNDANCY)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     val destinationBucketName = givenBucket()
@@ -525,7 +517,6 @@ internal class CopyObjectIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun `copy object succeeds with overwriting stored headers`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucket(testInfo)
 
     s3Client.putObject(
@@ -534,7 +525,7 @@ internal class CopyObjectIT : S3TestBase() {
         it.key(sourceKey)
         it.contentDisposition("")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     val destinationBucketName = givenBucket()

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectIT.kt
@@ -19,6 +19,7 @@ package com.adobe.testing.s3mock.its
 import com.adobe.testing.s3mock.util.DigestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.params.ParameterizedTest
@@ -901,7 +902,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
 
   @Test
   @S3VerifiedSuccess(year = 2025)
-  fun `PUT object succeeds with matching etag`(testInfo: TestInfo) {
+  fun `PUT object succeeds with if-match=true`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val matchingEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -922,7 +923,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
 
   @Test
   @S3VerifiedSuccess(year = 2025)
-  fun `PUT object fails with non matching wildcard etag`(testInfo: TestInfo) {
+  fun `PUT object fails with if-none-match=false with wildcard`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -948,7 +949,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
 
   @Test
   @S3VerifiedSuccess(year = 2025)
-  fun `PUT object fails with non matching etag`(testInfo: TestInfo) {
+  fun `PUT object fails with if-match=false`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -956,7 +957,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
     val nonMatchingEtag = "\"$randomName\""
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag().also {
+    putObjectResponse.eTag().also {
       assertThat(it).isEqualTo(expectedEtag)
     }
 
@@ -975,14 +976,14 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   @Test
   @S3VerifiedFailure(year = 2025,
     reason = "Supported only on directory buckets. S3 returns: A header you provided implies functionality that is not implemented.")
-  fun `DELETE object succeeds with matching etag`(testInfo: TestInfo) {
+  fun `DELETE object succeeds with if-match=true`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
     }
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag().also {
+    putObjectResponse.eTag().also {
       assertThat(it).isEqualTo(expectedEtag)
     }
 
@@ -996,7 +997,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   @Test
   @S3VerifiedFailure(year = 2025,
     reason = "Supported only on directory buckets. S3 returns: A header you provided implies functionality that is not implemented.")
-  fun `DELETE object succeeds with matching wildcard etag`(testInfo: TestInfo) {
+  fun `DELETE object succeeds with if-match=true with wildcard`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -1005,7 +1006,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
     val matchingEtag = WILDCARD
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag().also {
+    putObjectResponse.eTag().also {
       assertThat(it).isEqualTo(expectedEtag)
     }
 
@@ -1019,14 +1020,14 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   @Test
   @S3VerifiedFailure(year = 2025,
     reason = "Supported only on directory buckets. S3 returns: A header you provided implies functionality that is not implemented.")
-  fun `DELETE object succeeds with matching size`(testInfo: TestInfo) {
+  fun `DELETE object succeeds with if-match-size=true`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
     }
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag().also {
+    putObjectResponse.eTag().also {
       assertThat(it).isEqualTo(expectedEtag)
     }
 
@@ -1041,7 +1042,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   @Test
   @S3VerifiedFailure(year = 2025,
     reason = "Supported only on directory buckets. S3 returns: A header you provided implies functionality that is not implemented.")
-  fun `DELETE object succeeds with matching lastModifiedTime`(testInfo: TestInfo) {
+  fun `DELETE object succeeds with if-match-last-modified-time=true`(testInfo: TestInfo) {
     val (bucketName, _) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
 
     val lastModified = s3Client.headObject {
@@ -1059,7 +1060,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   @Test
   @S3VerifiedFailure(year = 2025,
     reason = "Supported only on directory buckets. S3 returns: A header you provided implies functionality that is not implemented.")
-  fun `DELETE object fails with non matching etag`(testInfo: TestInfo) {
+  fun `DELETE object fails with if-match=false`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -1067,7 +1068,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
     val nonMatchingEtag = "\"$randomName\""
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag().also {
+    putObjectResponse.eTag().also {
       assertThat(it).isEqualTo(expectedEtag)
     }
 
@@ -1084,7 +1085,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   @Test
   @S3VerifiedFailure(year = 2025,
     reason = "Supported only on directory buckets. S3 returns: A header you provided implies functionality that is not implemented.")
-  fun `DELETE object fails with non matching size`(testInfo: TestInfo) {
+  fun `DELETE object fails with if-match-size=false`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -1092,7 +1093,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
     val nonMatchingSize = 0L
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag().also {
+    putObjectResponse.eTag().also {
       assertThat(it).isEqualTo(expectedEtag)
     }
 
@@ -1109,7 +1110,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   @Test
   @S3VerifiedFailure(year = 2025,
     reason = "Supported only on directory buckets. S3 returns: A header you provided implies functionality that is not implemented.")
-  fun `DELETE object fails with non matching lastModifiedTime`(testInfo: TestInfo) {
+  fun `DELETE object fails with if-match-last-modified-time=false`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -1117,7 +1118,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
     val lastModifiedTime = Instant.now().minusSeconds(60)
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
-    val eTag = putObjectResponse.eTag().also {
+    putObjectResponse.eTag().also {
       assertThat(it).isEqualTo(expectedEtag)
     }
 
@@ -1133,7 +1134,79 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
 
   @Test
   @S3VerifiedSuccess(year = 2025)
-  fun testHeadObject_successWithNonMatchEtag(testInfo: TestInfo) {
+  fun `HEAD object succeeds with if-match=true`(testInfo: TestInfo) {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedEtag = FileInputStream(uploadFile).let {
+      "\"${DigestUtil.hexDigest(it)}\""
+    }
+
+    val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
+    val eTag = putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
+
+    s3Client.headObject {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+      it.ifMatch(expectedEtag)
+    }.also {
+      assertThat(it.eTag()).isEqualTo(eTag)
+    }
+  }
+
+  @Disabled("Spring Boot sends a 412 for this request even though the controller returns a 200 OK." +
+    "This test succeeds against the AWS S3 API.")
+  @Test
+  @S3VerifiedSuccess(year = 2025)
+  fun `HEAD object succeeds with if-match=true and if-unmodified-since=false`(testInfo: TestInfo) {
+    val now = Instant.now().minusSeconds(60)
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedEtag = FileInputStream(uploadFile).let {
+      "\"${DigestUtil.hexDigest(it)}\""
+    }
+
+    val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
+    val eTag = putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
+
+    s3Client.headObject {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+      it.ifMatch(expectedEtag)
+      it.ifUnmodifiedSince(now)
+    }.also {
+      assertThat(it.eTag()).isEqualTo(eTag)
+    }
+  }
+
+  @Test
+  @S3VerifiedSuccess(year = 2025)
+  fun `HEAD object fails with if-match=false`(testInfo: TestInfo) {
+    val expectedEtag = FileInputStream(File(UPLOAD_FILE_NAME)).let {
+      "\"${DigestUtil.hexDigest(it)}\""
+    }
+
+    val nonMatchingEtag = "\"$randomName\""
+
+    val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
+    putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
+
+    assertThatThrownBy {
+      s3Client.headObject {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.ifMatch(nonMatchingEtag)
+      }
+    }.isInstanceOf(S3Exception::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 412")
+  }
+
+  @Test
+  @S3VerifiedSuccess(year = 2025)
+  fun `HEAD object succeeds with if-none-match=true`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -1157,7 +1230,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
 
   @Test
   @S3VerifiedSuccess(year = 2025)
-  fun testHeadObject_failureWithNonMatchWildcardEtag(testInfo: TestInfo) {
+  fun `HEAD object fails with if-none-match=false with wildcard`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
@@ -1182,12 +1255,14 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
 
   @Test
   @S3VerifiedSuccess(year = 2025)
-  fun testHeadObject_failureWithMatchEtag(testInfo: TestInfo) {
-    val expectedEtag = FileInputStream(File(UPLOAD_FILE_NAME)).let {
+  fun `HEAD object fails with if-modified-since=true and if-none-match=false with wildcard`(testInfo: TestInfo) {
+    val now = Instant.now().minusSeconds(60)
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
     }
 
-    val nonMatchingEtag = "\"$randomName\""
+    val nonMatchingEtag = WILDCARD
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
     putObjectResponse.eTag().also {
@@ -1198,7 +1273,105 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
       s3Client.headObject {
         it.bucket(bucketName)
         it.key(UPLOAD_FILE_NAME)
-        it.ifMatch(nonMatchingEtag)
+        it.ifModifiedSince(now)
+        it.ifNoneMatch(nonMatchingEtag)
+      }
+    }.isInstanceOf(S3Exception::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 304")
+  }
+
+  @Test
+  @S3VerifiedSuccess(year = 2025)
+  fun `HEAD object succeeds with if-modified-since=true`(testInfo: TestInfo) {
+    val now = Instant.now().minusSeconds(60)
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedEtag = FileInputStream(uploadFile).let {
+      "\"${DigestUtil.hexDigest(it)}\""
+    }
+
+    val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
+    val eTag = putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
+
+    s3Client.headObject {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+      it.ifModifiedSince(now)
+    }.also {
+      assertThat(it.eTag()).isEqualTo(eTag)
+    }
+  }
+
+  @Test
+  @S3VerifiedSuccess(year = 2025)
+  fun `HEAD object fails with if-modified-since=false`(testInfo: TestInfo) {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedEtag = FileInputStream(uploadFile).let {
+      "\"${DigestUtil.hexDigest(it)}\""
+    }
+
+    val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
+    putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
+
+    val now = Instant.now().plusSeconds(60)
+
+    assertThatThrownBy {
+      s3Client.headObject {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.ifModifiedSince(now)
+      }
+    }.isInstanceOf(S3Exception::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 304")
+  }
+
+  @Test
+  @S3VerifiedSuccess(year = 2025)
+  fun `HEAD object succeeds with if-unmodified-since=true`(testInfo: TestInfo) {
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedEtag = FileInputStream(uploadFile).let {
+      "\"${DigestUtil.hexDigest(it)}\""
+    }
+
+    val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
+    val eTag = putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
+
+    val now = Instant.now().plusSeconds(60)
+
+    s3Client.headObject {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+      it.ifUnmodifiedSince(now)
+    }.also {
+      assertThat(it.eTag()).isEqualTo(eTag)
+    }
+  }
+
+  @Test
+  @S3VerifiedSuccess(year = 2025)
+  fun `HEAD object fails with if-unmodified-since=false`(testInfo: TestInfo) {
+    val now = Instant.now().minusSeconds(60)
+    val uploadFile = File(UPLOAD_FILE_NAME)
+    val expectedEtag = FileInputStream(uploadFile).let {
+      "\"${DigestUtil.hexDigest(it)}\""
+    }
+
+    val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
+    putObjectResponse.eTag().also {
+      assertThat(it).isEqualTo(expectedEtag)
+    }
+
+
+    assertThatThrownBy {
+      s3Client.headObject {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.ifUnmodifiedSince(now)
       }
     }.isInstanceOf(S3Exception::class.java)
       .hasMessageContaining("Service: S3, Status Code: 412")

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/GetPutDeleteObjectIT.kt
@@ -944,7 +944,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   fun testGetObject_successWithMatchingWildcardEtag(testInfo: TestInfo) {
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
     val eTag = putObjectResponse.eTag()
-    val matchingEtag = "\"*\""
+    val matchingEtag = WILDCARD
 
     s3Client.getObject {
       it.bucket(bucketName)
@@ -977,14 +977,13 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedFailure(year = 2025,
-    reason = "S3 returns: A header you provided implies functionality that is not implemented.")
+  @S3VerifiedSuccess(year = 2025)
   fun `PUT object fails with non matching wildcard etag`(testInfo: TestInfo) {
     val uploadFile = File(UPLOAD_FILE_NAME)
     val expectedEtag = FileInputStream(uploadFile).let {
       "\"${DigestUtil.hexDigest(it)}\""
     }
-    val nonMatchingEtag = "\"*\""
+    val nonMatchingEtag = WILDCARD
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
     putObjectResponse.eTag().also {
@@ -1059,7 +1058,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
       "\"${DigestUtil.hexDigest(it)}\""
     }
 
-    val matchingEtag = "\"*\""
+    val matchingEtag = WILDCARD
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
     val eTag = putObjectResponse.eTag().also {
@@ -1220,7 +1219,7 @@ internal class GetPutDeleteObjectIT : S3TestBase() {
       "\"${DigestUtil.hexDigest(it)}\""
     }
 
-    val nonMatchingEtag = "\"*\""
+    val nonMatchingEtag = WILDCARD
 
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
     putObjectResponse.eTag().also {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/LegalHoldIT.kt
@@ -16,6 +16,7 @@
 
 package com.adobe.testing.s3mock.its
 
+import com.adobe.testing.s3mock.util.DigestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -49,7 +50,6 @@ internal class LegalHoldIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun testGetLegalHoldNoObjectLockConfiguration(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val bucketName = bucketName(testInfo)
     s3Client.createBucket {
@@ -61,7 +61,7 @@ internal class LegalHoldIT : S3TestBase() {
         it.bucket(bucketName)
         it.key(sourceKey)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     assertThatThrownBy {
@@ -77,7 +77,6 @@ internal class LegalHoldIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun testPutAndGetLegalHold(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val bucketName = bucketName(testInfo)
     s3Client.createBucket {
@@ -89,7 +88,7 @@ internal class LegalHoldIT : S3TestBase() {
         it.bucket(bucketName)
         it.key(sourceKey)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.putObjectLegalHold {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectVersionsIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectVersionsIT.kt
@@ -31,7 +31,6 @@ internal class ListObjectVersionsIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun listObjectVersions(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucket(testInfo)
     s3Client.putBucketVersioning {
       it.bucket(bucketName)
@@ -45,7 +44,7 @@ internal class ListObjectVersionsIT : S3TestBase() {
         it.bucket(bucketName)
         it.key("$UPLOAD_FILE_NAME-1")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     ).versionId()
 
     val version2 = s3Client.putObject(
@@ -53,7 +52,7 @@ internal class ListObjectVersionsIT : S3TestBase() {
         it.bucket(bucketName)
         it.key("$UPLOAD_FILE_NAME-2")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     ).versionId()
 
     s3Client.listObjectVersions {
@@ -69,7 +68,6 @@ internal class ListObjectVersionsIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun listObjectVersions_noVersioning(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucket(testInfo)
 
     s3Client.putObject(
@@ -77,7 +75,7 @@ internal class ListObjectVersionsIT : S3TestBase() {
         it.bucket(bucketName)
         it.key("$UPLOAD_FILE_NAME-1")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.putObject(
@@ -85,7 +83,7 @@ internal class ListObjectVersionsIT : S3TestBase() {
         it.bucket(bucketName)
         it.key("$UPLOAD_FILE_NAME-2")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.listObjectVersions {
@@ -101,7 +99,6 @@ internal class ListObjectVersionsIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun listObjectVersions_deleteMarker(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucket(testInfo)
     s3Client.putBucketVersioning {
       it.bucket(bucketName)
@@ -115,7 +112,7 @@ internal class ListObjectVersionsIT : S3TestBase() {
         it.bucket(bucketName)
         it.key("$UPLOAD_FILE_NAME-1")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     ).versionId()
 
     val version2 = s3Client.putObject(
@@ -123,7 +120,7 @@ internal class ListObjectVersionsIT : S3TestBase() {
         it.bucket(bucketName)
         it.key("$UPLOAD_FILE_NAME-2")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     ).versionId()
 
     val version3 = s3Client.putObject(
@@ -131,7 +128,7 @@ internal class ListObjectVersionsIT : S3TestBase() {
         it.bucket(bucketName)
         it.key("$UPLOAD_FILE_NAME-3")
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     ).versionId()
 
     s3Client.deleteObject {

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectsIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/ListObjectsIT.kt
@@ -40,7 +40,6 @@ internal class ListObjectsIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun testPutObjectsListObjectsV2_checksumAlgorithm_sha256(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucket(testInfo)
 
     s3Client.putObject(
@@ -49,7 +48,7 @@ internal class ListObjectsIT : S3TestBase() {
         it.key("$UPLOAD_FILE_NAME-1")
         it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.putObject(
@@ -57,7 +56,7 @@ internal class ListObjectsIT : S3TestBase() {
         it.bucket(bucketName).key("$UPLOAD_FILE_NAME-2")
         it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.listObjectsV2 {
@@ -76,7 +75,6 @@ internal class ListObjectsIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun testPutObjectsListObjectsV1_checksumAlgorithm_sha256(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val bucketName = givenBucket(testInfo)
 
     s3Client.putObject(
@@ -84,7 +82,7 @@ internal class ListObjectsIT : S3TestBase() {
         it.bucket(bucketName).key("$UPLOAD_FILE_NAME-1")
         it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.putObject(
@@ -92,7 +90,7 @@ internal class ListObjectsIT : S3TestBase() {
         it.bucket(bucketName).key("$UPLOAD_FILE_NAME-2")
         it.checksumAlgorithm(ChecksumAlgorithm.SHA256)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.listObjects {
@@ -117,16 +115,15 @@ internal class ListObjectsIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun shouldListV1WithCorrectObjectNames(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val weirdStuff = charsSafe()
     val prefix = "shouldListWithCorrectObjectNames/"
-    val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
+    val key = "$prefix$weirdStuff${UPLOAD_FILE_NAME}$weirdStuff"
     s3Client.putObject(
       {
         it.bucket(bucketName)
         it.key(key)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.listObjects {
@@ -150,16 +147,15 @@ internal class ListObjectsIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun shouldListV2WithCorrectObjectNames(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val weirdStuff = charsSafe()
     val prefix = "shouldListWithCorrectObjectNames/"
-    val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
+    val key = "$prefix$weirdStuff${UPLOAD_FILE_NAME}$weirdStuff"
     s3Client.putObject(
       {
         it.bucket(bucketName)
         it.key(key)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.listObjectsV2 {
@@ -187,16 +183,15 @@ internal class ListObjectsIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun shouldHonorEncodingTypeV1(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val weirdStuff = "\u0001" // key invalid in XML
     val prefix = "shouldHonorEncodingTypeV1/"
-    val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
+    val key = "$prefix$weirdStuff${UPLOAD_FILE_NAME}$weirdStuff"
     s3Client.putObject(
       {
         it.bucket(bucketName)
         it.key(key)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.listObjects {
@@ -224,16 +219,15 @@ internal class ListObjectsIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun shouldHonorEncodingTypeV2(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val weirdStuff = "\u0001" // key invalid in XML
     val prefix = "shouldHonorEncodingTypeV2/"
-    val key = "$prefix$weirdStuff${uploadFile.name}$weirdStuff"
+    val key = "$prefix$weirdStuff${UPLOAD_FILE_NAME}$weirdStuff"
     s3Client.putObject(
       {
         it.bucket(bucketName)
         it.key(key)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     s3Client.listObjectsV2 {
@@ -253,7 +247,6 @@ internal class ListObjectsIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun listV1(parameters: Param, testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
 
     for(key in ALL_OBJECTS) {
       s3Client.putObject(
@@ -261,7 +254,7 @@ internal class ListObjectsIT : S3TestBase() {
           it.bucket(bucketName)
           it.key(key)
         },
-        RequestBody.fromFile(uploadFile)
+        RequestBody.fromFile(UPLOAD_FILE)
       )
     }
 
@@ -304,7 +297,6 @@ internal class ListObjectsIT : S3TestBase() {
   @S3VerifiedSuccess(year = 2025)
   fun listV2(parameters: Param, testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
 
     for(key in ALL_OBJECTS) {
       s3Client.putObject(
@@ -312,7 +304,7 @@ internal class ListObjectsIT : S3TestBase() {
           it.bucket(bucketName)
           it.key(key)
         },
-        RequestBody.fromFile(uploadFile)
+        RequestBody.fromFile(UPLOAD_FILE)
       )
     }
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultipartIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultipartIT.kt
@@ -49,7 +49,6 @@ import software.amazon.awssdk.transfer.s3.S3TransferManager
 import software.amazon.awssdk.utils.http.SdkHttpUtils
 import java.io.ByteArrayInputStream
 import java.io.File
-import java.io.FileInputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files.newOutputStream
 import java.time.Instant
@@ -156,7 +155,6 @@ internal class MultipartIT : S3TestBase() {
         it.uploadId(uploadId)
         it.partNumber(1)
         it.contentLength(UPLOAD_FILE_LENGTH)
-        //it.lastPart(true)
       },
       RequestBody.fromFile(UPLOAD_FILE),
     )
@@ -206,7 +204,6 @@ internal class MultipartIT : S3TestBase() {
         it.uploadId(uploadId)
         it.partNumber(2)
         it.contentLength(UPLOAD_FILE_LENGTH)
-        //it.lastPart(true)
       },
       RequestBody.fromFile(UPLOAD_FILE),
     ).eTag()
@@ -593,7 +590,7 @@ internal class MultipartIT : S3TestBase() {
   fun `list parts lists all uploaded parts`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val objectMetadata = mapOf(Pair("key", "value"))
-    val hash = FileInputStream(UPLOAD_FILE).use { DigestUtils.md5Hex(it) }
+    val hash = UPLOAD_FILE.inputStream().use { DigestUtils.md5Hex(it) }
     val initiateMultipartUploadResult = s3Client.createMultipartUpload {
         it.bucket(bucketName)
         it.key(UPLOAD_FILE_NAME)
@@ -652,7 +649,7 @@ internal class MultipartIT : S3TestBase() {
   fun `list parts lists uploaded parts matching parameters`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val objectMetadata = mapOf(Pair("key", "value"))
-    val hash = FileInputStream(UPLOAD_FILE).use { DigestUtils.md5Hex(it) }
+    val hash = UPLOAD_FILE.inputStream().use { DigestUtils.md5Hex(it) }
     val initiateMultipartUploadResult = s3Client.createMultipartUpload {
         it.bucket(bucketName)
         it.key(UPLOAD_FILE_NAME)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/PlainHttpIT.kt
@@ -256,7 +256,6 @@ internal class PlainHttpIT : S3TestBase() {
     reason = "No credentials sent in plain HTTP request")
   fun completeMultipartUsesApplicationXmlContentType(testInfo: TestInfo) {
     val targetBucket = givenBucket(testInfo)
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val initiateMultipartUploadResult = s3Client
       .createMultipartUpload {
         it.bucket(targetBucket)
@@ -270,9 +269,9 @@ internal class PlainHttpIT : S3TestBase() {
         it.key(initiateMultipartUploadResult.key())
         it.uploadId(uploadId)
         it.partNumber(1)
-        it.contentLength(uploadFile.length())
+        it.contentLength(UPLOAD_FILE_LENGTH)
       },
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
 

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/RetentionIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/RetentionIT.kt
@@ -30,7 +30,6 @@ import software.amazon.awssdk.services.s3.model.ObjectLockRetentionMode
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRetentionRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
-import java.io.File
 import java.time.Instant
 import java.time.temporal.ChronoUnit.DAYS
 import java.time.temporal.ChronoUnit.MILLIS
@@ -60,7 +59,6 @@ internal class RetentionIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun testGetRetentionNoObjectLockConfiguration(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val bucketName = bucketName(testInfo)
     s3Client.createBucket(
@@ -76,7 +74,7 @@ internal class RetentionIT : S3TestBase() {
         .bucket(bucketName)
         .key(sourceKey)
         .build(),
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     assertThatThrownBy {
@@ -96,7 +94,6 @@ internal class RetentionIT : S3TestBase() {
   @S3VerifiedFailure(year = 2025,
     reason = "S3 Object Lock makes it impossible to delete the object until the retention period is over.")
   fun testPutAndGetRetention(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val bucketName = bucketName(testInfo)
     s3Client.createBucket(
@@ -112,7 +109,7 @@ internal class RetentionIT : S3TestBase() {
         .bucket(bucketName)
         .key(sourceKey)
         .build(),
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     val retainUntilDate = Instant.now().plus(1, DAYS)
@@ -149,7 +146,6 @@ internal class RetentionIT : S3TestBase() {
   @Test
   @S3VerifiedSuccess(year = 2025)
   fun testPutInvalidRetentionUntilDate(testInfo: TestInfo) {
-    val uploadFile = File(UPLOAD_FILE_NAME)
     val sourceKey = UPLOAD_FILE_NAME
     val bucketName = bucketName(testInfo)
     s3Client.createBucket(
@@ -165,7 +161,7 @@ internal class RetentionIT : S3TestBase() {
         .bucket(bucketName)
         .key(sourceKey)
         .build(),
-      RequestBody.fromFile(uploadFile)
+      RequestBody.fromFile(UPLOAD_FILE)
     )
 
     val invalidRetainUntilDate = Instant.now().minus(1, DAYS)

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -245,6 +245,7 @@ internal abstract class S3TestBase {
         .replace(' ', '-')
         .replace(',', '-')
         .replace('\'', '-')
+        .replace('=', '-')
         .let {
           if (it.length > 50) {
             //max bucket name length is 63, shorten name to 50 since we add the timestamp below.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -602,6 +602,9 @@ internal abstract class S3TestBase {
     const val TEST_IMAGE_LARGE = "src/test/resources/test-image_large.png"
     const val TEST_IMAGE_TIFF = "src/test/resources/test-image.tiff"
     const val UPLOAD_FILE_NAME = SAMPLE_FILE_LARGE
+    val UPLOAD_FILE = File(UPLOAD_FILE_NAME)
+    val UPLOAD_FILE_PATH = UPLOAD_FILE.toPath()
+    val UPLOAD_FILE_LENGTH = UPLOAD_FILE.length()
     const val TEST_WRONG_KEY_ID = "key-ID-WRONGWRONGWRONG"
     const val _1MB = 1024 * 1024
     const val _5MB = 5L * _1MB

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -358,21 +358,25 @@ public class ObjectService extends ServiceBase {
 
     var setModifiedSince = ifModifiedSince != null && !ifModifiedSince.isEmpty();
     if (setModifiedSince && ifModifiedSince.get(0).isAfter(lastModified)) {
+      LOG.debug("Object {} not modified since {}", s3ObjectMetadata.key(), ifModifiedSince.get(0));
       throw NOT_MODIFIED;
     }
 
     var setMatch = match != null && !match.isEmpty();
     if (setMatch) {
       if (match.contains(WILDCARD_ETAG) || match.contains(WILDCARD) || match.contains(etag)) {
-        //request cares only that the object exists
+        //request cares only that the object exists or that the etag matches.
+        LOG.debug("Object {} exists", s3ObjectMetadata.key());
         return;
       } else if (!match.contains(etag)) {
+        LOG.debug("Object {} does not match etag {}", s3ObjectMetadata.key(), etag);
         throw PRECONDITION_FAILED;
       }
     }
 
     var setUnmodifiedSince = ifUnmodifiedSince != null && !ifUnmodifiedSince.isEmpty();
     if (setUnmodifiedSince && ifUnmodifiedSince.get(0).isBefore(lastModified)) {
+      LOG.debug("Object {} modified since {}", s3ObjectMetadata.key(), ifUnmodifiedSince.get(0));
       throw PRECONDITION_FAILED;
     }
 
@@ -380,7 +384,8 @@ public class ObjectService extends ServiceBase {
     if (setNoneMatch
         && (noneMatch.contains(WILDCARD_ETAG) || noneMatch.contains(WILDCARD) || noneMatch.contains(etag))
     ) {
-      //request cares only that the object DOES NOT exist.
+      //request cares only that the object etag does not match.
+      LOG.debug("Object {} does not exist", s3ObjectMetadata.key());
       throw NOT_MODIFIED;
     }
   }

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -361,19 +361,19 @@ public class ObjectService extends ServiceBase {
       throw NOT_MODIFIED;
     }
 
-    var setUnmodifiedSince = ifUnmodifiedSince != null && !ifUnmodifiedSince.isEmpty();
-    if (setUnmodifiedSince && ifUnmodifiedSince.get(0).isBefore(lastModified)) {
-      throw PRECONDITION_FAILED;
-    }
-
     var setMatch = match != null && !match.isEmpty();
     if (setMatch) {
-      if (match.contains(WILDCARD_ETAG) || match.contains(WILDCARD)) {
+      if (match.contains(WILDCARD_ETAG) || match.contains(WILDCARD) || match.contains(etag)) {
         //request cares only that the object exists
         return;
       } else if (!match.contains(etag)) {
         throw PRECONDITION_FAILED;
       }
+    }
+
+    var setUnmodifiedSince = ifUnmodifiedSince != null && !ifUnmodifiedSince.isEmpty();
+    if (setUnmodifiedSince && ifUnmodifiedSince.get(0).isBefore(lastModified)) {
+      throw PRECONDITION_FAILED;
     }
 
     var setNoneMatch = noneMatch != null && !noneMatch.isEmpty();

--- a/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/ObjectService.java
@@ -28,7 +28,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 
 import com.adobe.testing.s3mock.S3Exception;
 import com.adobe.testing.s3mock.dto.AccessControlPolicy;
-import com.adobe.testing.s3mock.dto.Checksum;
 import com.adobe.testing.s3mock.dto.ChecksumAlgorithm;
 import com.adobe.testing.s3mock.dto.ChecksumType;
 import com.adobe.testing.s3mock.dto.Delete;
@@ -49,7 +48,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +56,7 @@ import org.slf4j.LoggerFactory;
 
 public class ObjectService extends ServiceBase {
   static final String WILDCARD_ETAG = "\"*\"";
+  static final String WILDCARD = "*";
   private static final Logger LOG = LoggerFactory.getLogger(ObjectService.class);
   private final BucketStore bucketStore;
   private final ObjectStore objectStore;
@@ -369,7 +368,7 @@ public class ObjectService extends ServiceBase {
 
     var setMatch = match != null && !match.isEmpty();
     if (setMatch) {
-      if (match.contains(WILDCARD_ETAG)) {
+      if (match.contains(WILDCARD_ETAG) || match.contains(WILDCARD)) {
         //request cares only that the object exists
         return;
       } else if (!match.contains(etag)) {
@@ -378,7 +377,9 @@ public class ObjectService extends ServiceBase {
     }
 
     var setNoneMatch = noneMatch != null && !noneMatch.isEmpty();
-    if (setNoneMatch && (noneMatch.contains(WILDCARD_ETAG) || noneMatch.contains(etag))) {
+    if (setNoneMatch
+        && (noneMatch.contains(WILDCARD_ETAG) || noneMatch.contains(WILDCARD) || noneMatch.contains(etag))
+    ) {
       //request cares only that the object DOES NOT exist.
       throw NOT_MODIFIED;
     }

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-common</artifactId>

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit4</artifactId>

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit5</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testcontainers/pom.xml
+++ b/testsupport/testcontainers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testcontainers</artifactId>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testng</artifactId>


### PR DESCRIPTION
## Description
S3 API accepts * for conditional requests on all APIs. All APIs but PutObject succeed with "*" as well.

## Related Issue
Fixes #2371

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
