### PR TITLE
Fix InvalidRange error code

### DIFF
--- a/server/src/main/kotlin/com/adobe/testing/s3mock/S3Exception.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/S3Exception.kt
@@ -31,7 +31,7 @@ class S3Exception(
   companion object {
     private const val INVALID_REQUEST_CODE = "InvalidRequest"
     private const val BAD_REQUEST_CODE = "BadRequest"
-    private const val REQUESTED_RANGE_NOT_SATISFIABLE_CODE = "RequestedRangeNotSatisfiable"
+    private const val REQUESTED_RANGE_NOT_SATISFIABLE_CODE = "InvalidRange"
     val INVALID_PART_NUMBER: S3Exception =
       S3Exception(
         HttpStatus.BAD_REQUEST.value(),


### PR DESCRIPTION
## Description
Invlaid http ranges should return status code 416 and error code `InvalidRange` https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html

38b1e29587d34023418b4f702ff852f611293856 fixed the response for invalid ranges. c99a0ece2ce32250fd8a06db184a75be6f2916e5 introduced a regression by changing the error code to the name of the HTTP status code.

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
- [x] I have run `make format` to fix code style.
- [x] I have updated `CHANGELOG.md` (if applicable).
- [x] I have updated documentation (if applicable).
