### PR TITLE
feat: persist part metadata

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
 
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         queries: security-extended #,security-and-quality
-        tools: linked
+        tools: latest
 
     # Set up JDK, otherwise autobuild will fail below.
     - name: Set up JDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,12 @@ Version 5.x is JDK17 LTS bytecode compatible, with Docker and JUnit / direct Jav
 ## 5.2.0 - PLANNED
 
 * Features and fixes
-  * TBD
+  * feat: Persist per-part checksums uploaded via `UploadPart` as `.partmeta.json` sidecar files so that `CompleteMultipartUpload` can pass without clients re-sending per-part checksums for `FULL_OBJECT` type uploads. ([#3034](https://github.com/adobe/S3Mock/issues/3034))
+  * feat: Expose per-part checksum metadata via `ListParts` (returned in each `Part` element) and `GetObjectAttributes` (`ObjectParts` attribute).
+  * feat: Correctly model the S3 checksum type support matrix — `COMPOSITE` requires per-part checksums in `CompleteMultipartUpload`; `FULL_OBJECT` does not.
+  * feat: Default `ChecksumType` is now derived per algorithm when not explicitly specified (`CRC64NVME` → `FULL_OBJECT`; `CRC32`/`CRC32C`/`SHA1`/`SHA256` → `COMPOSITE`), matching real S3 behavior.
+  * feat: Reject invalid algorithm/type combinations at `CreateMultipartUpload` with HTTP 400 (`COMPOSITE`+`CRC64NVME`, `FULL_OBJECT`+`SHA1`, `FULL_OBJECT`+`SHA256`).
+  * feat: validated all tests in MultipartIT.kt against real S3 backend.
 * Version updates (deliverable dependencies)
   * TBD
 * Version updates (build dependencies)

--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ S3Mock stores data on disk with the following structure:
       <upload-id>/
         multipartMetadata.json
         <part-number>.part
+        <part-number>.partmeta.json # per-part checksum + size; removed after CompleteMultipartUpload
 ```
 
 **Note:** The file system structure is an implementation detail and may change between releases. While files can be inspected during runtime, reusing persisted data across restarts is not officially supported.

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultipartIT.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/MultipartIT.kt
@@ -42,6 +42,7 @@ import software.amazon.awssdk.services.s3.model.CompletedPart
 import software.amazon.awssdk.services.s3.model.ListPartsRequest
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.ObjectAttributes
 import software.amazon.awssdk.services.s3.model.S3Exception
 import software.amazon.awssdk.services.s3.model.UploadPartRequest
 import software.amazon.awssdk.transfer.s3.S3TransferManager
@@ -61,7 +62,7 @@ internal class MultipartIT : S3TestBase() {
   private val transferManager: S3TransferManager = createTransferManager()
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload_asyncClient(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     s3CrtAsyncClient
@@ -100,7 +101,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload_transferManager(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     transferManager
@@ -142,7 +143,7 @@ internal class MultipartIT : S3TestBase() {
    * Tests if user metadata can be passed by multipart upload.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload_withUserMetadata(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val objectMetadata = mapOf("key" to "value")
@@ -188,7 +189,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload_withChecksumType_COMPOSITE(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val initiateMultipartUploadResult =
@@ -249,7 +250,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload_withChecksumType_throwsOn_DIFFERENT(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val initiateMultipartUploadResult =
@@ -294,7 +295,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload_withChecksumType_FULL_OBJECT(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val initiateMultipartUploadResult =
@@ -359,7 +360,7 @@ internal class MultipartIT : S3TestBase() {
    * Tests if a multipart upload with the last part being smaller than 5MB works.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val objectMetadata = mapOf(Pair("key", "value"))
@@ -430,24 +431,21 @@ internal class MultipartIT : S3TestBase() {
   }
 
   /**
-   * Tests that a multipart upload with parts >5MB (as required by S3 for all non-last parts) and
-   * an explicit checksum algorithm works end-to-end: checksums are validated per part and the
-   * composite checksum is returned correctly after completing the upload.
+   * Tests COMPOSITE multipart upload end-to-end for algorithms that support it
+   * (CRC32, CRC32C, SHA1, SHA256). Per-part checksums are required in Complete for COMPOSITE.
    *
-   * Regression coverage for https://github.com/adobe/S3Mock/issues/3034 – ensures the checksum
-   * code path is exercised with realistically-sized parts, not only small test files.
+   * Regression coverage for https://github.com/adobe/S3Mock/issues/3034.
    */
   @S3VerifiedSuccess(year = 2026)
   @ParameterizedTest
-  @MethodSource(value = ["checksumAlgorithms"])
-  fun testMultipartUpload_largeParts_checksum(
+  @MethodSource(value = ["compositeChecksumAlgorithms"])
+  fun testMultipartUpload_largeParts_composite(
     checksumAlgorithm: software.amazon.awssdk.checksums.spi.ChecksumAlgorithm,
     testInfo: TestInfo,
   ) {
     val bucketName = givenBucket(testInfo)
 
-    // Keep the random bytes in memory for both upload and content verification,
-    // then write to a temp file so DigestUtil can compute checksums from it via Path
+    // Keep bytes in memory for content verification; write to temp file for DigestUtil (needs Path)
     val part1Bytes = randomBytes()
     val part1File =
       Files.newTemporaryFile().also { file ->
@@ -482,7 +480,7 @@ internal class MultipartIT : S3TestBase() {
       )
     assertThat(part1Response.checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(part1ExpectedChecksum)
 
-    // upload part 2, <5MB (last part is allowed to be smaller)
+    // upload part 2, <5MB (last part may be smaller)
     val part2ExpectedChecksum = DigestUtil.checksumFor(UPLOAD_FILE_PATH, checksumAlgorithm)
     val part2Response =
       s3Client.uploadPart(
@@ -498,6 +496,7 @@ internal class MultipartIT : S3TestBase() {
       )
     assertThat(part2Response.checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(part2ExpectedChecksum)
 
+    // COMPOSITE: final checksum = checksum-of-part-checksums with -N suffix
     val expectedCompositeChecksum =
       DigestUtil.checksumMultipart(listOf(part1Path, UPLOAD_FILE_PATH), checksumAlgorithm)
 
@@ -536,8 +535,117 @@ internal class MultipartIT : S3TestBase() {
       }
   }
 
+  /**
+   * Tests FULL_OBJECT multipart upload end-to-end for algorithms that support it
+   * (CRC32, CRC32C, CRC64NVME). Per-part checksums are NOT required in Complete for FULL_OBJECT;
+   * S3 uses the persisted per-part data to compute the final checksum over the whole object.
+   *
+   * Regression coverage for https://github.com/adobe/S3Mock/issues/3034.
+   */
+  @S3VerifiedSuccess(year = 2026)
+  @ParameterizedTest
+  @MethodSource(value = ["fullObjectChecksumAlgorithms"])
+  fun testMultipartUpload_largeParts_fullObject(
+    checksumAlgorithm: software.amazon.awssdk.checksums.spi.ChecksumAlgorithm,
+    testInfo: TestInfo,
+  ) {
+    val bucketName = givenBucket(testInfo)
+
+    val part1Bytes = randomBytes()
+    val part1File =
+      Files.newTemporaryFile().also { file ->
+        file.writeBytes(part1Bytes)
+      }
+    part1File.deleteOnExit()
+
+    val initiateResult =
+      s3Client.createMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.checksumAlgorithm(checksumAlgorithm.toAlgorithm())
+        it.checksumType(ChecksumType.FULL_OBJECT)
+      }
+    assertThat(initiateResult.checksumType()).isEqualTo(ChecksumType.FULL_OBJECT)
+    val uploadId = initiateResult.uploadId()
+
+    // upload part 1, >5MB — send per-part checksum (optional for FULL_OBJECT but validates upload)
+    val part1ExpectedChecksum = DigestUtil.checksumFor(part1File.toPath(), checksumAlgorithm)
+    val part1Response =
+      s3Client.uploadPart(
+        {
+          it.bucket(bucketName)
+          it.key(UPLOAD_FILE_NAME)
+          it.uploadId(uploadId)
+          it.partNumber(1)
+          it.checksum(part1ExpectedChecksum, checksumAlgorithm.toAlgorithm())
+          it.contentLength(part1File.length())
+        },
+        RequestBody.fromFile(part1File),
+      )
+    assertThat(part1Response.checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(part1ExpectedChecksum)
+
+    // upload part 2, <5MB
+    val part2ExpectedChecksum = DigestUtil.checksumFor(UPLOAD_FILE_PATH, checksumAlgorithm)
+    val part2Response =
+      s3Client.uploadPart(
+        {
+          it.bucket(bucketName)
+          it.key(UPLOAD_FILE_NAME)
+          it.uploadId(uploadId)
+          it.partNumber(2)
+          it.checksum(part2ExpectedChecksum, checksumAlgorithm.toAlgorithm())
+          it.contentLength(UPLOAD_FILE_LENGTH)
+        },
+        RequestBody.fromFile(UPLOAD_FILE),
+      )
+    assertThat(part2Response.checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(part2ExpectedChecksum)
+
+    // FULL_OBJECT: final checksum = single checksum over the concatenated content (no -N suffix)
+    val concatFile =
+      Files.newTemporaryFile().also { f ->
+        concatByteArrays(part1Bytes, UPLOAD_FILE.readBytes())
+          .inputStream()
+          .use { stream -> stream.copyTo(f.outputStream()) }
+      }
+    concatFile.deleteOnExit()
+    val expectedFullObjectChecksum = DigestUtil.checksumFor(concatFile.toPath(), checksumAlgorithm)
+
+    val completeResult =
+      s3Client.completeMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.uploadId(uploadId)
+        it.checksumType(ChecksumType.FULL_OBJECT)
+        it.multipartUpload {
+          // FULL_OBJECT: per-part checksums NOT required in Complete
+          it.parts(
+            {
+              it.eTag(part1Response.eTag())
+              it.partNumber(1)
+            },
+            {
+              it.eTag(part2Response.eTag())
+              it.partNumber(2)
+            },
+          )
+        }
+      }
+    assertThat(completeResult.checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(expectedFullObjectChecksum)
+
+    s3Client
+      .getObject {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.checksumMode(ChecksumMode.ENABLED)
+      }.use {
+        assertThat(it.response().checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(expectedFullObjectChecksum)
+        assertThat(it.response().contentLength()).isEqualTo(part1File.length() + UPLOAD_FILE_LENGTH)
+        assertThat(readStreamIntoByteArray(it.buffered())).isEqualTo(concatByteArrays(part1Bytes, UPLOAD_FILE.readBytes()))
+      }
+  }
+
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `multipartupload send checksum in create and complete`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val uploadFile = File(TEST_IMAGE_TIFF)
@@ -666,17 +774,19 @@ internal class MultipartIT : S3TestBase() {
         }
       }
 
+    assertThat(completeMultipartUpload.checksumType()).isEqualTo(ChecksumType.COMPOSITE)
+
     // for unknown reasons, a simple equals call fails on both objects.
     // assertThat(completeMultipartUpload).isEqualTo(completeMultipartUpload1)
     assertThat(completeMultipartUpload.location()).isEqualTo(completeMultipartUpload1.location())
     assertThat(completeMultipartUpload.bucket()).isEqualTo(completeMultipartUpload1.bucket())
     assertThat(completeMultipartUpload.key()).isEqualTo(completeMultipartUpload1.key())
     assertThat(completeMultipartUpload.eTag()).isEqualTo(completeMultipartUpload1.eTag())
-    assertThat(completeMultipartUpload.checksumType()).isEqualTo(completeMultipartUpload1.checksumType())
+    // S3 does not include checksumType in idempotent Complete responses
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `multipartupload send checksum in create only`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val uploadFile = File(TEST_IMAGE_TIFF)
@@ -761,7 +871,7 @@ internal class MultipartIT : S3TestBase() {
       )
   }
 
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testUploadPart_checksumAlgorithm_initiate(
@@ -801,7 +911,7 @@ internal class MultipartIT : S3TestBase() {
     }
   }
 
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testUploadPart_checksumAlgorithm_complete(
@@ -839,7 +949,7 @@ internal class MultipartIT : S3TestBase() {
       .hasMessageContaining("Service: S3, Status Code: 400")
   }
 
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   @ParameterizedTest
   @MethodSource(value = ["checksumAlgorithms"])
   fun testMultipartUpload_checksum(
@@ -880,7 +990,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testMultipartUpload_wrongChecksum(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val expectedChecksum = "wrongChecksum"
@@ -907,6 +1017,31 @@ internal class MultipartIT : S3TestBase() {
     }.isInstanceOf(S3Exception::class.java)
       .hasMessageContaining("Service: S3, Status Code: 400")
       .hasMessageContaining("Value for x-amz-checksum-sha1 header is invalid.")
+  }
+
+  /**
+   * Tests that invalid [ChecksumType]/[ChecksumAlgorithm] combinations are rejected with 400 at
+   * CreateMultipartUpload. Invalid combos per the S3 support matrix:
+   * - COMPOSITE + CRC64NVME (CRC64NVME is always FULL_OBJECT)
+   * - FULL_OBJECT + SHA1 or SHA256 (these only support COMPOSITE)
+   */
+  @ParameterizedTest
+  @MethodSource(value = ["invalidChecksumTypeCombos"])
+  fun testCreateMultipartUpload_invalidChecksumTypeCombos(
+    checksumAlgorithm: ChecksumAlgorithm,
+    checksumType: ChecksumType,
+    testInfo: TestInfo,
+  ) {
+    val bucketName = givenBucket(testInfo)
+    assertThatThrownBy {
+      s3Client.createMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.checksumAlgorithm(checksumAlgorithm)
+        it.checksumType(checksumType)
+      }
+    }.isInstanceOf(AwsServiceException::class.java)
+      .hasMessageContaining("Service: S3, Status Code: 400")
   }
 
   private fun UploadPartRequest.Builder.checksum(
@@ -948,8 +1083,30 @@ internal class MultipartIT : S3TestBase() {
       else -> error("Unknown checksum algorithm")
     }
 
+  /** Returns the checksum for the given algorithm from a [software.amazon.awssdk.services.s3.model.Part]. */
+  private fun software.amazon.awssdk.services.s3.model.Part.checksum(checksumAlgorithm: ChecksumAlgorithm): String? =
+    when (checksumAlgorithm) {
+      ChecksumAlgorithm.SHA1 -> checksumSHA1()
+      ChecksumAlgorithm.SHA256 -> checksumSHA256()
+      ChecksumAlgorithm.CRC32 -> checksumCRC32()
+      ChecksumAlgorithm.CRC32_C -> checksumCRC32C()
+      ChecksumAlgorithm.CRC64_NVME -> checksumCRC64NVME()
+      else -> null
+    }
+
+  /** Returns the checksum for the given algorithm from a [software.amazon.awssdk.services.s3.model.ObjectPart]. */
+  private fun software.amazon.awssdk.services.s3.model.ObjectPart.checksum(checksumAlgorithm: ChecksumAlgorithm): String? =
+    when (checksumAlgorithm) {
+      ChecksumAlgorithm.SHA1 -> checksumSHA1()
+      ChecksumAlgorithm.SHA256 -> checksumSHA256()
+      ChecksumAlgorithm.CRC32 -> checksumCRC32()
+      ChecksumAlgorithm.CRC32_C -> checksumCRC32C()
+      ChecksumAlgorithm.CRC64_NVME -> checksumCRC64NVME()
+      else -> null
+    }
+
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list parts lists all uploaded parts`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val objectMetadata = mapOf("key" to "value")
@@ -1011,8 +1168,125 @@ internal class MultipartIT : S3TestBase() {
     }
   }
 
+  /**
+   * Tests that ListParts returns per-part checksums when the upload was created with a checksum
+   * algorithm and COMPOSITE type. Part checksums are persisted by UploadPart and surfaced here.
+   */
+  @ParameterizedTest
+  @MethodSource(value = ["compositeChecksumAlgorithms"])
+  fun `list parts returns per-part checksums`(
+    checksumAlgorithm: software.amazon.awssdk.checksums.spi.ChecksumAlgorithm,
+    testInfo: TestInfo,
+  ) {
+    val bucketName = givenBucket(testInfo)
+    val initiateResult =
+      s3Client.createMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.checksumAlgorithm(checksumAlgorithm.toAlgorithm())
+        it.checksumType(ChecksumType.COMPOSITE)
+      }
+    val uploadId = initiateResult.uploadId()
+    val expectedChecksum = DigestUtil.checksumFor(UPLOAD_FILE_PATH, checksumAlgorithm)
+
+    s3Client.uploadPart(
+      {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.uploadId(uploadId)
+        it.partNumber(1)
+        it.checksum(expectedChecksum, checksumAlgorithm.toAlgorithm())
+        it.contentLength(UPLOAD_FILE_LENGTH)
+      },
+      RequestBody.fromFile(UPLOAD_FILE),
+    )
+
+    s3Client
+      .listParts {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.uploadId(uploadId)
+      }.also {
+        assertThat(it.checksumAlgorithm()).isEqualTo(checksumAlgorithm.toAlgorithm())
+        assertThat(it.parts()).hasSize(1)
+        it.parts()[0].also { part ->
+          assertThat(part.checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(expectedChecksum)
+        }
+      }
+  }
+
+  /**
+   * Tests that GetObjectAttributes returns per-part checksums via the OBJECT_PARTS attribute
+   * for multipart-completed objects with COMPOSITE checksum type.
+   *
+   * Regression coverage for https://github.com/adobe/S3Mock/issues/3034.
+   */
+  @S3VerifiedSuccess(year = 2026)
+  @ParameterizedTest
+  @MethodSource(value = ["compositeChecksumAlgorithms"])
+  fun `getObjectAttributes returns object parts with checksums`(
+    checksumAlgorithm: software.amazon.awssdk.checksums.spi.ChecksumAlgorithm,
+    testInfo: TestInfo,
+  ) {
+    val bucketName = givenBucket(testInfo)
+    val initiateResult =
+      s3Client.createMultipartUpload {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.checksumAlgorithm(checksumAlgorithm.toAlgorithm())
+        it.checksumType(ChecksumType.COMPOSITE)
+      }
+    val uploadId = initiateResult.uploadId()
+    val expectedChecksum = DigestUtil.checksumFor(UPLOAD_FILE_PATH, checksumAlgorithm)
+
+    val partResponse =
+      s3Client.uploadPart(
+        {
+          it.bucket(bucketName)
+          it.key(UPLOAD_FILE_NAME)
+          it.uploadId(uploadId)
+          it.partNumber(1)
+          it.checksum(expectedChecksum, checksumAlgorithm.toAlgorithm())
+          it.contentLength(UPLOAD_FILE_LENGTH)
+        },
+        RequestBody.fromFile(UPLOAD_FILE),
+      )
+
+    s3Client.completeMultipartUpload {
+      it.bucket(bucketName)
+      it.key(UPLOAD_FILE_NAME)
+      it.uploadId(uploadId)
+      it.checksumType(ChecksumType.COMPOSITE)
+      it.multipartUpload {
+        it.parts(
+          {
+            it.eTag(partResponse.eTag())
+            it.partNumber(1)
+            it.checksum(expectedChecksum, checksumAlgorithm.toAlgorithm())
+          },
+        )
+      }
+    }
+
+    s3Client
+      .getObjectAttributes {
+        it.bucket(bucketName)
+        it.key(UPLOAD_FILE_NAME)
+        it.objectAttributes(ObjectAttributes.OBJECT_PARTS)
+      }.also { response ->
+        assertThat(response.objectParts()).isNotNull()
+        assertThat(response.objectParts().totalPartsCount()).isEqualTo(1)
+        assertThat(response.objectParts().parts()).hasSize(1)
+        response.objectParts().parts()[0].also { part ->
+          assertThat(part.partNumber()).isEqualTo(1)
+          assertThat(part.size()).isEqualTo(UPLOAD_FILE_LENGTH)
+          assertThat(part.checksum(checksumAlgorithm.toAlgorithm())).isEqualTo(expectedChecksum)
+        }
+      }
+  }
+
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list parts lists uploaded parts matching parameters`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val objectMetadata = mapOf("key" to "value")
@@ -1082,7 +1356,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list parts is empty if no parts were uploaded`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     assertThat(
@@ -1112,7 +1386,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list parts for unknown uploadId throws exception`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
 
@@ -1127,7 +1401,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list MultipartUploads returns OK`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     assertThat(
@@ -1161,7 +1435,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list MultipartUploads by prefix returns OK`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     s3Client.createMultipartUpload {
@@ -1183,7 +1457,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list MultipartUploads by bucket returns OK`(testInfo: TestInfo) {
     // create multipart upload 1
     val bucketName1 =
@@ -1225,7 +1499,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `list MultipartUploads limited by max-uploads returns OK`(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     for (i in 1..10) {
@@ -1260,7 +1534,7 @@ internal class MultipartIT : S3TestBase() {
    * Tests if a multipart upload can be aborted.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testAbortMultipartUpload(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     assertThat(
@@ -1329,7 +1603,7 @@ internal class MultipartIT : S3TestBase() {
    * irrespective of the number of parts uploaded before.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testCompleteMultipartUpload_partLeftOut(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val key = randomName
@@ -1400,7 +1674,7 @@ internal class MultipartIT : S3TestBase() {
    * aborted.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun testListParts_completeAndAbort(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val key = randomName
@@ -1469,7 +1743,7 @@ internal class MultipartIT : S3TestBase() {
    * Upload two objects, copy as parts without length, complete multipart.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun shouldCopyPartsAndComplete(testInfo: TestInfo) {
     // Initiate upload
     val bucketName2 = givenBucket()
@@ -1566,7 +1840,7 @@ internal class MultipartIT : S3TestBase() {
    * Requests parts for the uploadId; compares etag of upload response and parts list.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun shouldCopyObjectPart(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObject(testInfo, sourceKey)
@@ -1609,7 +1883,7 @@ internal class MultipartIT : S3TestBase() {
    * Tries to copy part of a non-existing object to a new bucket.
    */
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun shouldThrowNoSuchKeyOnCopyObjectPartForNonExistingKey(testInfo: TestInfo) {
     val sourceKey = "NON_EXISTENT_KEY"
     val destinationBucket = givenBucket()
@@ -1686,7 +1960,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy fails with copy-source-if-match=false`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObject(testInfo, sourceKey)
@@ -1763,7 +2037,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy succeeds with copy-source-if-none-match=true`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObject(testInfo, sourceKey)
@@ -1803,7 +2077,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy fails with copy-source-if-none-match=false`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, putObjectResponse) = givenBucketAndObject(testInfo, sourceKey)
@@ -1835,7 +2109,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy fails with copy-source-if-none-match=false and copy-source-if-modified-since=true`(testInfo: TestInfo) {
     val now = Instant.now().minusSeconds(60)
     val sourceKey = UPLOAD_FILE_NAME
@@ -1869,7 +2143,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy succeeds with copy-source-if-modified-since=true`(testInfo: TestInfo) {
     val now = Instant.now().minusSeconds(60)
     val sourceKey = UPLOAD_FILE_NAME
@@ -1909,20 +2183,29 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy fails with copy-source-if-modified-since=false`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObject(testInfo, sourceKey)
     val destinationBucket = givenBucket()
     val destinationKey = "copyOf/$sourceKey"
 
+    // Use the object's S3-reported lastModified (second precision from the HTTP date header).
+    // Per RFC 7232 the "modified since T" condition fails (→ 412) when lastModified ≤ T, so
+    // T == lastModified is sufficient — no future date required, and S3Mock's comparison is
+    // now also truncated to second precision to match HTTP semantics.
+    val sourceLastModified =
+      s3Client
+        .headObject {
+          it.bucket(bucketName)
+          it.key(sourceKey)
+        }.lastModified()
+
     val initiateMultipartUploadResult =
       s3Client.createMultipartUpload {
         it.bucket(destinationBucket)
         it.key(destinationKey)
       }
-
-    val now = Instant.now().plusSeconds(60)
 
     val uploadId = initiateMultipartUploadResult.uploadId()
     assertThatThrownBy {
@@ -1934,7 +2217,7 @@ internal class MultipartIT : S3TestBase() {
         it.sourceBucket(bucketName)
         it.partNumber(1)
         it.copySourceRange("bytes=0-${UPLOAD_FILE_LENGTH - 1}")
-        it.copySourceIfModifiedSince(now)
+        it.copySourceIfModifiedSince(sourceLastModified)
       }
     }.isInstanceOf(S3Exception::class.java)
       .hasMessageContaining("Service: S3, Status Code: 412")
@@ -1942,7 +2225,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy succeeds with copy-source-if-unmodified-since=true`(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObject(testInfo, sourceKey)
@@ -1982,7 +2265,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `UploadPartCopy fails with copy-source-if-unmodified-since=false`(testInfo: TestInfo) {
     val now = Instant.now().minusSeconds(60)
     val sourceKey = UPLOAD_FILE_NAME
@@ -2014,7 +2297,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun createMultipartUpload_noSuchBucket() {
     assertThatThrownBy {
       s3Client.createMultipartUpload {
@@ -2026,7 +2309,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun listMultipartUploads_noSuchBucket() {
     assertThatThrownBy {
       s3Client.listMultipartUploads {
@@ -2037,7 +2320,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun abortMultipartUpload_noSuchBucket() {
     assertThatThrownBy {
       s3Client.abortMultipartUpload {
@@ -2050,7 +2333,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun transferManagerUpload_noSuchSourceBucket() {
     assertThatThrownBy {
       transferManager
@@ -2068,7 +2351,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun transferManagerCopy_noSuchDestinationBucket(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (_, _) = givenBucketAndObject(testInfo, sourceKey)
@@ -2096,7 +2379,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun transferManagerCopy_noSuchSourceKey(testInfo: TestInfo) {
     val sourceKey = UPLOAD_FILE_NAME
     val (bucketName, _) = givenBucketAndObject(testInfo, sourceKey)
@@ -2121,7 +2404,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun uploadMultipart_invalidPartNumber(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val initiateMultipartUploadResult =
@@ -2155,7 +2438,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun completeMultipartUpload_nonExistingPartNumber(testInfo: TestInfo) {
     val bucketName = givenBucket(testInfo)
     val initiateMultipartUploadResult =
@@ -2203,7 +2486,7 @@ internal class MultipartIT : S3TestBase() {
   }
 
   @Test
-  @S3VerifiedSuccess(year = 2025)
+  @S3VerifiedSuccess(year = 2026)
   fun `CompleteMultipart fails with if-none-match=true`(testInfo: TestInfo) {
     val (bucketName, response) = givenBucketAndObject(testInfo, UPLOAD_FILE_NAME)
     val initiateMultipartUploadResult =

--- a/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
+++ b/integration-tests/src/test/kotlin/com/adobe/testing/s3mock/its/S3TestBase.kt
@@ -24,6 +24,7 @@ import org.apache.http.impl.client.HttpClientBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.params.provider.Arguments
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
@@ -43,6 +44,7 @@ import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient
 import software.amazon.awssdk.services.s3.model.Bucket
 import software.amazon.awssdk.services.s3.model.BucketType
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm
+import software.amazon.awssdk.services.s3.model.ChecksumType
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
 import software.amazon.awssdk.services.s3.model.EncodingType
@@ -828,6 +830,38 @@ internal abstract class S3TestBase {
         DefaultChecksumAlgorithm.CRC32C,
         DefaultChecksumAlgorithm.CRC64NVME,
       ).stream()
+
+    /** Algorithms valid with [ChecksumType.COMPOSITE]: CRC32, CRC32C, SHA1, SHA256. */
+    @JvmStatic
+    protected fun compositeChecksumAlgorithms(): Stream<software.amazon.awssdk.checksums.spi.ChecksumAlgorithm> =
+      listOf(
+        DefaultChecksumAlgorithm.CRC32,
+        DefaultChecksumAlgorithm.CRC32C,
+        DefaultChecksumAlgorithm.SHA1,
+        DefaultChecksumAlgorithm.SHA256,
+      ).stream()
+
+    /** Algorithms valid with [ChecksumType.FULL_OBJECT]: CRC32, CRC32C, CRC64NVME. */
+    @JvmStatic
+    protected fun fullObjectChecksumAlgorithms(): Stream<software.amazon.awssdk.checksums.spi.ChecksumAlgorithm> =
+      listOf(
+        DefaultChecksumAlgorithm.CRC32,
+        DefaultChecksumAlgorithm.CRC32C,
+        DefaultChecksumAlgorithm.CRC64NVME,
+      ).stream()
+
+    /**
+     * Invalid type/algorithm combinations per the S3 support matrix.
+     * Each [Arguments] pair is ([ChecksumAlgorithm], [ChecksumType]).
+     * Creating a multipart upload with these combos must result in a 400.
+     */
+    @JvmStatic
+    protected fun invalidChecksumTypeCombos(): Stream<Arguments> =
+      Stream.of(
+        Arguments.of(ChecksumAlgorithm.CRC64_NVME, ChecksumType.COMPOSITE),
+        Arguments.of(ChecksumAlgorithm.SHA1, ChecksumType.FULL_OBJECT),
+        Arguments.of(ChecksumAlgorithm.SHA256, ChecksumType.FULL_OBJECT),
+      )
 
     @JvmStatic
     protected fun charsSafe(): Stream<String> =

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -77,7 +77,8 @@ Filesystem layout:
 <root>/<bucket>/<uuid>/<version-id>-binaryData              # versioning
 <root>/<bucket>/<uuid>/<version-id>-objectMetadata.json      # versioning
 <root>/<bucket>/multiparts/<upload-id>/multipartMetadata.json
-<root>/<bucket>/multiparts/<upload-id>/<part>.part
+<root>/<bucket>/multiparts/<upload-id>/<part-number>.part
+<root>/<bucket>/multiparts/<upload-id>/<part-number>.partmeta.json  # per-part checksum + size
 ```
 
 **`bucketMetadata.json`** fields (`BucketMetadata`):
@@ -122,6 +123,18 @@ Filesystem layout:
 | `policy` | `AccessControlPolicy?` | ACL policy |
 | `versionId` | `String?` | non-null when versioning is enabled |
 | `deleteMarker` | `Boolean` | true for versioned delete markers |
+| `parts` | `List<ObjectPart>?` | per-part metadata for multipart-completed objects; null for single-PUT objects; populated at `CompleteMultipartUpload` from `.partmeta.json` sidecar files |
+
+**`<part-number>.partmeta.json`** fields (`PartMetadata`) — written alongside each `.part` file during `UploadPart`; deleted after `CompleteMultipartUpload`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `partNumber` | `Int` | S3 part number (1-based) |
+| `etag` | `String?` | ETag of the part |
+| `size` | `Long` | part size in bytes |
+| `lastModified` | `Long` | epoch millis when the part was uploaded |
+| `checksum` | `String?` | base64-encoded checksum value, or null if not provided |
+| `checksumAlgorithm` | `ChecksumAlgorithm?` | algorithm used, or null |
 
 ## Testing
 

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/S3Exception.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/S3Exception.kt
@@ -85,6 +85,16 @@ class S3Exception(
         ),
       )
 
+    fun invalidChecksumTypeForAlgorithm(
+      algorithm: String,
+      checksumType: String,
+    ): S3Exception =
+      S3Exception(
+        HttpStatus.BAD_REQUEST.value(),
+        INVALID_REQUEST_CODE,
+        "The checksum type $checksumType is not applicable to the $algorithm checksum algorithm.",
+      )
+
     val NO_SUCH_UPLOAD_MULTIPART: S3Exception =
       S3Exception(
         HttpStatus.NOT_FOUND.value(),

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/controller/MultipartController.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/controller/MultipartController.kt
@@ -262,6 +262,8 @@ class MultipartController(
         partNum,
         tempFile,
         encryptionHeadersFrom(httpHeaders),
+        checksum,
+        checksumAlgorithm,
       )
 
     runCatching { tempFile.toFile().deleteRecursively() }

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/controller/ObjectController.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/controller/ObjectController.kt
@@ -26,6 +26,7 @@ import com.adobe.testing.s3mock.dto.CopySource
 import com.adobe.testing.s3mock.dto.Delete
 import com.adobe.testing.s3mock.dto.DeleteResult
 import com.adobe.testing.s3mock.dto.GetObjectAttributesOutput
+import com.adobe.testing.s3mock.dto.GetObjectAttributesParts
 import com.adobe.testing.s3mock.dto.LegalHold
 import com.adobe.testing.s3mock.dto.ObjectAttributes
 import com.adobe.testing.s3mock.dto.ObjectCannedACL
@@ -753,7 +754,21 @@ class ObjectController(
         } else {
           null
         },
-        null, // parts not supported right now
+        if (objectAttributes.contains(ObjectAttributes.OBJECT_PARTS.toString()) && s3ObjectMetadata.parts != null) {
+          val objectParts = s3ObjectMetadata.parts
+          listOf(
+            GetObjectAttributesParts(
+              isTruncated = false,
+              maxParts = objectParts.size,
+              nextPartNumberMarker = 0,
+              partNumberMarker = 0,
+              partsCount = objectParts.size,
+              parts = objectParts,
+            ),
+          )
+        } else {
+          null
+        },
         if (objectAttributes.contains(ObjectAttributes.OBJECT_SIZE.toString())) {
           objectSize
         } else {

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/dto/GetObjectAttributesParts.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/dto/GetObjectAttributesParts.kt
@@ -22,7 +22,7 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
 /**
  * [API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAttributesParts.html).
  */
-@S3Verified(year = 2025)
+@S3Verified(year = 2026)
 data class GetObjectAttributesParts(
   @param:JsonProperty("IsTruncated", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   val isTruncated: Boolean,
@@ -32,9 +32,9 @@ data class GetObjectAttributesParts(
   val nextPartNumberMarker: Int,
   @param:JsonProperty("PartNumberMarker", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   val partNumberMarker: Int,
+  @param:JsonProperty("PartsCount", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  val partsCount: Int,
   @param:JacksonXmlElementWrapper(useWrapping = false)
-  @param:JsonProperty("Parts", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @param:JsonProperty("Part", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   val parts: List<ObjectPart>?,
-  @param:JsonProperty("TotalPartsCount", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
-  val totalPartsCount: Int,
 )

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/dto/Part.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/dto/Part.kt
@@ -34,6 +34,16 @@ class Part(
   val lastModified: Date,
   @param:JsonProperty("Size", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   val size: Long,
+  @param:JsonProperty("ChecksumCRC32", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  val checksumCRC32: String? = null,
+  @param:JsonProperty("ChecksumCRC32C", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  val checksumCRC32C: String? = null,
+  @param:JsonProperty("ChecksumCRC64NVME", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  val checksumCRC64NVME: String? = null,
+  @param:JsonProperty("ChecksumSHA1", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  val checksumSHA1: String? = null,
+  @param:JsonProperty("ChecksumSHA256", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  val checksumSHA256: String? = null,
 ) {
   constructor(partNumber: Int, etag: String?, size: Long) :
     this(partNumber, normalizeEtag(etag), Date(), size)
@@ -57,6 +67,11 @@ class Part(
     if (size != other.size) return false
     if (lastModified != other.lastModified) return false
     if (etag != other.etag) return false
+    if (checksumCRC32 != other.checksumCRC32) return false
+    if (checksumCRC32C != other.checksumCRC32C) return false
+    if (checksumCRC64NVME != other.checksumCRC64NVME) return false
+    if (checksumSHA1 != other.checksumSHA1) return false
+    if (checksumSHA256 != other.checksumSHA256) return false
 
     return true
   }
@@ -66,6 +81,11 @@ class Part(
     result = 31 * result + size.hashCode()
     result = 31 * result + lastModified.hashCode()
     result = 31 * result + (etag?.hashCode() ?: 0)
+    result = 31 * result + (checksumCRC32?.hashCode() ?: 0)
+    result = 31 * result + (checksumCRC32C?.hashCode() ?: 0)
+    result = 31 * result + (checksumCRC64NVME?.hashCode() ?: 0)
+    result = 31 * result + (checksumSHA1?.hashCode() ?: 0)
+    result = 31 * result + (checksumSHA256?.hashCode() ?: 0)
     return result
   }
 }

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/service/MultipartService.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/service/MultipartService.kt
@@ -40,6 +40,7 @@ import org.springframework.http.HttpRange
 import software.amazon.awssdk.utils.http.SdkHttpUtils.urlEncodeIgnoreSlashes
 import java.nio.file.Path
 import java.util.Date
+import java.util.Locale
 import java.util.UUID
 
 open class MultipartService(
@@ -53,6 +54,8 @@ open class MultipartService(
     partNumber: Int,
     path: Path,
     encryptionHeaders: Map<String, String>,
+    checksum: String? = null,
+    checksumAlgorithm: ChecksumAlgorithm? = null,
   ): String? {
     val bucketMetadata = bucketStore.getBucketMetadata(bucketName)
     val uuid = bucketMetadata.getID(key) ?: return null
@@ -63,6 +66,8 @@ open class MultipartService(
       partNumber,
       path,
       encryptionHeaders,
+      checksum,
+      checksumAlgorithm,
     )
   }
 
@@ -204,6 +209,21 @@ open class MultipartService(
     checksumType: ChecksumType?,
     checksumAlgorithm: ChecksumAlgorithm?,
   ): InitiateMultipartUploadResult {
+    // Reject invalid type/algorithm combinations per the S3 support matrix:
+    //   COMPOSITE is not valid for CRC64NVME (CRC64NVME is always FULL_OBJECT)
+    //   FULL_OBJECT is not valid for SHA1 or SHA256
+    if (checksumType != null && checksumAlgorithm != null) {
+      val invalid =
+        (checksumType == ChecksumType.COMPOSITE && checksumAlgorithm == ChecksumAlgorithm.CRC64NVME) ||
+          (checksumType == ChecksumType.FULL_OBJECT && checksumAlgorithm == ChecksumAlgorithm.SHA1) ||
+          (checksumType == ChecksumType.FULL_OBJECT && checksumAlgorithm == ChecksumAlgorithm.SHA256)
+      if (invalid) {
+        throw S3Exception.invalidChecksumTypeForAlgorithm(
+          checksumAlgorithm.toString().lowercase(Locale.getDefault()),
+          checksumType.toString(),
+        )
+      }
+    }
     val bucketMetadata = bucketStore.getBucketMetadata(bucketName)
     val id = bucketStore.addKeyToBucket(key, bucketName)
 

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/service/ObjectService.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/service/ObjectService.kt
@@ -336,9 +336,13 @@ open class ObjectService(
 
     val etag = normalizeEtag(s3ObjectMetadata.etag)
     val lastModified = Instant.ofEpochMilli(s3ObjectMetadata.lastModified)
+    // HTTP-date headers have second precision; truncate before comparing to avoid false mismatches
+    // when the stored lastModified carries sub-second components.
+    val lastModifiedSeconds = lastModified.truncatedTo(ChronoUnit.SECONDS)
 
     ifModifiedSince?.firstOrNull()?.let {
-      if (it.isAfter(lastModified)) {
+      // "not modified since T" ↔ lastModified ≤ T (RFC 7232 §2.3); throw when condition fails
+      if (!it.isBefore(lastModifiedSeconds)) {
         LOG.debug("Object {} not modified since {}", s3ObjectMetadata.key, it)
         throw S3Exception.NOT_MODIFIED
       }
@@ -362,7 +366,8 @@ open class ObjectService(
     }
 
     ifUnmodifiedSince?.firstOrNull()?.let {
-      if (it.isBefore(lastModified)) {
+      // "modified since T" ↔ lastModified > T (RFC 7232 §2.4); throw when condition fails
+      if (lastModifiedSeconds.isAfter(it)) {
         LOG.debug("Object {} modified since {}", s3ObjectMetadata.key, it)
         throw S3Exception.PRECONDITION_FAILED
       }

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/store/MultipartStore.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/store/MultipartStore.kt
@@ -23,6 +23,7 @@ import com.adobe.testing.s3mock.dto.CompleteMultipartUploadResult
 import com.adobe.testing.s3mock.dto.CompletedPart
 import com.adobe.testing.s3mock.dto.Initiator
 import com.adobe.testing.s3mock.dto.MultipartUpload
+import com.adobe.testing.s3mock.dto.ObjectPart
 import com.adobe.testing.s3mock.dto.Owner
 import com.adobe.testing.s3mock.dto.Part
 import com.adobe.testing.s3mock.dto.StorageClass
@@ -90,10 +91,20 @@ open class MultipartStore(
         "Directories for storing multipart uploads couldn't be created.",
       )
     }
+    // Resolve checksumType: use requested type, or derive a default from the algorithm.
+    // CRC64NVME only supports FULL_OBJECT; all other algorithms default to COMPOSITE when no
+    // explicit type is provided. This matches observed real-S3 behavior per empirical ITs.
+    val resolvedChecksumType =
+      checksumType
+        ?: when (checksumAlgorithm) {
+          ChecksumAlgorithm.CRC64NVME -> ChecksumType.FULL_OBJECT
+          null -> null
+          else -> ChecksumType.COMPOSITE
+        }
     val upload =
       MultipartUpload(
         checksumAlgorithm,
-        ChecksumType.FULL_OBJECT,
+        resolvedChecksumType,
         Date(),
         initiator,
         key,
@@ -112,7 +123,7 @@ open class MultipartStore(
         storageClass,
         tags,
         null,
-        checksumType,
+        resolvedChecksumType,
         checksumAlgorithm,
       )
     lockStore.putIfAbsent(uploadId, Any())
@@ -193,10 +204,25 @@ open class MultipartStore(
     partNumber: Int,
     path: Path,
     encryptionHeaders: Map<String, String>,
+    checksum: String? = null,
+    checksumAlgorithm: ChecksumAlgorithm? = null,
   ): String {
     val file = inputPathToFile(path, getPartPath(bucket, uploadId, partNumber))
+    val etag = DigestUtil.hexDigest(encryptionHeaders[AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID], file)
 
-    return DigestUtil.hexDigest(encryptionHeaders[AwsHttpHeaders.X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID], file)
+    // Persist per-part metadata alongside the part file so checksums survive until CompleteMultipart
+    val partMetadata =
+      PartMetadata(
+        partNumber = partNumber,
+        etag = etag,
+        size = file.length(),
+        lastModified = file.lastModified(),
+        checksum = checksum,
+        checksumAlgorithm = checksumAlgorithm,
+      )
+    writePartMetafile(bucket, uploadId, partNumber, partMetadata)
+
+    return etag
   }
 
   fun completeMultipartUpload(
@@ -227,6 +253,13 @@ open class MultipartStore(
       }
       val checksumFor = validateChecksums(uploadInfo, tempFile, parts, partsPaths, checksum, checksumType, checksumAlgorithm)
       val etag = DigestUtil.hexDigestMultipart(partsPaths)
+
+      // Read per-part metadata under the lock to avoid racing with abort or ListParts
+      val objectParts =
+        synchronized(lockStore[uploadId]!!) {
+          readObjectParts(bucket, uploadId, parts)
+        }
+
       val s3ObjectMetadata =
         objectStore.storeS3ObjectMetadata(
           bucket,
@@ -243,10 +276,25 @@ open class MultipartStore(
           checksumFor,
           uploadInfo.upload.owner,
           uploadInfo.storageClass,
-          checksumType,
+          checksumType ?: uploadInfo.checksumType,
+          objectParts.ifEmpty { null },
         )
-      // delete parts and update MultipartInfo
+      // delete part files, then .partmeta.json sidecars (under lock) and update MultipartInfo
       partsPaths.forEach { runCatching { it.toFile().deleteRecursively() } }
+      synchronized(lockStore[uploadId]!!) {
+        partsPaths.forEach { path ->
+          runCatching {
+            getPartMetaPath(
+              bucket,
+              uploadId,
+              path.fileName
+                .toString()
+                .substringBefore('.')
+                .toInt(),
+            ).toFile().delete()
+          }
+        }
+      }
       val completedUploadInfo = uploadInfo.complete()
       writeMetafile(bucket, completedUploadInfo)
       return CompleteMultipartUploadResult.from(
@@ -274,18 +322,26 @@ open class MultipartStore(
   ): List<Part> {
     val partsPath = getPartsFolder(bucket, uploadId)
     try {
-      return partsPath
-        .listDirectoryEntries("*$PART_SUFFIX")
-        .map {
-          val name = it.fileName.toString()
-          val prefix = name.substringBefore('.')
-          val partNumber = prefix.toInt()
-          val file = it.toFile()
-          val partMd5 = DigestUtil.hexDigest(file)
-          val lastModified = Date(file.lastModified())
-          Part(partNumber, partMd5, lastModified, file.length())
-        }.sortedBy { it.partNumber }
-        .toList()
+      return synchronized(lockStore[uploadId]!!) {
+        partsPath
+          .listDirectoryEntries("*$PART_SUFFIX")
+          .map {
+            val name = it.fileName.toString()
+            val partNumber = name.substringBefore('.').toInt()
+            val file = it.toFile()
+            val partMetaPath = getPartMetaPath(bucket, uploadId, partNumber)
+            if (partMetaPath.exists()) {
+              // Read persisted metadata (has checksum)
+              val meta = objectMapper.readValue(partMetaPath.toFile(), PartMetadata::class.java)
+              partFromMetadata(meta)
+            } else {
+              // Fall back to on-the-fly reconstruction (no checksum, e.g. copy-part uploads)
+              val partMd5 = DigestUtil.hexDigest(file)
+              Part(partNumber, partMd5, Date(file.lastModified()), file.length())
+            }
+          }.sortedBy { it.partNumber }
+          .toList()
+      }
     } catch (e: IOException) {
       throw IllegalStateException("Could not read all parts. bucket=$bucket, id=$id, uploadId=$uploadId", e)
     }
@@ -477,12 +533,16 @@ open class MultipartStore(
       }
 
     if (checksumAlgorithmToValidate != null) {
-      completedParts.forEach { part ->
-        if (part.checksum(checksumAlgorithmToValidate) == null) {
-          throw S3Exception.completeRequestMissingChecksum(
-            checksumAlgorithmToValidate.toString().lowercase(Locale.getDefault()),
-            part.partNumber,
-          )
+      // COMPOSITE uploads require per-part checksums in Complete; FULL_OBJECT does not.
+      val effectiveType = checksumType ?: uploadInfo.checksumType
+      if (effectiveType == ChecksumType.COMPOSITE) {
+        completedParts.forEach { part ->
+          if (part.checksum(checksumAlgorithmToValidate) == null) {
+            throw S3Exception.completeRequestMissingChecksum(
+              checksumAlgorithmToValidate.toString().lowercase(Locale.getDefault()),
+              part.partNumber,
+            )
+          }
         }
       }
       if (checksumToValidate != null) {
@@ -509,9 +569,69 @@ open class MultipartStore(
       DigestUtil.checksumFor(path, algo.toChecksumAlgorithm())
     }
 
+  private fun getPartMetaPath(
+    bucket: BucketMetadata,
+    uploadId: UUID,
+    partNumber: Int,
+  ): Path = getPartsFolder(bucket, uploadId).resolve(partNumber.toString() + PART_META_SUFFIX)
+
+  private fun writePartMetafile(
+    bucket: BucketMetadata,
+    uploadId: UUID,
+    partNumber: Int,
+    meta: PartMetadata,
+  ) {
+    try {
+      synchronized(lockStore[uploadId]!!) {
+        objectMapper.writeValue(getPartMetaPath(bucket, uploadId, partNumber).toFile(), meta)
+      }
+    } catch (e: IOException) {
+      throw IllegalStateException("Could not write part metadata file uploadId=$uploadId, partNumber=$partNumber", e)
+    }
+  }
+
+  /** Builds a [Part] DTO from a persisted [PartMetadata], routing the checksum to the correct field. */
+  private fun partFromMetadata(meta: PartMetadata): Part =
+    Part(
+      partNumber = meta.partNumber,
+      etag = meta.etag,
+      lastModified = Date(meta.lastModified),
+      size = meta.size,
+      checksumCRC32 = if (meta.checksumAlgorithm == ChecksumAlgorithm.CRC32) meta.checksum else null,
+      checksumCRC32C = if (meta.checksumAlgorithm == ChecksumAlgorithm.CRC32C) meta.checksum else null,
+      checksumCRC64NVME = if (meta.checksumAlgorithm == ChecksumAlgorithm.CRC64NVME) meta.checksum else null,
+      checksumSHA1 = if (meta.checksumAlgorithm == ChecksumAlgorithm.SHA1) meta.checksum else null,
+      checksumSHA256 = if (meta.checksumAlgorithm == ChecksumAlgorithm.SHA256) meta.checksum else null,
+    )
+
+  /** Builds the [ObjectPart] list from persisted [PartMetadata] for the given [completedParts]. */
+  private fun readObjectParts(
+    bucket: BucketMetadata,
+    uploadId: UUID,
+    completedParts: List<CompletedPart>,
+  ): List<ObjectPart> =
+    completedParts.mapNotNull { completed ->
+      val metaPath = getPartMetaPath(bucket, uploadId, completed.partNumber)
+      if (metaPath.exists()) {
+        val meta = objectMapper.readValue(metaPath.toFile(), PartMetadata::class.java)
+        ObjectPart(
+          checksumCRC32 = if (meta.checksumAlgorithm == ChecksumAlgorithm.CRC32) meta.checksum else null,
+          checksumCRC32C = if (meta.checksumAlgorithm == ChecksumAlgorithm.CRC32C) meta.checksum else null,
+          checksumCRC64NVME = if (meta.checksumAlgorithm == ChecksumAlgorithm.CRC64NVME) meta.checksum else null,
+          checksumSHA1 = if (meta.checksumAlgorithm == ChecksumAlgorithm.SHA1) meta.checksum else null,
+          checksumSHA256 = if (meta.checksumAlgorithm == ChecksumAlgorithm.SHA256) meta.checksum else null,
+          partNumber = meta.partNumber,
+          size = meta.size,
+        )
+      } else {
+        null
+      }
+    }
+
   companion object {
     private val LOG: Logger = LoggerFactory.getLogger(MultipartStore::class.java)
     private const val PART_SUFFIX = ".part"
+    private const val PART_META_SUFFIX = ".partmeta.json"
     private const val MULTIPART_UPLOAD_META_FILE = "multipartMetadata.json"
     const val MULTIPARTS_FOLDER: String = "multiparts"
 

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/store/ObjectStore.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/store/ObjectStore.kt
@@ -23,6 +23,7 @@ import com.adobe.testing.s3mock.dto.ChecksumAlgorithm
 import com.adobe.testing.s3mock.dto.ChecksumType
 import com.adobe.testing.s3mock.dto.Grant
 import com.adobe.testing.s3mock.dto.LegalHold
+import com.adobe.testing.s3mock.dto.ObjectPart
 import com.adobe.testing.s3mock.dto.Owner
 import com.adobe.testing.s3mock.dto.Retention
 import com.adobe.testing.s3mock.dto.StorageClass
@@ -68,6 +69,7 @@ open class ObjectStore(
     owner: Owner,
     storageClass: StorageClass?,
     checksumType: ChecksumType?,
+    parts: List<ObjectPart>? = null,
   ): S3ObjectMetadata {
     lockStore.putIfAbsent(id, Any())
     synchronized(lockStore[id]!!) {
@@ -114,6 +116,7 @@ open class ObjectStore(
           versionId,
           false,
           checksumType,
+          parts,
         )
       writeMetafile(bucket, s3ObjectMetadata)
       return s3ObjectMetadata

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/store/PartMetadata.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/store/PartMetadata.kt
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2017-2026 Adobe.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.adobe.testing.s3mock.store
+
+import com.adobe.testing.s3mock.dto.ChecksumAlgorithm
+
+/**
+ * Persisted per-part metadata written alongside each `<partNumber>.part` file.
+ * Enables [MultipartStore.getMultipartUploadParts] to return checksums via ListParts,
+ * and [MultipartStore.completeMultipartUpload] to populate [S3ObjectMetadata.parts] for
+ * GetObjectAttributes.
+ */
+data class PartMetadata(
+  val partNumber: Int,
+  val etag: String?,
+  val size: Long,
+  val lastModified: Long,
+  val checksum: String?,
+  val checksumAlgorithm: ChecksumAlgorithm?,
+)

--- a/server/src/main/kotlin/com/adobe/testing/s3mock/store/S3ObjectMetadata.kt
+++ b/server/src/main/kotlin/com/adobe/testing/s3mock/store/S3ObjectMetadata.kt
@@ -20,6 +20,7 @@ import com.adobe.testing.s3mock.dto.AccessControlPolicy
 import com.adobe.testing.s3mock.dto.ChecksumAlgorithm
 import com.adobe.testing.s3mock.dto.ChecksumType
 import com.adobe.testing.s3mock.dto.LegalHold
+import com.adobe.testing.s3mock.dto.ObjectPart
 import com.adobe.testing.s3mock.dto.Owner
 import com.adobe.testing.s3mock.dto.Retention
 import com.adobe.testing.s3mock.dto.StorageClass
@@ -54,6 +55,8 @@ data class S3ObjectMetadata(
   val versionId: String?,
   val deleteMarker: Boolean = false,
   val checksumType: ChecksumType?,
+  /** Persisted per-part metadata for multipart-completed objects; null for single-PUT objects. */
+  val parts: List<ObjectPart>? = null,
 ) {
   companion object {
     fun deleteMarker(

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/controller/MultipartControllerTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/controller/MultipartControllerTest.kt
@@ -1081,7 +1081,7 @@ internal class MultipartControllerTest : BaseControllerTest() {
     val temp = Files.createTempFile("junie", "part")
     whenever(multipartService.toTempFile(any(), any())).thenReturn(Pair(temp, null))
     whenever(
-      multipartService.putPart(eq(TEST_BUCKET_NAME), eq("my/key.txt"), eq(uploadId), eq(1), eq(temp), any()),
+      multipartService.putPart(eq(TEST_BUCKET_NAME), eq("my/key.txt"), eq(uploadId), eq(1), eq(temp), any(), anyOrNull(), anyOrNull()),
     ).thenReturn("etag-123")
 
     val uri =
@@ -1423,7 +1423,7 @@ internal class MultipartControllerTest : BaseControllerTest() {
       }
 
     whenever(
-      multipartService.putPart(eq(TEST_BUCKET_NAME), eq("my/key.txt"), eq(uploadId), eq(1), eq(temp), any()),
+      multipartService.putPart(eq(TEST_BUCKET_NAME), eq("my/key.txt"), eq(uploadId), eq(1), eq(temp), any(), anyOrNull(), anyOrNull()),
     ).thenReturn("etag-321")
 
     val uri =

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/controller/ObjectControllerTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/controller/ObjectControllerTest.kt
@@ -27,6 +27,7 @@ import com.adobe.testing.s3mock.dto.GetObjectAttributesOutput
 import com.adobe.testing.s3mock.dto.Grant
 import com.adobe.testing.s3mock.dto.LegalHold
 import com.adobe.testing.s3mock.dto.Mode
+import com.adobe.testing.s3mock.dto.ObjectPart
 import com.adobe.testing.s3mock.dto.Owner
 import com.adobe.testing.s3mock.dto.Retention
 import com.adobe.testing.s3mock.dto.S3ObjectIdentifier
@@ -1176,6 +1177,43 @@ internal class ObjectControllerTest : BaseControllerTest() {
     assertThat(got.objectSize).isEqualTo(s3ObjectMetadata.dataPath.toFile().length())
     assertThat(got.checksum?.checksumCRC32C).isEqualTo("crcc-value")
     assertThat(got.checksum?.checksumType).isEqualTo(ChecksumType.FULL_OBJECT)
+  }
+
+  @Test
+  fun testGetObjectAttributes_WithObjectParts() {
+    givenBucket()
+    val key = "multipart.txt"
+    val part = ObjectPart(checksumCRC32 = "abc123==", partNumber = 1, size = 1024L)
+    val metadata = s3ObjectMetadata(key).copy(parts = listOf(part))
+    whenever(objectService.verifyObjectExists("test-bucket", key, null)).thenReturn(metadata)
+
+    val uri =
+      UriComponentsBuilder
+        .fromUriString("/test-bucket/$key")
+        .queryParam(AwsHttpParameters.ATTRIBUTES, "ignored")
+        .build()
+        .toString()
+
+    val mvcResult =
+      mockMvc
+        .perform(
+          get(uri)
+            .accept(MediaType.APPLICATION_XML)
+            .header(AwsHttpHeaders.X_AMZ_OBJECT_ATTRIBUTES, "ObjectParts"),
+        ).andExpect(status().isOk)
+        .andReturn()
+
+    val got = MAPPER.readValue(mvcResult.response.contentAsString, GetObjectAttributesOutput::class.java)
+    assertThat(got.objectParts).isNotNull().hasSize(1)
+    val objectParts = got.objectParts!![0]
+    assertThat(objectParts.partsCount).isEqualTo(1)
+    assertThat(objectParts.parts).hasSize(1)
+    assertThat(objectParts.parts!![0].partNumber).isEqualTo(1)
+    assertThat(objectParts.parts!![0].size).isEqualTo(1024L)
+    assertThat(objectParts.parts!![0].checksumCRC32).isEqualTo("abc123==")
+    // attributes not requested must be absent
+    assertThat(got.etag).isNull()
+    assertThat(got.storageClass).isNull()
   }
 
   @Test

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/dto/GetObjectAttributesOutputTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/dto/GetObjectAttributesOutputTest.kt
@@ -49,12 +49,12 @@ internal class GetObjectAttributesOutputTest {
       )
     val getObjectAttributesParts =
       GetObjectAttributesParts(
-        false,
-        1000,
-        0,
-        0,
-        listOf(part),
-        0,
+        isTruncated = false,
+        maxParts = 1000,
+        nextPartNumberMarker = 0,
+        partNumberMarker = 0,
+        partsCount = 0,
+        parts = listOf(part),
       )
     val iut =
       GetObjectAttributesOutput(

--- a/server/src/test/kotlin/com/adobe/testing/s3mock/store/MultipartStoreTest.kt
+++ b/server/src/test/kotlin/com/adobe/testing/s3mock/store/MultipartStoreTest.kt
@@ -748,6 +748,60 @@ internal class MultipartStoreTest : StoreTestBase() {
   }
 
   @Test
+  fun `putPart persists checksum and completeMultipartUpload stores ObjectParts for GetObjectAttributes`() {
+    val fileName = "PartFile"
+    val id = managedId()
+    val part1 = "Part1"
+    val tempFile = Files.createTempFile("", "")
+    part1.toByteArray().inputStream().transferTo(tempFile.outputStream())
+    val checksum = DigestUtil.checksumFor(tempFile, DefaultChecksumAlgorithm.CRC32)
+    requireNotNull(checksum)
+
+    val bucket = metadataFrom(TEST_BUCKET_NAME)
+    val multipartUpload =
+      multipartStore.createMultipartUpload(
+        bucket,
+        fileName,
+        id,
+        DEFAULT_CONTENT_TYPE,
+        storeHeaders(),
+        TEST_OWNER,
+        TEST_INITIATOR,
+        NO_USER_METADATA,
+        NO_ENCRYPTION_HEADERS,
+        NO_TAGS,
+        StorageClass.STANDARD,
+        ChecksumType.COMPOSITE,
+        ChecksumAlgorithm.CRC32,
+      )
+    val uploadId = UUID.fromString(multipartUpload.uploadId)
+    val multipartUploadInfo = multipartStore.getMultipartUploadInfo(bucket, uploadId)
+
+    multipartStore.putPart(bucket, id, uploadId, 1, tempFile, NO_ENCRYPTION_HEADERS, checksum, ChecksumAlgorithm.CRC32)
+
+    multipartStore.completeMultipartUpload(
+      bucket,
+      fileName,
+      id,
+      uploadId,
+      listOf(CompletedPart(ChecksumAlgorithm.CRC32, checksum, null, 1)),
+      NO_ENCRYPTION_HEADERS,
+      multipartUploadInfo,
+      "location",
+      NO_CHECKSUM,
+      ChecksumType.COMPOSITE,
+      ChecksumAlgorithm.CRC32,
+    )
+
+    objectStore.getS3ObjectMetadata(bucket, id, null).also { metadata ->
+      assertThat(metadata).isNotNull()
+      assertThat(metadata!!.parts).isNotNull().hasSize(1)
+      assertThat(metadata.parts!![0].partNumber).isEqualTo(1)
+      assertThat(metadata.parts!![0].checksumCRC32).isEqualTo(checksum)
+    }
+  }
+
+  @Test
   fun listsMultipartUploads() {
     val bucket = metadataFrom(TEST_BUCKET_NAME)
     assertThat(multipartStore.listMultipartUploads(bucket, NO_PREFIX)).isEmpty()

--- a/server/src/test/resources/com/adobe/testing/s3mock/dto/GetObjectAttributesOutputTest_testSerialization_multiPart.xml
+++ b/server/src/test/resources/com/adobe/testing/s3mock/dto/GetObjectAttributesOutputTest_testSerialization_multiPart.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017-2025 Adobe.
+     Copyright 2017-2026 Adobe.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@
     <IsTruncated>false</IsTruncated>
     <NextPartNumberMarker>0</NextPartNumberMarker>
     <PartNumberMarker>0</PartNumberMarker>
-    <TotalPartsCount>0</TotalPartsCount>
-    <Parts>
+    <PartsCount>0</PartsCount>
+    <Part>
       <ChecksumCRC32>checksumCRC32</ChecksumCRC32>
       <ChecksumCRC32C>checksumCRC32C</ChecksumCRC32C>
       <ChecksumSHA1>checksumSHA1</ChecksumSHA1>
@@ -40,7 +40,7 @@
       <ChecksumCRC64NVME>checksumCRC64NVME</ChecksumCRC64NVME>
       <Size>1</Size>
       <PartNumber>1</PartNumber>
-    </Parts>
+    </Part>
   </ObjectParts>
   <ObjectSize>1</ObjectSize>
   <StorageClass>STANDARD</StorageClass>


### PR DESCRIPTION
## Description

Depending on the checksum algrithm and type that is used to initialize a multipart upload, it may or may not be necessary to provide per-part checksum data when completing it.
Let S3Mock persist per-part metadata to support all combinations.

## Related Issue

fixes #3034

## Motivation and Context

See description.

## How Has This Been Tested?

Unit and Integration Tests, which were verified against the real S3 backend.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
