### PR TITLE
chore: skip spotless during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,14 @@
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <goals>deploy -DskipTests -Prelease -P!build-docker-image -Ppush-docker-image</goals>
+            <!-- Skip Spotless during the release. The source already passed spotless:check in
+                 CI and every PRB. The maven-release-plugin rewrites every pom to set the
+                 release/next-dev version, and its JDOM writer normalizes empty elements to
+                 `<foo />` (with a space), which Spotless sortPom would then reject (`<foo/>`) -
+                 a violation the plugin introduces itself, not present in the committed source.
+                 `arguments` is passed to both the prepare (preparationGoals) and perform
+                 (goals) forked Maven builds. -->
+            <arguments>-Dspotless.check.skip=true</arguments>
             <preparationGoals>clean install</preparationGoals>
             <tagNameFormat>@{project.version}</tagNameFormat>
           </configuration>


### PR DESCRIPTION
The maven release plugin rewrites poms which makes spotless fail only during release. :(

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
