### PR TITLE
junie-evaluation

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -99,7 +99,11 @@ The server module uses Spring Test Profiler to analyze test performance. Test ex
 
 #### Running Integration Tests
 
-Integration tests require Docker to be running as they start an S3Mock Docker container:
+Integration tests require Docker to be running as they start an S3Mock Docker container. The integration tests can only be executed through Maven because they need the S3Mock to run. The process works as follows:
+
+1. The Docker Maven plugin (io.fabric8:docker-maven-plugin) starts the S3Mock Docker container in the pre-integration-test phase
+2. The Maven Failsafe plugin runs the integration tests against the running container
+3. The Docker Maven plugin stops the container in the post-integration-test phase
 
 ```bash
 # Run all integration tests
@@ -111,6 +115,8 @@ Integration tests require Docker to be running as they start an S3Mock Docker co
 # Run tests without Docker (will skip integration tests)
 ./mvnw verify -DskipDocker
 ```
+
+Note that attempting to run integration tests directly from your IDE without starting the S3Mock Docker container will result in connection errors, as the tests expect S3Mock to be running on specific ports.
 
 ### Writing New Tests
 
@@ -280,6 +286,17 @@ S3Mock is a multi-module Maven project:
 
 The project uses Checkstyle for Java code style checking. The configuration is in `build-config/checkstyle.xml`.
 
+### License Headers
+
+S3Mock uses the Apache License 2.0 and enforces proper license headers in all source files through the `license-maven-plugin`. Important rules:
+
+- All source files must include the proper license header
+- When modifying a file, the copyright year range in the header must be updated to include the current year
+- The format is: `Copyright 2017-YYYY Adobe.` where YYYY is the current year
+- The license check runs automatically during the build process
+- To fix license headers, run: `./mvnw license:format`
+- To check license headers without modifying files: `./mvnw license:check`
+
 ### Debugging
 
 To debug the S3Mock server:
@@ -305,7 +322,9 @@ docker run -p 9090:9090 -p 9191:9191 -e debug=true -t adobe/s3mock
 ### Recommended Development Workflow
 
 1. Make changes to the code
