### PR TITLE
CompleteMultipartUpload is idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,7 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.
 
 * Features and fixes
-  * TBD
+  * CompleteMultipartUpload is idempotent (fixes #2586)
 * Refactorings
   * UploadId is always a UUID. Use UUID type in S3Mock instead of String.
   * Validate that partNumbers to be positive integers.
@@ -173,16 +173,17 @@ Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
   * Optimize file storage for large objects by using buffered streams.
 * Version updates (deliverable dependencies)
   * Bump spring-boot.version from 3.5.4 to 3.5.5
-  * Bump aws-v2.version from 2.32.7 to 2.32.23
+  * Bump aws-v2.version from 2.32.7 to 2.32.31
   * Bump org.apache.commons:commons-compress from 1.27.1 to 1.28.0
 * Version updates (build dependencies)
   * Bump kotlin.version from 2.2.0 to 2.2.10
-  * Bump aws.sdk.kotlin:s3-jvm from 1.4.125 to 1.5.19
+  * Bump aws.sdk.kotlin:s3-jvm from 1.4.125 to 1.5.26
   * Bump digital.pragmatech.testing:spring-test-profiler from 0.0.5 to 0.0.11
   * Bump com.puppycrawl.tools:checkstyle from 10.26.1 to 11.0.0
   * Bump github/codeql-action from 3.29.4 to 3.29.11
   * Bump actions/checkout from 4.2.2 to 5.0.0
   * Bump actions/setup-java from 4.7.1 to 5.0.0
+  * Bump actions/dependency-review-action from 4.7.2 to 4.7.3
 
 ## 4.7.0
 Version 4.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Java integration.

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-build-config</artifactId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-docker</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-integration-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.adobe.testing</groupId>
   <artifactId>s3mock-parent</artifactId>
-  <version>4.7.1-SNAPSHOT</version>
+  <version>4.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>S3Mock - Parent</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock</artifactId>

--- a/server/src/main/java/com/adobe/testing/s3mock/store/MultipartUploadInfo.java
+++ b/server/src/main/java/com/adobe/testing/s3mock/store/MultipartUploadInfo.java
@@ -39,5 +39,53 @@ public record MultipartUploadInfo(
     List<Tag> tags,
     @Nullable String checksum,
     @Nullable ChecksumType checksumType,
-    @Nullable ChecksumAlgorithm checksumAlgorithm) {
+    @Nullable ChecksumAlgorithm checksumAlgorithm,
+    boolean completed
+) {
+
+  public MultipartUploadInfo(
+      MultipartUpload upload,
+      String contentType,
+      Map<String, String> userMetadata,
+      Map<String, String> storeHeaders,
+      Map<String, String> encryptionHeaders,
+      String bucket,
+      StorageClass storageClass,
+      List<Tag> tags,
+      String checksum,
+      ChecksumType checksumType,
+      ChecksumAlgorithm checksumAlgorithm
+  ) {
+    this(
+        upload,
+        contentType,
+        userMetadata,
+        storeHeaders,
+        encryptionHeaders,
+        bucket,
+        storageClass,
+        tags,
+        checksum,
+        checksumType,
+        checksumAlgorithm,
+        false
+    );
+  }
+
+  public MultipartUploadInfo complete() {
+    return new MultipartUploadInfo(
+        this.upload,
+        this.contentType,
+        this.userMetadata,
+        this.storeHeaders,
+        this.encryptionHeaders,
+        this.bucket,
+        this.storageClass,
+        this.tags,
+        this.checksum,
+        this.checksumType,
+        this.checksumAlgorithm,
+        true
+    );
+  }
 }

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/MultipartControllerTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/MultipartControllerTest.kt
@@ -334,7 +334,8 @@ internal class MultipartControllerTest : BaseControllerTest() {
       emptyList(),
       null,
       ChecksumType.FULL_OBJECT,
-      null
+      null,
+      false
     )
     val result = CompleteMultipartUploadResult.from(
       "http://localhost/${TEST_BUCKET_NAME}/$key",
@@ -410,7 +411,8 @@ internal class MultipartControllerTest : BaseControllerTest() {
       emptyList(),
       null,
       ChecksumType.FULL_OBJECT,
-      null
+      null,
+      false
     )
     val result = CompleteMultipartUploadResult.from(
       "http://localhost/${TEST_BUCKET_NAME}/$key",
@@ -479,7 +481,8 @@ internal class MultipartControllerTest : BaseControllerTest() {
       emptyList(),
       null,
       ChecksumType.FULL_OBJECT,
-      null
+      null,
+      false
     )
     val result = CompleteMultipartUploadResult.from(
       "http://localhost/${TEST_BUCKET_NAME}/$key",
@@ -603,7 +606,7 @@ internal class MultipartControllerTest : BaseControllerTest() {
 
     doThrow(S3Exception.NO_SUCH_UPLOAD_MULTIPART)
       .whenever(multipartService)
-      .verifyMultipartUploadExists(TEST_BUCKET_NAME, uploadId)
+      .verifyMultipartUploadExists(TEST_BUCKET_NAME, uploadId, true)
 
     val uploadRequest = CompleteMultipartUpload(ArrayList())
     uploadRequest.addPart(CompletedPart(null, null, null, null, null, "etag1", 1))

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResultTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/dto/CompleteMultipartUploadResultTest.kt
@@ -51,7 +51,8 @@ internal class CompleteMultipartUploadResultTest {
         listOf(Tag("key", "value")),
         "checksumSHA256",
         ChecksumType.COMPOSITE,
-        ChecksumAlgorithm.SHA256
+        ChecksumAlgorithm.SHA256,
+        false
       ),
       "checksumSHA256",
       ChecksumType.COMPOSITE,

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/service/MultipartServiceTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/service/MultipartServiceTest.kt
@@ -24,7 +24,8 @@ import com.adobe.testing.s3mock.store.MultipartStore
 import com.adobe.testing.s3mock.store.ObjectStore
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -195,9 +196,9 @@ internal class MultipartServiceTest : ServiceTestBase() {
       )
     whenever(
       multipartStore.getMultipartUpload(
-        ArgumentMatchers.any(
-          BucketMetadata::class.java
-        ), ArgumentMatchers.eq(uploadId)
+        any(BucketMetadata::class.java),
+        eq(uploadId),
+        eq(false)
       )
     )
       .thenThrow(IllegalArgumentException())
@@ -277,8 +278,9 @@ internal class MultipartServiceTest : ServiceTestBase() {
     // Simulate missing upload -> MultipartService should translate to NO_SUCH_UPLOAD_MULTIPART
     whenever(
       multipartStore.getMultipartUpload(
-        ArgumentMatchers.eq(bucketMetadata),
-        ArgumentMatchers.eq(uploadId)
+        eq(bucketMetadata),
+        eq(uploadId),
+        eq(false)
       )
     ).thenThrow(IllegalArgumentException())
 

--- a/testsupport/common/pom.xml
+++ b/testsupport/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-common</artifactId>

--- a/testsupport/junit4/pom.xml
+++ b/testsupport/junit4/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit4</artifactId>

--- a/testsupport/junit5/pom.xml
+++ b/testsupport/junit5/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-junit5</artifactId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-parent</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testsupport-reactor</artifactId>

--- a/testsupport/testcontainers/pom.xml
+++ b/testsupport/testcontainers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testcontainers</artifactId>

--- a/testsupport/testng/pom.xml
+++ b/testsupport/testng/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.adobe.testing</groupId>
     <artifactId>s3mock-testsupport-reactor</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>s3mock-testng</artifactId>


### PR DESCRIPTION
## Description
CompleteMultipartUpload will not delete MultipartUpload data, only the parts.
This is only part of a fix, we really shouldn't delete parts at all and preserve all multipart data, streaming a full binary on getObject requests.

## Related Issue
#2586

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
