### PR TITLE
Fix persistent storage startup with blank initialBuckets entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ Version 5.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 ## 5.1.0 - PLANNED
 
 * Features and fixes
-  * TBD
+  * Skip blank `initialBuckets` entries during startup to avoid creating a bogus root-level persisted bucket.
 * Version updates (deliverable dependencies)
   * Bump alpine from 3.23.3 to 3.23.4 in /docker
   * Bump spring-boot.version from 4.0.5 to 4.0.6

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/store/StoreConfiguration.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/store/StoreConfiguration.kt
@@ -67,6 +67,7 @@ class StoreConfiguration {
     // load initialBuckets if not part of existing buckets
     properties.initialBuckets
       .stream()
+      .filter { it.isNotBlank() }
       .filter { name: String? ->
         val partOfExistingBuckets = bucketNames.contains(name)
         if (partOfExistingBuckets) {

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/store/StoreConfigurationTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/store/StoreConfigurationTest.kt
@@ -108,6 +108,25 @@ internal class StoreConfigurationTest {
       .containsExactlyInAnyOrder(Path.of(existingBucketName), Path.of(initialBucketName))
   }
 
+  @Test 
+  fun bucketCreation_ignoresBlankInitialBuckets( 
+    @TempDir tempDir: Path, 
+  ) { 
+    val properties = StoreProperties(false, "", setOf(), listOf(""), Region.EU_CENTRAL_1) 
+    val iut = StoreConfiguration() 
+    val bucketStore = 
+      iut.bucketStore( 
+        properties, 
+        tempDir.toFile(), 
+        listOf(), 
+        OBJECT_MAPPER, 
+        Region.EU_CENTRAL_1, 
+      )
+
+    assertThat(bucketStore.listBuckets()).isEmpty() 
+    assertThat(tempDir.listDirectoryEntries()).isEmpty() 
+  }
+  
   companion object {
     private const val BUCKET_META_FILE = "bucketMetadata.json"
     private val OBJECT_MAPPER: ObjectMapper =


### PR DESCRIPTION
**Description**
This PR fixes a startup bug in persistent storage mode where a blank `initialBuckets` entry could create an invalid root-level persisted bucket metadata file and cause `InternalError` responses after restart.

Changes:
- Ignore blank or whitespace-only `initialBuckets` entries during startup.
- Add a regression test covering `initialBuckets = listOf("")`.
- Update `CHANGELOG.md` with the bug fix.

**Related Issue**
- N/A

**Tasks**
- [x] I have written tests and verified that they fail without my change.
- [x] I have run `make format` to fix code style.
- [x] I have updated `CHANGELOG.md` (if applicable).
- [x] I have updated documentation (if applicable).
- [x] I have signed the CLA.
  - Nếu bạn đã ký rồi thì tick luôn ô này trước khi mở PR.

**Verification**
- Ran:
  ```powershell
  .\mvnw.cmd -B -V -pl server -Dtest=StoreConfigurationTest test
  ```
- Result: test suite passed.