-2. Run unit tests to verify basic functionality
+2. Run unit tests frequently to verify basic functionality
+   - Unit tests should be run very frequently during development
+   - No task can be declared as done without running a full Maven build successfully
 3. Run integration tests to verify end-to-end functionality
 4. Build the Docker image to verify packaging
 5. Test with your application to verify real-world usage

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,311 @@
+# S3Mock Development Guidelines
+
+This document provides essential information for developers working on the S3Mock project.
+
+## Build and Configuration Instructions
+
+### Building the Project
+
+S3Mock uses Maven for building. The project includes a Maven wrapper (`mvnw`) so you don't need to install Maven separately.
+
+#### Basic Build Commands
+
+```bash
+# Build the entire project
+./mvnw clean install
+
+# Build without running Docker (useful for quick builds)
+./mvnw clean install -DskipDocker
+
+# Build a specific module
+./mvnw clean install -pl server -am
+```
+
+#### Build Requirements
+
+- JDK 17 or higher
+- Docker (for building the Docker image and running integration tests)
+
+### Configuration Options
+
+S3Mock can be configured with the following environment variables:
+
+| Environment Variable                                  | Legacy Name                       | Description                                           | Default             |
+|-------------------------------------------------------|-----------------------------------|-------------------------------------------------------|---------------------|
+| `COM_ADOBE_TESTING_S3MOCK_STORE_VALID_KMS_KEYS`       | `validKmsKeys`                    | List of KMS Key-Refs that are treated as valid        | none                |
+| `COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS`      | `initialBuckets`                  | List of bucket names that will be available initially | none                |
+| `COM_ADOBE_TESTING_S3MOCK_STORE_REGION`               | `COM_ADOBE_TESTING_S3MOCK_REGION` | The region the S3Mock is supposed to mock             | `us-east-1`         |
+| `COM_ADOBE_TESTING_S3MOCK_STORE_ROOT`                 | `root`                            | Base directory for temporary files                    | Java temp directory |
+| `COM_ADOBE_TESTING_S3MOCK_STORE_RETAIN_FILES_ON_EXIT` | `retainFilesOnExit`               | Set to `true` to keep files after shutdown            | `false`             |
+| `debug`                                               | -                                 | Enable Spring Boot's debug output                     | `false`             |
+| `trace`                                               | -                                 | Enable Spring Boot's trace output                     | `false`             |
+
+## Testing Information
+
+### Test Structure
+
+The project uses JUnit 5 for testing. There are two main types of tests in the project:
+
+1. **Integration Tests**: Located in the `integration-tests` module and written in Kotlin. These tests verify the end-to-end functionality of S3Mock by starting a Docker container and making actual HTTP requests to it.
+
+2. **Server Module Tests**: Located in the `server` module and primarily written in Kotlin. These include:
+   - Unit tests for utility classes and DTOs
+   - Spring Boot tests for controllers, services, and stores
+   - XML serialization/deserialization tests
+
+#### Integration Tests
+
+The main test base class for integration tests is `S3TestBase` which provides utility methods for:
+- Creating S3 clients
+- Managing buckets and objects
+- Handling SSL certificates
+- Generating test data
+
+#### Server Module Tests
+
+The server module contains several types of tests:
+
+1. **Controller Tests**: Use `@SpringBootTest` with `WebEnvironment.RANDOM_PORT` and `TestRestTemplate` to test HTTP endpoints. These tests mock the service layer using `@MockBean`.
+
+2. **Store Tests**: Use `@SpringBootTest` with `WebEnvironment.NONE` to test the data storage layer. These tests often use `@Autowired` to inject the component under test.
+
+3. **Service Tests**: Test the service layer with mocked dependencies.
+
+4. **Unit Tests**: Simple tests for utility classes and DTOs without Spring context.
+
+Common base classes and utilities:
+- `BaseControllerTest`: Sets up XML serialization/deserialization for controller tests
+- `StoreTestBase`: Common setup for store tests
+- `ServiceTestBase`: Common setup for service tests
+
+### Running Tests
+
+#### Running Server Module Tests
+
+The server module tests can be run without Docker:
+
+```bash
+# Run all server module tests
+./mvnw -pl server test
+
+# Run a specific test class
+./mvnw -pl server test -Dtest=ObjectStoreTest
+
+# Run a specific test method
+./mvnw -pl server test -Dtest=ObjectStoreTest#testStoreObject
+```
+
+The server module uses Spring Test Profiler to analyze test performance. Test execution times are reported in the `target/spring-test-profiler` directory.
+
+#### Running Integration Tests
+
+Integration tests require Docker to be running as they start an S3Mock Docker container:
+
+```bash
+# Run all integration tests
+./mvnw verify
+
+# Run a specific integration test
+./mvnw -pl integration-tests -am verify -Dit.test=BucketIT
+
+# Run tests without Docker (will skip integration tests)
+./mvnw verify -DskipDocker
+```
+
+### Writing New Tests
+
+#### Writing Integration Tests
+
+To create a new integration test:
+
+1. Create a new Kotlin class in the `integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its` directory
+2. Extend the `S3TestBase` class to inherit utility methods
+3. Name your test class with an `IT` suffix to be recognized as an integration test
+4. Use the provided S3 client methods to interact with S3Mock
+
+Example integration test:
+
+```kotlin
+// ExampleIT.kt
+internal class ExampleIT : S3TestBase() {
+    private val s3Client = createS3Client()
+
+    @Test
+    fun testPutAndGetObject(testInfo: TestInfo) {
+        // Create a bucket
+        val bucketName = givenBucket(testInfo)
+        
+        // Create test content
+        val content = "This is a test file content"
+        val contentBytes = content.toByteArray(StandardCharsets.UTF_8)
+        
+        // Put an object into the bucket
+        val key = "test-object.txt"
+        val putObjectResponse = s3Client.putObject(
+            PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build(),
+            RequestBody.fromBytes(contentBytes)
+        )
+        
+        // Verify the object was uploaded successfully
+        assertThat(putObjectResponse.eTag()).isNotBlank()
+        
+        // Get the object back
+        val getObjectResponse = s3Client.getObject(
+            GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build()
+        )
+        
+        // Read the content and verify it matches what we uploaded
+        val retrievedContent = getObjectResponse.readAllBytes()
+        assertThat(retrievedContent).isEqualTo(contentBytes)
+        
+        // Clean up
+        s3Client.deleteObject { it.bucket(bucketName).key(key) }
+    }
+}
+```
+
+#### Writing Server Module Tests
+
+The server module uses different testing approaches depending on what's being tested:
+
+1. **Controller Tests**:
+   - Extend `BaseControllerTest` to inherit XML serialization setup
+   - Use `@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)`
+   - Use `@MockBean` to mock service dependencies
+   - Inject `TestRestTemplate` to make HTTP requests to the controller
+
+Example controller test:
+
+```kotlin
+// BucketControllerTest.kt
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@MockBean(classes = [BucketService::class, ObjectService::class, MultipartService::class])
+internal class BucketControllerTest : BaseControllerTest() {
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+    
+    @MockBean
+    private lateinit var bucketService: BucketService
+    
+    @Test
+    fun testListBuckets() {
+        // Mock service response
+        whenever(bucketService.listBuckets()).thenReturn(givenBuckets(2))
+        
+        // Make HTTP request
+        val response = restTemplate.getForEntity("/", ListAllMyBucketsResult::class.java)
+        
+        // Verify response
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body.buckets.bucket).hasSize(2)
+    }
+}
+```
+
+2. **Store Tests**:
+   - Extend `StoreTestBase` for common setup
+   - Use `@SpringBootTest(webEnvironment = WebEnvironment.NONE)`
+   - Use `@Autowired` to inject the component under test
+
+Example store test:
+
+```kotlin
+// ObjectStoreTest.kt
+@SpringBootTest(classes = [StoreConfiguration::class], webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@MockBean(classes = [KmsKeyStore::class, BucketStore::class])
+internal class ObjectStoreTest : StoreTestBase() {
+    @Autowired
+    private lateinit var objectStore: ObjectStore
+    
+    @Test
+    fun testStoreAndGetObject() {
+        // Test storing and retrieving an object
+        val sourceFile = File(TEST_FILE_PATH)
+        val id = UUID.randomUUID().toString()
+        val name = sourceFile.name
+        
+        objectStore.storeS3ObjectMetadata(
+            metadataFrom("test-bucket"), id, name, "text/plain", 
+            emptyMap(), sourceFile.toPath(), 
+            emptyMap(), emptyMap(), null, emptyList(), 
+            null, null, Owner.DEFAULT_OWNER, StorageClass.STANDARD
+        )
+        
+        val metadata = objectStore.getS3ObjectMetadata(metadataFrom("test-bucket"), id, null)
+        
+        assertThat(metadata.key).isEqualTo(name)
+        assertThat(metadata.contentType).isEqualTo("text/plain")
+    }
+}
+```
+
+3. **Unit Tests**:
+   - Use standard JUnit 5 tests without Spring context
+   - Focus on testing a single class or method in isolation
+
+Example unit test:
+
+```kotlin
+// DigestUtilTest.kt
+internal class DigestUtilTest {
+    @Test
+    fun testHexDigest() {
+        val input = "test data".toByteArray()
+        val expected = DigestUtils.md5Hex(input)
+        
+        assertThat(DigestUtil.hexDigest(input)).isEqualTo(expected)
+    }
+}
+```
+
+## Additional Development Information
+
+### Project Structure
+
+S3Mock is a multi-module Maven project:
+
+- `build-config`: Build configuration files
+- `docker`: Docker image build module
+- `integration-tests`: Integration tests
+- `server`: Core S3Mock implementation
+- `testsupport`: Test support modules for different testing frameworks
+
+### Code Style
+
+The project uses Checkstyle for Java code style checking. The configuration is in `build-config/checkstyle.xml`.
+
+### Debugging
+
+To debug the S3Mock server:
+
+1. Run the S3MockApplication class in your IDE with debug mode
+2. The server will start on ports 9090 (HTTP) and 9191 (HTTPS)
+3. Configure your S3 client to connect to these ports
+
+Alternatively, you can run the Docker container with debug enabled:
+
+```bash
+docker run -p 9090:9090 -p 9191:9191 -e debug=true -t adobe/s3mock
+```
+
+### Common Issues
+
+1. **Connection refused errors**: Ensure the S3Mock server is running and the ports are correctly configured.
+
+2. **SSL certificate errors**: S3Mock uses a self-signed certificate. Configure your client to trust all certificates or use HTTP instead.
+
+3. **Docker-related errors**: Make sure Docker is running, and you have permissions to create containers.
+
+### Recommended Development Workflow
+
+1. Make changes to the code
+2. Run unit tests to verify basic functionality
+3. Run integration tests to verify end-to-end functionality
+4. Build the Docker image to verify packaging
+5. Test with your application to verify real-world usage

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,6 +1,36 @@
-# S3Mock Development Guidelines
+# S3Mock Development Guidelines (Concise)
 
-This document provides essential information for developers working on the S3Mock project.
+Essential info for working on S3Mock. This top section is a quick, no‑frills guide. Details follow below.
+
+Quickstart TL;DR
+- Build (fast): ./mvnw clean install -DskipDocker
+- Build (full): ./mvnw clean install
+- Server tests only: ./mvnw -pl server test
+- All tests incl. ITs (requires Docker): ./mvnw verify
+- One server test: ./mvnw -pl server test -Dtest=ObjectStoreTest
+- One IT: ./mvnw -pl integration-tests -am verify -Dit.test=BucketIT
+
+Requirements
+- JDK 17+
+- Docker (only for integration tests and Docker image build)
+
+Common config (env vars)
+- COM_ADOBE_TESTING_S3MOCK_STORE_REGION (default: us-east-1)
+- COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS
+- COM_ADOBE_TESTING_S3MOCK_STORE_RETAIN_FILES_ON_EXIT (default: false)
+- debug / trace (Spring Boot flags)
+
+Tips
+- IDE runs: use server tests; ITs need Docker via Maven lifecycle.
+- Debug server on 9090/9191; trust self‑signed cert or use HTTP.
+- Before declaring done: run a full Maven build successfully.
+
+Troubleshooting
+- Connection refused: ensure S3Mock is running on expected ports.
+- SSL errors: trust self‑signed cert or switch to HTTP.
+- Docker errors: ensure Docker is running and you have permissions.
+
+—
 
 ## Build and Configuration Instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,18 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 
 **The current major version 4 will receive new features, dependency updates and bug fixes on a continuous basis.**
 
+## 4.9.0 - PLANNED
+Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
+
+* Features and fixes
+  * TBD
+* Refactorings
+  * TBD
+* Version updates (deliverable dependencies)
+  * TBD
+* Version updates (build dependencies)
+  * TBD
+
 ## 4.8.0 - PLANNED
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
@@ -157,9 +169,14 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * Force convergence on the newest available transitive dependency versions.
   * Optimize file storage for large objects by using buffered streams.
 * Version updates (deliverable dependencies)
-  * TBD
+  * 
+  * Bump org.apache.commons:commons-compress from 1.27.1 to 1.28.0
 * Version updates (build dependencies)
-  * TBD
+  * Bump kotlin.version from 2.2.0 to 2.2.10
+  * Bump digital.pragmatech.testing:spring-test-profiler from 0.0.5 to 0.0.11
+  * Bump com.puppycrawl.tools:checkstyle from 10.26.1 to 11.0.0
+  * Bump github/codeql-action from 3.29.4 to 3.29.9
+  * Bump actions/checkout from 4.2.2 to 5.0.0
 
 ## 4.7.0
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,8 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Features and fixes
   * TBD
 * Refactorings
-  * TBD
+  * Force convergence on the newest available transitive dependency versions.
+  * Optimize file storage for large objects by using buffered streams.
 * Version updates (deliverable dependencies)
   * TBD
 * Version updates (build dependencies)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,8 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 * Features and fixes
   * TBD
 * Refactorings
+  * UploadId is always a UUID. Use UUID type in S3Mock instead of String.
+  * Validate that partNumbers to be positive integers.
   * Force convergence on the newest available transitive dependency versions.
   * Optimize file storage for large objects by using buffered streams.
 * Version updates (deliverable dependencies)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -30,11 +30,11 @@ This document contains a list of potential improvements for the S3Mock project. 
 
 ## Performance Improvements
 
-21. [ ] Optimize file storage for large objects
+21. [x] Optimize file storage for large objects
 22. [ ] Implement caching for frequently accessed objects
 23. [ ] Optimize list operations for buckets with many objects
 24. [ ] Improve multipart upload performance
-25. [ ] Reduce memory usage when handling large files
+25. [x] Reduce memory usage when handling large files
 26. [ ] Optimize XML serialization/deserialization
 27. [ ] Implement more efficient storage of object metadata
 28. [ ] Add support for conditional requests to reduce unnecessary data transfer

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,120 @@
+# S3Mock Improvement Tasks
+
+This document contains a list of potential improvements for the S3Mock project. Each task is marked with a checkbox that can be checked off when completed.
+
+## Architecture Improvements
+
+1. [ ] Implement support for domain-style access to buckets (e.g., `http://bucket.localhost:9090/someKey`) to better match AWS S3 behavior
+2. [ ] Add support for AWS S3 operations that are currently not implemented (e.g., bucket policies, website configuration, etc.)
+3. [ ] Implement a plugin architecture to allow for custom extensions and behaviors
+4. [ ] Add support for S3 event notifications (SNS, SQS, Lambda)
+5. [ ] Improve error handling to more closely match AWS S3 error responses
+6. [ ] Implement a metrics collection system to monitor performance and usage
+7. [ ] Add support for S3 Select for querying object content
+8. [ ] Implement support for S3 Inventory reports
+9. [ ] Add support for S3 Analytics configurations
+10. [ ] Implement S3 Batch Operations
+
+## Code Quality Improvements
+
+11. [ ] Increase unit test coverage for service and store layers
+12. [ ] Refactor synchronization mechanisms in store classes to improve concurrency handling
+13. [ ] Implement more comprehensive input validation for S3 API parameters
+14. [ ] Add more detailed logging throughout the application for better debugging
+15. [ ] Refactor XML serialization/deserialization to use more type-safe approaches
+16. [ ] Improve exception handling and error messages
+17. [ ] Implement more robust cleanup of temporary files
+18. [ ] Add comprehensive JavaDoc to all public APIs
+19. [ ] Refactor controller classes to reduce code duplication
+20. [ ] Implement more thorough validation of S3 object metadata
+
+## Performance Improvements
+
+21. [ ] Optimize file storage for large objects
+22. [ ] Implement caching for frequently accessed objects
+23. [ ] Optimize list operations for buckets with many objects
+24. [ ] Improve multipart upload performance
+25. [ ] Reduce memory usage when handling large files
+26. [ ] Optimize XML serialization/deserialization
+27. [ ] Implement more efficient storage of object metadata
+28. [ ] Add support for conditional requests to reduce unnecessary data transfer
+29. [ ] Optimize concurrent access patterns
+30. [ ] Implement more efficient bucket and object locking mechanisms
+
+## Security Improvements
+
+31. [ ] Add support for bucket policies
+32. [ ] Implement proper authentication and authorization mechanisms
+33. [ ] Add support for AWS IAM-style access control
+34. [ ] Implement proper handling of AWS signatures for authentication
+35. [ ] Add support for server-side encryption with customer-provided keys
+36. [ ] Improve SSL/TLS configuration and certificate management
+37. [ ] Implement proper input sanitization to prevent injection attacks
+38. [ ] Add support for VPC endpoint policies
+39. [ ] Implement proper access logging
+40. [ ] Add support for AWS CloudTrail-style audit logging
+
+## Documentation Improvements
+
+41. [ ] Create comprehensive API documentation
+42. [ ] Add more examples for different usage scenarios
+43. [ ] Improve README with more detailed setup instructions
+44. [ ] Create troubleshooting guide
+45. [ ] Add architecture diagrams
+46. [ ] Document internal design decisions
+47. [ ] Create contributor guidelines
+48. [ ] Add more code examples for different programming languages
+49. [ ] Create a user guide with common use cases
+50. [ ] Document performance characteristics and limitations
+
+## DevOps Improvements
+
+51. [ ] Add Docker Compose examples for different scenarios
+52. [ ] Implement health checks for container orchestration
+53. [ ] Add Kubernetes deployment examples
+54. [ ] Improve CI/CD pipeline
+55. [ ] Add performance benchmarking to CI process
+56. [ ] Implement automated security scanning
+57. [ ] Add support for configuration through environment variables for all settings
+58. [ ] Improve Docker image size and build time
+59. [ ] Add support for container orchestration tools
+60. [ ] Implement graceful shutdown and startup procedures
+
+## Dependency and Technology Updates
+
+61. [ ] Evaluate migration to Java 21 for improved performance and features
+62. [ ] Update to latest Spring Boot version when available
+63. [ ] Consider using reactive programming model with Spring WebFlux
+64. [ ] Evaluate using non-blocking I/O for file operations
+65. [ ] Consider using a more efficient serialization format for metadata storage
+66. [ ] Evaluate using a database for metadata storage instead of files
+67. [ ] Update AWS SDK dependencies regularly
+68. [ ] Consider using GraalVM native image compilation for faster startup
+69. [ ] Evaluate using Project Loom virtual threads for improved concurrency
+70. [ ] Consider using modern Java language features more extensively (records, sealed classes, etc.)
+
+## Testing Improvements
+
+71. [ ] Add more integration tests for edge cases
+72. [ ] Implement property-based testing for robust validation
+73. [ ] Add performance regression tests
+74. [ ] Implement chaos testing for resilience verification
+75. [ ] Add more unit tests for utility classes
+76. [ ] Implement contract tests for S3 API compatibility
+77. [ ] Add tests for concurrent access scenarios
+78. [ ] Improve test coverage for error conditions
+79. [ ] Add tests for different storage backends
+80. [ ] Implement automated compatibility testing with different AWS SDK versions
+
+## User Experience Improvements
+
+81. [ ] Add a web-based UI for browsing buckets and objects
+82. [ ] Implement a CLI tool for interacting with S3Mock
+83. [ ] Add better error messages and troubleshooting information
+84. [ ] Improve startup time
+85. [ ] Add support for custom endpoints
+86. [ ] Implement request/response logging for debugging
+87. [ ] Add support for request tracing
+88. [ ] Improve configuration options documentation
+89. [ ] Add support for programmatic configuration
+90. [ ] Implement better defaults for common use cases

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -63,6 +63,26 @@
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Force Kotlin stdlib alignment to match aws-sdk-kotlin 1.5.x requirements -->
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Force Kotlin coroutines alignment to match aws-sdk-kotlin 1.5.x requirements -->
+    <dependency>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+      <version>${kotlin-coroutines.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-test-junit</artifactId>

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultipartIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultipartIT.kt
@@ -743,7 +743,7 @@ internal class MultipartIT : S3TestBase() {
       s3Client.listParts {
         it.bucket(bucketName)
         it.key("NON_EXISTENT_KEY")
-        it.uploadId("NON_EXISTENT_UPLOAD_ID")
+        it.uploadId(UUID.randomUUID().toString())
       }
     }
       .isInstanceOf(AwsServiceException::class.java)
@@ -1616,7 +1616,7 @@ internal class MultipartIT : S3TestBase() {
       s3Client.abortMultipartUpload {
         it.bucket(randomName)
         it.key(UPLOAD_FILE_NAME)
-        it.uploadId("uploadId")
+        it.uploadId(UUID.randomUUID().toString())
       }
     }
       .isInstanceOf(NoSuchBucketException::class.java)

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,10 @@
 
     <aws-kotlin.version>1.4.125</aws-kotlin.version>
 
-    <commons-codec.version>1.15</commons-codec.version>
+    <commons-codec.version>1.19.0</commons-codec.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.20.0</commons-io.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpmime.version>4.5.14</httpmime.version>
     <httpcore.version>4.4.16</httpcore.version>
@@ -245,6 +246,16 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${commons-compress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
     <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>
     <kotlin.compiler.languageVersion>2.2</kotlin.compiler.languageVersion>
+    <kotlin-coroutines.version>1.10.2</kotlin-coroutines.version>
 
     <aws-v2.version>2.32.7</aws-v2.version>
 
@@ -204,6 +205,20 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-bom</artifactId>
+        <version>${kotlin.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlinx</groupId>
+        <artifactId>kotlinx-coroutines-bom</artifactId>
+        <version>${kotlin-coroutines.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -514,7 +529,8 @@
               <requireJavaVersion>
                 <version>${java.version}</version>
               </requireJavaVersion>
-              <!--dependencyConvergence/-->
+              <dependencyConvergence/>
+              <requireUpperBoundDeps/>
             </rules>
           </configuration>
         </plugin>

--- a/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/MultipartController.java
@@ -74,6 +74,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.jspecify.annotations.Nullable;
@@ -170,7 +171,7 @@ public class MultipartController {
   public ResponseEntity<Void> abortMultipartUpload(
       @PathVariable String bucketName,
       @PathVariable ObjectKey key,
-      @RequestParam String uploadId) {
+      @RequestParam UUID uploadId) {
     bucketService.verifyBucketExists(bucketName);
     multipartService.verifyMultipartUploadExists(bucketName, uploadId);
     multipartService.abortMultipartUpload(bucketName, key.key(), uploadId);
@@ -193,7 +194,7 @@ public class MultipartController {
       @PathVariable ObjectKey key,
       @RequestParam(name = MAX_PARTS, defaultValue = "1000", required = false) Integer maxParts,
       @RequestParam(name = PART_NUMBER_MARKER, required = false) Integer partNumberMarker,
-      @RequestParam String uploadId) {
+      @RequestParam UUID uploadId) {
     bucketService.verifyBucketExists(bucketName);
     multipartService.verifyMultipartUploadExists(bucketName, uploadId);
 
@@ -226,7 +227,7 @@ public class MultipartController {
   public ResponseEntity<Void> uploadPart(
       @PathVariable String bucketName,
       @PathVariable ObjectKey key,
-      @RequestParam String uploadId,
+      @RequestParam UUID uploadId,
       @RequestParam String partNumber,
       @RequestHeader HttpHeaders httpHeaders,
       InputStream inputStream) {
@@ -296,7 +297,7 @@ public class MultipartController {
       @RequestHeader(value = X_AMZ_COPY_SOURCE_IF_NONE_MATCH, required = false) List<String> noneMatch,
       @RequestHeader(value = X_AMZ_COPY_SOURCE_IF_MODIFIED_SINCE, required = false) List<Instant> ifModifiedSince,
       @RequestHeader(value = X_AMZ_COPY_SOURCE_IF_UNMODIFIED_SINCE, required = false) List<Instant> ifUnmodifiedSince,
-      @RequestParam String uploadId,
+      @RequestParam UUID uploadId,
       @RequestParam String partNumber,
       @RequestHeader HttpHeaders httpHeaders) {
     var bucket = bucketService.verifyBucketExists(bucketName);
@@ -413,7 +414,7 @@ public class MultipartController {
       @PathVariable ObjectKey key,
       @RequestHeader(value = IF_MATCH, required = false) List<String> match,
       @RequestHeader(value = IF_NONE_MATCH, required = false) List<String> noneMatch,
-      @RequestParam String uploadId,
+      @RequestParam UUID uploadId,
       @RequestBody CompleteMultipartUpload upload,
       HttpServletRequest request,
       @RequestHeader HttpHeaders httpHeaders) {

--- a/server/src/main/java/com/adobe/testing/s3mock/service/MultipartService.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/service/MultipartService.java
@@ -70,7 +70,7 @@ public class MultipartService extends ServiceBase {
   public String putPart(
       String bucketName,
       String key,
-      String uploadId,
+      UUID uploadId,
       String partNumber,
       Path path,
       Map<String, String> encryptionHeaders) {
@@ -91,7 +91,7 @@ public class MultipartService extends ServiceBase {
       String partNumber,
       String destinationBucket,
       String destinationKey,
-      String uploadId,
+      UUID uploadId,
       Map<String, String> encryptionHeaders,
       String versionId) {
     var sourceBucketMetadata = bucketStore.getBucketMetadata(bucketName);
@@ -124,7 +124,7 @@ public class MultipartService extends ServiceBase {
       String key,
       Integer maxParts,
       Integer partNumberMarker,
-      String uploadId) {
+      UUID uploadId) {
     var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
     var id = bucketMetadata.getID(key);
     if (id == null) {
@@ -158,11 +158,11 @@ public class MultipartService extends ServiceBase {
         parts,
         partNumberMarker,
         multipartUpload.storageClass(),
-        uploadId,
+        uploadId.toString(),
         null);
   }
 
-  public void abortMultipartUpload(String bucketName, String key, String uploadId) {
+  public void abortMultipartUpload(String bucketName, String key, UUID uploadId) {
     var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
     var id = bucketMetadata.getID(key);
     try {
@@ -176,7 +176,7 @@ public class MultipartService extends ServiceBase {
   public CompleteMultipartUploadResult completeMultipartUpload(
       String bucketName,
       String key,
-      String uploadId,
+      UUID uploadId,
       List<CompletedPart> parts,
       Map<String, String> encryptionHeaders,
       String location,
@@ -322,7 +322,7 @@ public class MultipartService extends ServiceBase {
   }
 
   public void verifyMultipartParts(String bucketName, String key,
-      String uploadId, List<CompletedPart> requestedParts) throws S3Exception {
+      UUID uploadId, List<CompletedPart> requestedParts) throws S3Exception {
     var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
     var id = bucketMetadata.getID(key);
     if (id == null) {
@@ -353,7 +353,7 @@ public class MultipartService extends ServiceBase {
     }
   }
 
-  public void verifyMultipartParts(String bucketName, UUID id, String uploadId) throws S3Exception {
+  public void verifyMultipartParts(String bucketName, UUID id, UUID uploadId) throws S3Exception {
     verifyMultipartUploadExists(bucketName, uploadId);
     var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
     var uploadedParts = multipartStore.getMultipartUploadParts(bucketMetadata, id, uploadId);
@@ -370,7 +370,7 @@ public class MultipartService extends ServiceBase {
     }
   }
 
-  public void verifyMultipartUploadExists(String bucketName, String uploadId) throws S3Exception {
+  public void verifyMultipartUploadExists(String bucketName, UUID uploadId) throws S3Exception {
     try {
       var bucketMetadata = bucketStore.getBucketMetadata(bucketName);
       multipartStore.getMultipartUpload(bucketMetadata, uploadId);

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
@@ -420,6 +420,12 @@ public class MultipartStore extends StoreBase {
     return partFile;
   }
 
+  private static void validatePartNumber(String partNumber) {
+    if (!partNumber.matches("^[1-9][0-9]*$")) {
+      throw new IllegalArgumentException("Invalid part number: " + partNumber);
+    }
+  }
+
   private void verifyMultipartUploadPreparation(
       BucketMetadata bucket,
       @Nullable UUID id,
@@ -451,6 +457,7 @@ public class MultipartStore extends StoreBase {
   }
 
   private Path getPartPath(BucketMetadata bucket, UUID uploadId, String partNumber) {
+    validatePartNumber(partNumber);
     return getPartsFolder(bucket, uploadId).resolve(partNumber + PART_SUFFIX);
   }
 

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartStore.java
@@ -94,7 +94,7 @@ public class MultipartStore extends StoreBase {
       StorageClass storageClass,
       @Nullable ChecksumType checksumType,
       @Nullable ChecksumAlgorithm checksumAlgorithm) {
-    var uploadId = UUID.randomUUID().toString();
+    var uploadId = UUID.randomUUID();
     if (!createPartsFolder(bucket, uploadId)) {
       LOG.error("Directories for storing multipart uploads couldn't be created. bucket={}, key={}, "
               + "id={}, uploadId={}", bucket, key, id, uploadId);
@@ -108,7 +108,7 @@ public class MultipartStore extends StoreBase {
         key,
         owner,
         storageClass,
-        uploadId
+        uploadId.toString()
     );
     var multipartUploadInfo = new MultipartUploadInfo(upload,
         contentType,
@@ -121,7 +121,7 @@ public class MultipartStore extends StoreBase {
         null,
         checksumType,
         checksumAlgorithm);
-    lockStore.putIfAbsent(UUID.fromString(uploadId), new Object());
+    lockStore.putIfAbsent(uploadId, new Object());
     writeMetafile(bucket, multipartUploadInfo);
 
     return upload;
@@ -138,7 +138,7 @@ public class MultipartStore extends StoreBase {
           .map(
               path -> {
                 var fileName = path.getFileName().toString();
-                var uploadMetadata = getUploadMetadata(bucketMetadata, fileName);
+                var uploadMetadata = getUploadMetadata(bucketMetadata, UUID.fromString(fileName));
                 if (uploadMetadata != null) {
                   return uploadMetadata.upload();
                 } else  {
@@ -157,11 +157,11 @@ public class MultipartStore extends StoreBase {
   @Nullable
   public MultipartUploadInfo getMultipartUploadInfo(
       BucketMetadata bucketMetadata,
-      String uploadId) {
+      UUID uploadId) {
     return getUploadMetadata(bucketMetadata, uploadId);
   }
 
-  public MultipartUpload getMultipartUpload(BucketMetadata bucketMetadata, String uploadId) {
+  public MultipartUpload getMultipartUpload(BucketMetadata bucketMetadata, UUID uploadId) {
     var uploadMetadata = getUploadMetadata(bucketMetadata, uploadId);
     if (uploadMetadata != null) {
       return uploadMetadata.upload();
@@ -170,16 +170,16 @@ public class MultipartStore extends StoreBase {
     }
   }
 
-  public void abortMultipartUpload(BucketMetadata bucket, UUID id, String uploadId) {
+  public void abortMultipartUpload(BucketMetadata bucket, UUID id, UUID uploadId) {
     var multipartUploadInfo = getMultipartUploadInfo(bucket, uploadId);
     if (multipartUploadInfo != null) {
-      synchronized (lockStore.get(UUID.fromString(uploadId))) {
+      synchronized (lockStore.get(uploadId)) {
         try {
           FileUtils.deleteDirectory(getPartsFolder(bucket, uploadId).toFile());
         } catch (IOException e) {
           throw new IllegalStateException("Could not delete multipart-directory " + uploadId, e);
         }
-        lockStore.remove(UUID.fromString(uploadId));
+        lockStore.remove(uploadId);
       }
     }
   }
@@ -187,7 +187,7 @@ public class MultipartStore extends StoreBase {
   public String putPart(
       BucketMetadata bucket,
       UUID id,
-      String uploadId,
+      UUID uploadId,
       String partNumber,
       Path path,
       Map<String, String> encryptionHeaders) {
@@ -200,7 +200,7 @@ public class MultipartStore extends StoreBase {
       BucketMetadata bucket,
       String key,
       UUID id,
-      String uploadId,
+      UUID uploadId,
       List<CompletedPart> parts,
       Map<String, String> encryptionHeaders,
       @Nullable MultipartUploadInfo uploadInfo,
@@ -308,7 +308,7 @@ public class MultipartStore extends StoreBase {
   public List<Part> getMultipartUploadParts(
       BucketMetadata bucket,
       UUID id,
-      String uploadId) {
+      UUID uploadId) {
     var partsPath = getPartsFolder(bucket, uploadId);
     try (var directoryStream = newDirectoryStream(partsPath,
             path -> path.getFileName().toString().endsWith(PART_SUFFIX))) {
@@ -337,7 +337,7 @@ public class MultipartStore extends StoreBase {
       String partNumber,
       BucketMetadata destinationBucket,
       UUID destinationId,
-      String uploadId,
+      UUID uploadId,
       @Nullable Map<String, String> encryptionHeaders,
       @Nullable String versionId) {
 
@@ -398,7 +398,7 @@ public class MultipartStore extends StoreBase {
   private File createPartFile(
       BucketMetadata bucket,
       @Nullable UUID id,
-      String uploadId,
+      UUID uploadId,
       String partNumber) {
     if (id == null) {
       return null;
@@ -423,7 +423,7 @@ public class MultipartStore extends StoreBase {
   private void verifyMultipartUploadPreparation(
       BucketMetadata bucket,
       @Nullable UUID id,
-      String uploadId) {
+      UUID uploadId) {
     Path partsFolder = null;
     var multipartUploadInfo = getMultipartUploadInfo(bucket, uploadId);
     if (id != null) {
@@ -440,7 +440,7 @@ public class MultipartStore extends StoreBase {
     }
   }
 
-  private boolean createPartsFolder(BucketMetadata bucket, String uploadId) {
+  private boolean createPartsFolder(BucketMetadata bucket, UUID uploadId) {
     var partsFolder = getPartsFolder(bucket, uploadId).toFile();
     return partsFolder.mkdirs();
   }
@@ -450,24 +450,24 @@ public class MultipartStore extends StoreBase {
     return Paths.get(bucket.path().toString(), MULTIPARTS_FOLDER);
   }
 
-  private Path getPartPath(BucketMetadata bucket, String uploadId, String partNumber) {
+  private Path getPartPath(BucketMetadata bucket, UUID uploadId, String partNumber) {
     return getPartsFolder(bucket, uploadId).resolve(partNumber + PART_SUFFIX);
   }
 
-  private Path getUploadMetadataPath(BucketMetadata bucket, String uploadId) {
+  private Path getUploadMetadataPath(BucketMetadata bucket, UUID uploadId) {
     return getPartsFolder(bucket, uploadId).resolve(MULTIPART_UPLOAD_META_FILE);
   }
 
-  private Path getPartsFolder(BucketMetadata bucket, String uploadId) {
-    return getMultipartsFolder(bucket).resolve(uploadId);
+  private Path getPartsFolder(BucketMetadata bucket, UUID uploadId) {
+    return getMultipartsFolder(bucket).resolve(uploadId.toString());
   }
 
   @Nullable
-  private MultipartUploadInfo getUploadMetadata(BucketMetadata bucket, String uploadId) {
+  private MultipartUploadInfo getUploadMetadata(BucketMetadata bucket, UUID uploadId) {
     var metaPath = getUploadMetadataPath(bucket, uploadId);
 
     if (Files.exists(metaPath)) {
-      synchronized (lockStore.get(UUID.fromString(uploadId))) {
+      synchronized (lockStore.get(uploadId)) {
         try {
           return objectMapper.readValue(metaPath.toFile(), MultipartUploadInfo.class);
         } catch (IOException e) {
@@ -482,7 +482,7 @@ public class MultipartStore extends StoreBase {
     var uploadId = uploadInfo.upload().uploadId();
     try {
       synchronized (lockStore.get(UUID.fromString(uploadId))) {
-        var metaFile = getUploadMetadataPath(bucket, uploadId).toFile();
+        var metaFile = getUploadMetadataPath(bucket, UUID.fromString(uploadId)).toFile();
         objectMapper.writeValue(metaFile, uploadInfo);
       }
     } catch (IOException e) {

--- a/server/src/main/java/com/adobe/testing/s3mock/store/StoreBase.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/StoreBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017-2024 Adobe.
+ *  Copyright 2017-2025 Adobe.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,15 +19,20 @@ package com.adobe.testing.s3mock.store;
 import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
 abstract class StoreBase {
 
+  private static final int BUFFER_SIZE = 1024 * 1024;
+
   /**
    * Stores the content of an InputStream in a File.
    * Creates the File if it does not exist.
+   * Uses buffered streams with a fixed buffer size to optimize memory usage for large files.
    *
    * @param inputPath the incoming binary data to be saved.
    * @param filePath Path where the stream should be saved.
@@ -38,8 +43,8 @@ abstract class StoreBase {
     var targetFile = filePath.toFile();
     try {
       targetFile.createNewFile();
-      try (var is = newInputStream(inputPath);
-           var os = newOutputStream(targetFile.toPath())) {
+      try (var is = new BufferedInputStream(newInputStream(inputPath), BUFFER_SIZE);
+           var os = new BufferedOutputStream(newOutputStream(targetFile.toPath()), BUFFER_SIZE)) {
         is.transferTo(os);
       }
     } catch (IOException e) {

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/MultipartControllerTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/MultipartControllerTest.kt
@@ -45,6 +45,7 @@ import org.springframework.web.util.UriComponentsBuilder
 import java.nio.file.Paths
 import java.time.Instant
 import java.util.Date
+import java.util.UUID
 
 @MockBeans(
   MockBean(
@@ -87,7 +88,7 @@ internal class MultipartControllerTest : BaseControllerTest() {
     }
 
     val key = "sampleFile.txt"
-    val uploadId = "testUploadId"
+    val uploadId = UUID.randomUUID()
     doThrow(S3Exception.ENTITY_TOO_SMALL)
       .whenever(multipartService)
       .verifyMultipartParts(
@@ -120,7 +121,7 @@ internal class MultipartControllerTest : BaseControllerTest() {
   @Throws(Exception::class)
   fun testCompleteMultipart_BadRequest_uploadIdNotFound() {
     givenBucket()
-    val uploadId = "testUploadId"
+    val uploadId = UUID.randomUUID()
 
     val parts = listOf(
       createPart(0, 5L),
@@ -177,7 +178,7 @@ internal class MultipartControllerTest : BaseControllerTest() {
   fun testCompleteMultipart_BadRequest_partNotFound() {
     givenBucket()
     val key = "sampleFile.txt"
-    val uploadId = "testUploadId"
+    val uploadId = UUID.randomUUID()
 
     val requestParts = listOf(createPart(1, 5L))
 
@@ -230,7 +231,7 @@ internal class MultipartControllerTest : BaseControllerTest() {
     givenBucket()
 
     val key = "sampleFile.txt"
-    val uploadId = "testUploadId"
+    val uploadId = UUID.randomUUID()
 
     doThrow(S3Exception.INVALID_PART_ORDER)
       .whenever(multipartService)

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/service/MultipartServiceTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/service/MultipartServiceTest.kt
@@ -72,7 +72,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
   fun testVerifyMultipartParts_withRequestedParts_success() {
     val bucketName = "bucketName"
     val key = "key"
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketMetadata = givenBucket(bucketName)
     val id = bucketMetadata.addKey(key)
     val parts = givenParts(2, MultipartService.MINIMUM_PART_SIZE)
@@ -86,7 +86,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
   fun testVerifyMultipartParts_withRequestedParts_wrongPartsFailure() {
     val bucketName = "bucketName"
     val key = "key"
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketMetadata = givenBucket(bucketName)
     val id = bucketMetadata.addKey(key)
     val parts = givenParts(1, 1L)
@@ -111,7 +111,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
   fun testVerifyMultipartParts_withRequestedParts_wrongPartOrderFailure() {
     val bucketName = "bucketName"
     val key = "key"
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketMetadata = givenBucket(bucketName)
     val id = bucketMetadata.addKey(key)
     val parts = givenParts(2, MultipartService.MINIMUM_PART_SIZE)
@@ -142,7 +142,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
   fun testVerifyMultipartParts_onePart() {
     val bucketName = "bucketName"
     val id = UUID.randomUUID()
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketMetadata = givenBucket(bucketName)
     val parts = givenParts(1, 1L)
     whenever(multipartStore.getMultipartUploadParts(bucketMetadata, id, uploadId)).thenReturn(parts)
@@ -154,7 +154,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
   fun testVerifyMultipartParts_twoParts() {
     val bucketName = "bucketName"
     val id = UUID.randomUUID()
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketMetadata = givenBucket(bucketName)
     val parts = givenParts(2, MultipartService.MINIMUM_PART_SIZE)
     whenever(multipartStore.getMultipartUploadParts(bucketMetadata, id, uploadId)).thenReturn(parts)
@@ -166,7 +166,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
   fun testVerifyMultipartParts_twoPartsFailure() {
     val bucketName = "bucketName"
     val id = UUID.randomUUID()
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketMetadata = givenBucket(bucketName)
     val parts = givenParts(2, 1L)
     whenever(multipartStore.getMultipartUploadParts(bucketMetadata, id, uploadId)).thenReturn(parts)
@@ -176,7 +176,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
 
   @Test
   fun testVerifyMultipartUploadExists_failure() {
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketName = "bucketName"
     whenever(bucketStore.getBucketMetadata(bucketName))
       .thenReturn(
@@ -207,7 +207,7 @@ internal class MultipartServiceTest : ServiceTestBase() {
 
   @Test
   fun testVerifyMultipartUploadExists_success() {
-    val uploadId = "uploadId"
+    val uploadId = UUID.randomUUID()
     val bucketName = "bucketName"
     iut.verifyMultipartUploadExists(bucketName, uploadId)
   }

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/store/MultipartStoreTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/store/MultipartStoreTest.kt
@@ -92,12 +92,12 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     Paths.get(
       rootFolder.absolutePath,
       TEST_BUCKET_NAME,
       MultipartStore.MULTIPARTS_FOLDER,
-      uploadId
+      uploadId.toString()
     )
       .toFile().also {
         assertThat(it)
@@ -132,7 +132,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     multipartStore.putPart(
       bucket,
       id,
@@ -146,7 +146,7 @@ internal class MultipartStoreTest : StoreTestBase() {
         rootFolder.absolutePath,
         TEST_BUCKET_NAME,
         MultipartStore.MULTIPARTS_FOLDER,
-        uploadId,
+        uploadId.toString(),
         "$partNumber.part"
       ).toFile()
     ).exists()
@@ -181,7 +181,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     multipartStore
       .putPart(
@@ -259,7 +259,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     multipartStore.putPart(
       bucket,
@@ -326,7 +326,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     multipartStore.putPart(
       bucket,
@@ -397,7 +397,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       ChecksumType.COMPOSITE,
       checksumAlgorithm,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     multipartStore.putPart(
       bucket,
@@ -480,7 +480,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       ChecksumType.COMPOSITE,
       checksumAlgorithm,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     multipartStore.putPart(
       bucket,
@@ -563,7 +563,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
 
     multipartStore.putPart(
       bucket,
@@ -626,7 +626,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     val tempFile = Files.createTempFile("", "")
     ByteArrayInputStream("Part1".toByteArray()).transferTo(Files.newOutputStream(tempFile))
@@ -653,7 +653,7 @@ internal class MultipartStoreTest : StoreTestBase() {
     )
 
     assertThat(
-      Paths.get(rootFolder.absolutePath, TEST_BUCKET_NAME, fileName, uploadId)
+      Paths.get(rootFolder.absolutePath, TEST_BUCKET_NAME, fileName, uploadId.toString())
         .toFile()
     ).doesNotExist()
   }
@@ -681,14 +681,14 @@ internal class MultipartStoreTest : StoreTestBase() {
         NO_CHECKSUMTYPE,
         NO_CHECKSUM_ALGORITHM,
       )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     val uploads = multipartStore.listMultipartUploads(bucket, NO_PREFIX)
     assertThat(uploads).hasSize(1)
     uploads.iterator().next().also {
       assertThat(it).isEqualTo(multipartUpload)
       // and some specific sanity checks
-      assertThat(it.uploadId).isEqualTo(uploadId)
+      assertThat(it.uploadId).isEqualTo(uploadId.toString())
       assertThat(it.key).isEqualTo(fileName)
     }
 
@@ -735,7 +735,7 @@ internal class MultipartStoreTest : StoreTestBase() {
         NO_CHECKSUMTYPE,
         NO_CHECKSUM_ALGORITHM,
       )
-    val uploadId1 = multipartUpload1.uploadId
+    val uploadId1 = UUID.fromString(multipartUpload1.uploadId)
     val multipartUploadInfo1 = multipartStore.getMultipartUploadInfo(bucketMetadata1, uploadId1)
     val fileName2 = "PartFile2"
     val id2 = managedId()
@@ -755,14 +755,14 @@ internal class MultipartStoreTest : StoreTestBase() {
         NO_CHECKSUMTYPE,
         NO_CHECKSUM_ALGORITHM,
       )
-    val uploadId2 = multipartUpload2.uploadId
+    val uploadId2 = UUID.fromString(multipartUpload2.uploadId)
     val multipartUploadInfo2 = multipartStore.getMultipartUploadInfo(bucketMetadata2, uploadId2)
     multipartStore.listMultipartUploads(bucketMetadata1, NO_PREFIX).also {
       assertThat(it).hasSize(1)
       it[0].also {
         assertThat(it).isEqualTo(multipartUpload1)
         // and some specific sanity checks
-        assertThat(it.uploadId).isEqualTo(uploadId1)
+        assertThat(it.uploadId).isEqualTo(uploadId1.toString())
         assertThat(it.key).isEqualTo(fileName1)
       }
     }
@@ -772,7 +772,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       it[0].also {
         assertThat(it).isEqualTo(multipartUpload2)
         // and some specific sanity checks
-        assertThat(it.uploadId).isEqualTo(uploadId2)
+        assertThat(it.uploadId).isEqualTo(uploadId2.toString())
         assertThat(it.key).isEqualTo(fileName2)
       }
     }
@@ -829,7 +829,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val tempFile = Files.createTempFile("", "")
     ByteArrayInputStream("Part1".toByteArray()).transferTo(Files.newOutputStream(tempFile))
     multipartStore.putPart(
@@ -856,7 +856,7 @@ internal class MultipartStoreTest : StoreTestBase() {
     assertThat(
       Paths.get(
         rootFolder.absolutePath,
-        TEST_BUCKET_NAME, fileName, uploadId
+        TEST_BUCKET_NAME, fileName, uploadId.toString()
       ).toFile()
     ).doesNotExist()
   }
@@ -906,7 +906,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
 
     val range = HttpRange.createByteRange(0, contentBytes.size.toLong())
     multipartStore.copyPart(
@@ -925,7 +925,8 @@ internal class MultipartStoreTest : StoreTestBase() {
         rootFolder.absolutePath,
         TEST_BUCKET_NAME,
         MultipartStore.MULTIPARTS_FOLDER,
-        uploadId, "$partNumber.part"
+        uploadId.toString(),
+        "$partNumber.part"
       )
         .toFile()
     ).exists()
@@ -978,7 +979,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
 
     multipartStore.copyPart(
       bucketMetadata,
@@ -996,7 +997,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       Paths.get(
         bucketMetadata.path.toString(),
         MultipartStore.MULTIPARTS_FOLDER,
-        uploadId,
+        uploadId.toString(),
         "$partNumber.part"
       ).toFile()
     ).exists()
@@ -1008,7 +1009,7 @@ internal class MultipartStoreTest : StoreTestBase() {
     val range = HttpRange.createByteRange(0, 0)
     val id = UUID.randomUUID()
     val destinationId = UUID.randomUUID()
-    val uploadId = UUID.randomUUID().toString()
+    val uploadId = UUID.randomUUID()
     val bucketMetadata = metadataFrom(TEST_BUCKET_NAME)
     val encryptionHeaders = encryptionHeaders()
     assertThatThrownBy {
@@ -1049,7 +1050,7 @@ internal class MultipartStoreTest : StoreTestBase() {
       NO_CHECKSUMTYPE,
       NO_CHECKSUM_ALGORITHM,
     )
-    val uploadId = multipartUpload.uploadId
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
     val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
     for (i in 1..10) {
       val tempFile = Files.createTempFile("", "")

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -34,6 +34,13 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Force dependency convergence on the newest version. -->
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.adobe.testing</groupId>


### PR DESCRIPTION
## Description
* Let Junie generate guidelines and tasks
* Junie: Optimize file storage for large objects
* Force dependency convergence to highest version
  * The AWS Kotlin SDK depends on Kotlin 2.2.0 and newest Coroutines
dependencies. Maven manages versions down during convergence by default, leading to
runtime failures.

## Related Issue
https://github.com/awslabs/aws-sdk-kotlin/issues/1654

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
